### PR TITLE
acl policy action disablement

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,25 +46,26 @@ Smokescreen uses a [custom fork](https://github.com/stripe/goproxy) of goproxy t
 ### CLI
 Here are the options you can give Smokescreen:
 ```
-   --help                                   Show this help text.
-   --listen-ip IP                           listen on interface with address IP.
-                                              This argument is ignored when running under Einhorn. (default: any)
-   --listen-port PORT                       listen on port PORT.
-                                              This argument is ignored when running under Einhorn. (default: 4750)
-   --timeout DURATION                       Time out after DURATION when connecting. (default: 10s)
-   --maintenance-file FILE                  Watch FILE for maintenance mode.
-                                              HTTP(S) requests to /healthcheck return 404 if the file's permissions are set to 000.
-   --proxy-protocol                         Enable PROXY protocol support.
-   --deny-range RANGE                       Add RANGE(in CIDR notation) to list of blocked IP ranges.  Repeatable.
-   --allow-range RANGE                      Add RANGE (in CIDR notation) to list of allowed IP ranges.  Repeatable.
-   --egress-acl-file FILE                   Validate egress traffic against FILE
-   --statsd-address ADDRESS                 Send metrics to statsd at ADDRESS (IP:port). (default: "127.0.0.1:8200")
-   --tls-server-bundle-file FILE            Authenticate to clients using key and certs from FILE
-   --tls-client-ca-file FILE                Validate client certificates using Certificate Authority from FILE
-   --tls-crl-file FILE                      Verify validity of client certificates against Certificate Revocation List from FILE
-   --danger-allow-access-to-private-ranges  WARNING: circumvent the check preventing client to reach hosts in private networks - It will make you vulnerable to SSRF.
-   --error-message-on-deny MESSAGE          Display MESSAGE in the HTTP response if proxying request is denied
-   --version, -v                            print the version
+   --help                                     Show this help text.
+   --listen-ip IP                             listen on interface with address IP.
+                                                This argument is ignored when running under Einhorn. (default: any)
+   --listen-port PORT                         listen on port PORT.
+                                                This argument is ignored when running under Einhorn. (default: 4750)
+   --timeout DURATION                         Time out after DURATION when connecting. (default: 10s)
+   --maintenance-file FILE                    Watch FILE for maintenance mode.
+                                                HTTP(S) requests to /healthcheck return 404 if the file's permissions are set to 000.
+   --proxy-protocol                           Enable PROXY protocol support.
+   --deny-range RANGE                         Add RANGE(in CIDR notation) to list of blocked IP ranges.  Repeatable.
+   --allow-range RANGE                        Add RANGE (in CIDR notation) to list of allowed IP ranges.  Repeatable.
+   --egress-acl-file FILE                     Validate egress traffic against FILE
+   --statsd-address ADDRESS                   Send metrics to statsd at ADDRESS (IP:port). (default: "127.0.0.1:8200")
+   --tls-server-bundle-file FILE              Authenticate to clients using key and certs from FILE
+   --tls-client-ca-file FILE                  Validate client certificates using Certificate Authority from FILE
+   --tls-crl-file FILE                        Verify validity of client certificates against Certificate Revocation List from FILE
+   --danger-allow-access-to-private-ranges    WARNING: circumvent the check preventing client to reach hosts in private networks - It will make you vulnerable to SSRF.
+   --error-message-on-deny MESSAGE            Display MESSAGE in the HTTP response if proxying request is denied
+   --disable-acl-policy-action POLICY ACTION  Disable usage of a POLICY ACTION such as "open" in the egress ACL
+   --version, -v                              print the version
 ```
 
 ### Importing

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -35,7 +35,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
-			Name: "help",
+			Name:  "help",
 			Usage: "Show this help text.",
 		},
 		cli.StringFlag{
@@ -97,6 +97,10 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			Name:  "error-message-on-deny",
 			Usage: "Display `MESSAGE` in the HTTP response if proxying request is denied",
 		},
+		cli.StringSliceFlag{
+			Name:  "disable-acl-policy-action",
+			Usage: "Disable usage of a `POLICY ACTION` such as \"open\" in the egress ACL",
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -149,6 +153,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			c.StringSlice("tls-crl-file"),
 			c.Bool("danger-allow-access-to-private-ranges"),
 			c.String("error-message-on-deny"),
+			c.StringSlice("disable-acl-policy-action"),
 		)
 		if err != nil {
 			return err

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -70,6 +70,7 @@ func NewConfig(
 	crlFiles []string,
 	allowPrivateRanges bool,
 	errorMessageOnDeny string,
+	disabledAclPolicyActions []string,
 
 ) (*Config, error) {
 
@@ -125,7 +126,7 @@ func NewConfig(
 		return nil, err
 	}
 
-	err = config.setupEgressAcl(egressAclFile)
+	err = config.setupEgressAcl(egressAclFile, disabledAclPolicyActions)
 	if err != nil {
 		return nil, err
 	}
@@ -219,10 +220,10 @@ func (config *Config) setupStatsd(statsdAddr string) error {
 	return nil
 }
 
-func (config *Config) setupEgressAcl(aclFile string) error {
+func (config *Config) setupEgressAcl(aclFile string, disabledAclPolicyActions []string) error {
 	if aclFile != "" {
 		log.Printf("Loading egress ACL from %s", aclFile)
-		egressAcl, err := LoadFromYamlFile(aclFile)
+		egressAcl, err := LoadFromYamlFile(config, aclFile, disabledAclPolicyActions)
 		if err != nil {
 			log.Print(err)
 			return err

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -62,6 +62,7 @@ func TestClassifyIP(t *testing.T) {
 		nil,
 		false,
 		"Proxy denied",
+		[]string{},
 	)
 	a.NoError(err)
 
@@ -132,6 +133,7 @@ func TestClearsErrorHeader(t *testing.T) {
 		nil,
 		false,
 		"Proxy denied",
+		[]string{},
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/smokescreen/testdata/contains_invalid_glob.yaml
+++ b/pkg/smokescreen/testdata/contains_invalid_glob.yaml
@@ -1,23 +1,6 @@
 ---
 version: v1
 services:
-  - name: enforce-dummy-srv
-    project: usersec
-    action: enforce
-    allowed_domains:
-      - example1.com
-      - example2.com
-
-  - name: report-dummy-srv
-    project: security
-    action: report
-    allowed_domains:
-      - example3.com
-      
-  - name: open-dummy-srv
-    project: automation
-    action: open
-
   - name: dummy-glob
     project: phony
     action: enforce

--- a/pkg/smokescreen/testdata/contains_middle_glob.yaml
+++ b/pkg/smokescreen/testdata/contains_middle_glob.yaml
@@ -1,23 +1,6 @@
 ---
 version: v1
 services:
-  - name: enforce-dummy-srv
-    project: usersec
-    action: enforce
-    allowed_domains:
-      - example1.com
-      - example2.com
-
-  - name: report-dummy-srv
-    project: security
-    action: report
-    allowed_domains:
-      - example3.com
-      
-  - name: open-dummy-srv
-    project: automation
-    action: open
-
   - name: dummy-glob
     project: phony
     action: enforce


### PR DESCRIPTION
r?: @rlk-stripe 

Allows disabling ACL policy actions with flag `disable-acl-policy-action`:
```--disable-acl-policy-action POLICY ACTION  Disable usage of a POLICY ACTION such as "open" in the egress ACL```