### PR TITLE
Improve error messaging on deny

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Here are the options you can give Smokescreen:
    --tls-client-ca-file FILE                  Validate client certificates using Certificate Authority from FILE
    --tls-crl-file FILE                        Verify validity of client certificates against Certificate Revocation List from FILE
    --danger-allow-access-to-private-ranges    WARNING: circumvent the check preventing client to reach hosts in private networks - It will make you vulnerable to SSRF.
-   --error-message-on-deny MESSAGE            Display MESSAGE in the HTTP response if proxying request is denied
+   --additional-error-message-on-deny MESSAGE Display MESSAGE in the HTTP response if proxying request is denied
    --disable-acl-policy-action POLICY ACTION  Disable usage of a POLICY ACTION such as "open" in the egress ACL
    --version, -v                              print the version
 ```

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -95,7 +95,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			Usage: "WARNING: circumvent the check preventing client to reach hosts in private networks - It will make you vulnerable to SSRF.",
 		},
 		cli.StringFlag{
-			Name:  "error-message-on-deny",
+			Name:  "additional-error-message-on-deny",
 			Usage: "Display `MESSAGE` in the HTTP response if proxying request is denied",
 		},
 		cli.StringSliceFlag{
@@ -138,17 +138,17 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 		}
 
 		conf := &smokescreen.Config{
-			Log:                     logger,
-			Ip:                      c.String("listen-ip"),
-			Port:                    c.Int("listen-port"),
-			CidrBlacklist:           cidrBlacklist,
-			CidrBlacklistExemptions: cidrBlacklistExemptions,
-			ConnectTimeout:          c.Duration("timeout"),
-			ExitTimeout:             60 * time.Second,
-			MaintenanceFile:         c.String("maintenance-file"),
-			SupportProxyProtocol:    c.Bool("proxy-protocol"),
-			AllowPrivateRange:       c.Bool("danger-allow-access-to-private-ranges"),
-			ErrorMessageOnDeny:      c.String("error-message-on-deny"),
+			Log:                          logger,
+			Ip:                           c.String("listen-ip"),
+			Port:                         c.Int("listen-port"),
+			CidrBlacklist:                cidrBlacklist,
+			CidrBlacklistExemptions:      cidrBlacklistExemptions,
+			ConnectTimeout:               c.Duration("timeout"),
+			ExitTimeout:                  60 * time.Second,
+			MaintenanceFile:              c.String("maintenance-file"),
+			SupportProxyProtocol:         c.Bool("proxy-protocol"),
+			AllowPrivateRange:            c.Bool("danger-allow-access-to-private-ranges"),
+			AdditionalErrorMessageOnDeny: c.String("additional-error-message-on-deny"),
 		}
 
 		if err := conf.SetupStatsd(c.String("statsd-address"), "smokescreen."); err != nil {

--- a/pkg/smokescreen/acl_loader_v1.go
+++ b/pkg/smokescreen/acl_loader_v1.go
@@ -3,10 +3,11 @@ package smokescreen
 import (
 	"errors"
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 type EgressAclRule struct {
@@ -38,7 +39,7 @@ func (ew *EgressAclConfig) Decide(fromService string, toHost string) (EgressAclD
 	}
 
 	if !found {
-		return 0, fmt.Errorf("unknown role role=%#v", fromService)
+		return 0, UnknownRoleError{fromService}
 	}
 
 	if service.Policy == ConfigEnforcementPolicyOpen {

--- a/pkg/smokescreen/egressacl.go
+++ b/pkg/smokescreen/egressacl.go
@@ -1,6 +1,16 @@
 package smokescreen
 
+import "fmt"
+
 type EgressAcl interface {
 	Decide(fromService string, toHost string) (EgressAclDecision, error)
 	Project(fromService string) (string, error)
+}
+
+type UnknownRoleError struct {
+	Role string
+}
+
+func (u UnknownRoleError) Error() string {
+	return fmt.Sprintf("unknown role role=%s", u.Role)
 }

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -47,11 +47,11 @@ func TestClassifyIP(t *testing.T) {
 	a.NoError(err)
 
 	conf := &Config{
-		CidrBlacklist:           PrivateNetworks(),
-		CidrBlacklistExemptions: cidrBlacklistExemptions,
-		ConnectTimeout:          10 * time.Second,
-		ExitTimeout:             10 * time.Second,
-		ErrorMessageOnDeny:      "Proxy denied",
+		CidrBlacklist:                PrivateNetworks(),
+		CidrBlacklistExemptions:      cidrBlacklistExemptions,
+		ConnectTimeout:               10 * time.Second,
+		ExitTimeout:                  10 * time.Second,
+		AdditionalErrorMessageOnDeny: "Proxy denied",
 	}
 	err = conf.Init()
 	a.NoError(err)
@@ -107,12 +107,12 @@ func TestClearsErrorHeader(t *testing.T) {
 
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	conf := &Config{
-		Port:                    39381,
-		CidrBlacklist:           PrivateNetworks(),
-		CidrBlacklistExemptions: cidrBlacklistExemptions,
-		ConnectTimeout:          10 * time.Second,
-		ExitTimeout:             10 * time.Second,
-		ErrorMessageOnDeny:      "Proxy denied",
+		Port:                         39381,
+		CidrBlacklist:                PrivateNetworks(),
+		CidrBlacklistExemptions:      cidrBlacklistExemptions,
+		ConnectTimeout:               10 * time.Second,
+		ExitTimeout:                  10 * time.Second,
+		AdditionalErrorMessageOnDeny: "Proxy denied",
 	}
 
 	err = conf.Init()


### PR DESCRIPTION
This makes a few major changes to smokescreen error messaging:
* Replaces the command line option for specifying a deny message with one for specifying additional content for the deny message. This allow the application to provide more specific messages for different deny reasons.
* Adds detailed error messages for IP blocking, ACL denies, missing role information and unknown roles.
* Adds a suggestion for using the `no_proxy` environment variable which hopefully will unblock people trying running into proxy errors on the command line.

r? @tremblay-stripe 
cc @rlk-stripe 