### PR TITLE
Log CONNECT proxy requests

### DIFF
--- a/smokescreen.go
+++ b/smokescreen.go
@@ -139,18 +139,27 @@ func buildProxy() *goproxy.ProxyHttpServer {
 	return proxy
 }
 
+func extractHostname(ctx *goproxy.ProxyCtx) string {
+	var hostname string
+	if (ctx.Req != nil) {
+		hostname, _, _ = net.SplitHostPort(ctx.Req.Host);
+	}
+	return hostname
+}
+
 func logHttpsRequest(ctx *goproxy.ProxyCtx, resolved string) {
 	var contentLength int64
 	if ctx.Resp != nil {
 		contentLength = ctx.Resp.ContentLength
 	}
+	hostname := extractHostname(ctx)
 	from_host, from_port, _ := net.SplitHostPort(ctx.Req.RemoteAddr)
 	to_host, to_port, _ := net.SplitHostPort(resolved)
 	log.Printf("Received CONNECT request: "+
 		"proxy_type=connect src_host=%#v src_port=%s host=%#v dest_ip=%#v dest_port=%s start_time=%#v end_time=%d content_length=%#v\n",
 		from_host,
 		from_port,
-		ctx.Req.Host,
+		hostname,
 		to_host,
 		to_port,
 		ctx.UserData,
@@ -175,11 +184,12 @@ func logResponse(ctx *goproxy.ProxyCtx) {
 		contentLength = ctx.Resp.ContentLength
 	}
 	from_host, from_port, _ := net.SplitHostPort(ctx.Req.RemoteAddr)
+	hostname := extractHostname(ctx)
 	log.Printf("Completed response: "+
 		"proxy_type=http src_host=%#v src_port=%s host=%#v dest_ip=%#v dest_port=%d start_time=%#v end_time=%d content_length=%#v\n",
 		from_host,
 		from_port,
-		ctx.Req.Host,
+		hostname,
 		ctx.RoundTrip.TCPAddr.IP.String(),
 		ctx.RoundTrip.TCPAddr.Port,
 		ctx.UserData,


### PR DESCRIPTION
r? @dougbarth-stripe cc @rb-stripe 

This adds a log line for CONNECT proxy requests. The log lines look like this: (the same format as the other requests we log).

I also added a proxy_type field to the log line.

```
2017/01/11 09:51:33 Received CONNECT request: proxy_type=connect src_host="::1" src_port=55395 host="stripe.com:443" dest_ip="54.187.119.242" dest_port=443 start_time=1484157093 end_time=1484157093 content_length=0
```