### PR TITLE
Dial down smokescreen logging.

### DIFF
--- a/smokescreen.go
+++ b/smokescreen.go
@@ -101,7 +101,7 @@ func errorResponse(req *http.Request, err error) *http.Response {
 
 func buildProxy() *goproxy.ProxyHttpServer {
 	proxy := goproxy.NewProxyHttpServer()
-	proxy.Verbose = true
+	proxy.Verbose = false
 	proxy.Tr.Dial = dial
 	proxy.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 		ctx.Logf("Received HTTP proxy request: "+


### PR DESCRIPTION
# What's this PR do?

Dials down smokescreen logging, since it's pretty loud.

Specifically, it sets the proxy's verbose flag to false. That control's the [rudimentary logging](https://github.com/elazarl/goproxy/blob/bee2110779c23d999b253c0ec8873757dc43d9a3/ctx.go#L56) and prevents a bunch of stuff from coming out. Specifically, `WARN` will continue to work.

# Why?

Specifically, it's been responsible for about 115MM log events in the last 24 hours in our setup.

# Note

I'm biasing to action here. Not sure what uses these logs and if they are needed for anything. Happy to adjust!

r? @antifuchs 
cc @andrew-d @zenazn @ebroder  