### PR TITLE
Improve handling of --version arg

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pkg/smokescreen/constants.go ident

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -14,10 +14,8 @@ import (
 
 // Process command line args into a configuration object.  If the "--help" or
 // "--version" flags are provided, return nil with no error.
-// As a side-effect, processing the "--help" argument will cause the program to
-// print the the help message and exit.  If args is nil, os.Args will be used.
-// If logger is nil, a default logger will be created and included in the
-// returned configuration.
+// If args is nil, os.Args will be used.  If logger is nil, a default logger
+// will be created and included in the returned configuration.
 func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, error) {
 	if args == nil {
 		args = os.Args
@@ -27,7 +25,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 
 	app := cli.NewApp()
 	app.Name = "smokescreen"
-	app.Version = smokescreen.Version
+	app.Version = smokescreen.Version()
 	app.Usage = "A simple HTTP proxy that prevents SSRF and can restrict destinations"
 	app.ArgsUsage = " " // blank but non-empty to suppress default "[arguments...]"
 
@@ -105,7 +103,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 	app.Action = func(c *cli.Context) error {
 		if c.Bool("help") {
 			cli.ShowAppHelp(c)
-			return
+			return nil // configToReturn will not be set
 		}
 		if len(c.Args()) > 0 {
 			return errors.New("Received unexpected non-option argument(s)")

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -41,12 +41,12 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 		},
 		cli.StringFlag{
 			Name:  "listen-ip",
-			Usage: "listen on interface with address `IP`.\n\t\tThis argument is ignored when running under Einhorn. (default: any)",
+			Usage: "Listen on interface with address `IP`.\n\t\tThis argument is ignored when running under Einhorn. (default: any)",
 		},
 		cli.IntFlag{
 			Name:  "listen-port",
 			Value: 4750,
-			Usage: "listen on port `PORT`.\n\t\tThis argument is ignored when running under Einhorn.",
+			Usage: "Listen on port `PORT`.\n\t\tThis argument is ignored when running under Einhorn.",
 		},
 		cli.DurationFlag{
 			Name:  "timeout",

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -12,7 +12,8 @@ import (
 	"github.com/stripe/smokescreen/pkg/smokescreen"
 )
 
-// Process command line args into a configuration object.
+// Process command line args into a configuration object.  If the "--help" or
+// "--version" flags are provided, return nil with no error.
 // As a side-effect, processing the "--help" argument will cause the program to
 // print the the help message and exit.  If args is nil, os.Args will be used.
 // If logger is nil, a default logger will be created and included in the
@@ -26,6 +27,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 
 	app := cli.NewApp()
 	app.Name = "smokescreen"
+	app.Version = smokescreen.Version
 	app.Usage = "A simple HTTP proxy that prevents SSRF and can restrict destinations"
 	app.ArgsUsage = " " // blank but non-empty to suppress default "[arguments...]"
 
@@ -102,7 +104,8 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 
 	app.Action = func(c *cli.Context) error {
 		if c.Bool("help") {
-			cli.ShowAppHelpAndExit(c, 0)
+			cli.ShowAppHelp(c)
+			return
 		}
 		if len(c.Args()) > 0 {
 			return errors.New("Received unexpected non-option argument(s)")

--- a/main.go
+++ b/main.go
@@ -10,11 +10,10 @@ func main() {
 
 	conf, err := cmd.NewConfiguration(nil, nil)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Could not create configuration: %v", err)
+	} else if conf != nil {
+		smokescreen.StartWithConfig(conf, nil)
+	} else {
+		// --help or --version was passed and handled by NewConfiguration, so do nothing
 	}
-
-	if conf == nil {
-		log.Fatal("No config")
-	}
-	smokescreen.StartWithConfig(conf, nil)
 }

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -2,9 +2,11 @@ package smokescreen
 
 import "net"
 
-const VersionSemver = "0.0.1"
-const VersionHash = "$Id$"[4:12] // See `git help attributes`
-const Version = VersionSemver + "-" + VersionHash
+const versionSemver = "0.0.1"
+const versionHash = "$Id$" // See `git help attributes`
+func Version() string {
+	return versionSemver + "-" + versionHash[5:13]
+}
 
 var PrivateNetworkStrings = []string{
 	"10.0.0.0/8",

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -2,6 +2,10 @@ package smokescreen
 
 import "net"
 
+const VersionSemver = "0.0.1"
+const VersionHash = "$Id$"[4:12] // See `git help attributes`
+const Version = VersionSemver + "-" + VersionHash
+
 var PrivateNetworkStrings = []string{
 	"10.0.0.0/8",
 	"172.16.0.0/12",

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -2,10 +2,10 @@ package smokescreen
 
 import "net"
 
-const versionSemver = "0.0.1"
+const versionSemantic = "0.0.1"
 const versionHash = "$Id$" // See `git help attributes`
 func Version() string {
-	return versionSemver + "-" + versionHash[5:13]
+	return versionSemantic + "-" + versionHash[5:13]
 }
 
 var PrivateNetworkStrings = []string{


### PR DESCRIPTION
* Provide an actual SemVer-style version (I'm just using `0.0.1` for now) plus a commit hash (using git's `ident` attribute to translate `$Id$` on checkout).
* Document that NewConfiguration my return `nil` even if no error is provided, and update `--help` handler to do this as well rather than directly exiting.
* Update `main.go` to handle the above case by just exiting cleanly rather than logging a fatal error.

cc @andrew-stripe 