### PR TITLE
Add logging for every completed request

### DIFF
--- a/smokescreen.go
+++ b/smokescreen.go
@@ -139,6 +139,10 @@ func buildProxy() *goproxy.ProxyHttpServer {
 }
 
 func logResponse(ctx *goproxy.ProxyCtx) {
+	if(ctx.RoundTrip == nil || ctx.RoundTrip.TCPAddr == nil) {
+		log.Println("Could not log response: missing IP address")
+		return
+	}
 	from_host, from_port, _ := net.SplitHostPort(ctx.Req.RemoteAddr)
 	log.Printf("Completed response: "+
 		"src_host=%#v src_port=%s host=%#v dest_ip=%#v dest_port=%d start_time=%#v end_time=%d content_length=%d\n",


### PR DESCRIPTION
r? @rb-stripe @dougbarth-stripe 

We want to be to log the IPs the proxy is connecting to. This adds a log line that logs that and several other things. what exactly it logs is probably best explained by this example log line:

>  2017/01/06 10:29:02 Completed response: src_host="::1" src_port=54211 host="example.com" dest_ip="93.184.216.34" dest_port=80 start_time=1483727342 end_time=1483727342 content_length=1270

@rb-stripe suggested logging the length of the body, but if we want to have everything on the same log line I'm pretty sure we can only log the value of the Content-Length header. I think the only place the actual value of that is accessible is here (goproxy logs it): https://github.com/elazarl/goproxy/blob/master/proxy.go#L139-L143.

Also maybe we should log requests in addition to / instead of responses.