### PR TITLE
Allow TLS health checks w/o client cert.

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -76,7 +76,7 @@ func (config *Config) Init() error {
 		config.RoleFromRequest = func(req *http.Request) (string, error) {
 			fail := func(err error) (string, error) { return "", err }
 			if len(req.TLS.PeerCertificates) == 0 {
-				return fail(MissingRoleError(fmt.Errorf("fatal: No PeerCertificates")))
+				return fail(MissingRoleError(fmt.Errorf("no PeerCertificates")))
 			}
 			return req.TLS.PeerCertificates[0].Subject.CommonName, nil
 		}

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -75,8 +75,8 @@ func (config *Config) Init() error {
 	if config.TlsConfig != nil && config.TlsConfig.ClientCAs != nil { // If client certs are set, pick the CN.
 		config.RoleFromRequest = func(req *http.Request) (string, error) {
 			fail := func(err error) (string, error) { return "", err }
-			if len(req.TLS.PeerCertificates) == 0 { // This should be impossible as long as ClientAuth is RequireAndVerifyClientCert
-				fail(MissingRoleError(fmt.Errorf("fatal: No PeerCertificates")))
+			if len(req.TLS.PeerCertificates) == 0 {
+				return fail(MissingRoleError(fmt.Errorf("fatal: No PeerCertificates")))
 			}
 			return req.TLS.PeerCertificates[0].Subject.CommonName, nil
 		}
@@ -228,7 +228,7 @@ func (config *Config) SetupTls(tlsServerPemFile string, tlsClientCasFiles []stri
 				}
 				success := tlsConfig.ClientCAs.AppendCertsFromPEM(caBytes)
 				if !success {
-					fail(fmt.Errorf("Problem decoding '%s'", clientCaFile))
+					return fail(fmt.Errorf("Problem decoding '%s'", clientCaFile))
 				}
 
 				config.populateClientCaMap(caBytes)

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -219,7 +219,7 @@ func (config *Config) SetupTls(tlsServerPemFile string, tlsClientCasFiles []stri
 		}
 
 		if len(tlsClientCasFiles) != 0 {
-			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+			tlsConfig.ClientAuth = tls.VerifyClientCertIfGiven
 			tlsConfig.ClientCAs = x509.NewCertPool()
 			for _, clientCaFile := range tlsClientCasFiles {
 				caBytes, err := ioutil.ReadFile(clientCaFile)

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -406,11 +406,9 @@ func checkIfRequestShouldBeProxied(config *Config, req *http.Request, outboundHo
 	}
 
 	role, roleErr := config.RoleFromRequest(req)
-	if roleErr != nil {
-		// A missing role is OK at this point since we may have a default
-		if _, ok := roleErr.(MissingRoleError); !ok {
-			return nil, roleErr
-		}
+	// A missing role is OK at this point since we may have a default
+	if roleErr != nil && !IsMissingRoleError(roleErr) {
+		return nil, roleErr
 	}
 	decision.role = role
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -125,7 +125,7 @@ func rejectResponse(req *http.Request, config *Config, err error) *http.Response
 	var msg string
 	switch err.(type) {
 	case denyError:
-		msg = fmt.Sprintf(denyMsgTmpl, err.Error(), req.Host)
+		msg = fmt.Sprintf(denyMsgTmpl, req.Host, err.Error())
 	default:
 		msg = "an unexpected error occurred."
 	}

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -176,6 +176,7 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 		return req, nil
 	})
 
+	// Handle CONNECT proxy to HTTPS destination
 	proxy.OnRequest().HandleConnectFunc(func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
 		resolved, err := handleConnect(config, ctx)
 		if err != nil {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -103,10 +103,10 @@ func safeResolve(config *Config, network, addr string) (*net.TCPAddr, error) {
 		return resolved, nil
 	case IpDenyNotGlobalUnicast:
 		config.StatsdClient.Count("resolver.illegal_total", 1, []string{}, 0.3)
-		return nil, denyError(fmt.Errorf("resolves to private address %s", resolved.IP))
+		return nil, denyError(fmt.Errorf("the destination resolves to private address %s", resolved.IP))
 	case IpDenyBlacklist:
 		config.StatsdClient.Count("resolver.illegal_total", 1, []string{}, 0.3)
-		return nil, denyError(fmt.Errorf("resolves to blacklisted address %s", resolved.IP))
+		return nil, denyError(fmt.Errorf("the destination resolves to blocked address %s", resolved.IP))
 	default:
 		return nil, fmt.Errorf("unknown IP type %v", classification)
 	}


### PR DESCRIPTION
Previously, when TLS was configured to request client certs, all requests w/o a client cert would be rejected, including those for `/healthcheck`.  This makes certs optional, allowing health checks to succeed.  

This also means that no-cert requests will fall through to the "default" ACL.  I plan to add an option to prevent this in a future patch.  For now, an implementation could work around this behavior by defining a `RoleFromRequest` that fails with a non-`MissingRoleError`.

This PR also includes some fixes for incorrect type assertions on aliases of `error` (such assertions are always true, as an alias of `error` also fulfills the `error` interface) and other small bugs exposed by the main change.