### PR TITLE
Use httptest in integration tests

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -145,7 +145,7 @@ func errorResponse(req *http.Request, config *Config, err error) *http.Response 
 	return resp
 }
 
-func buildProxy(config *Config) *goproxy.ProxyHttpServer {
+func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.Verbose = false
 	proxy.Tr.Dial = func(network, addr string) (net.Conn, error) {
@@ -300,7 +300,7 @@ func findListener(ip string, defaultPort int) (net.Listener, error) {
 
 func StartWithConfig(config *Config, quit <-chan interface{}) {
 	config.Log.Println("starting")
-	proxy := buildProxy(config)
+	proxy := BuildProxy(config)
 
 	listener, err := findListener(config.Ip, config.Port)
 	if err != nil {

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -118,7 +118,7 @@ func TestClearsErrorHeader(t *testing.T) {
 	err = conf.Init()
 	a.NoError(err)
 
-	proxy := buildProxy(conf)
+	proxy := BuildProxy(conf)
 	proxySrv := httptest.NewServer(proxy)
 	defer proxySrv.Close()
 


### PR DESCRIPTION
This switches the integration tests to use a server from httptest. That avoids having to hard code a port and makes sure the server is started before we start making requests. I started doing this because I ran into a race condition with the server starting when trying to write tests for log lines.

r? @tremblay-stripe 