### PR TITLE
extract default ranges and localhost from config

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -56,7 +56,7 @@ func conformResult(t *testing.T, test *TestCase, resp *http.Response, err error,
 		if !a.NoError(err) {
 			return
 		}
-		a.Equal(200, resp.StatusCode)
+		a.Equal(200, resp.StatusCode, "TestCase was %v", test)
 	} else {
 		if !a.NoError(err) {
 			return
@@ -335,6 +335,7 @@ func startSmokescreen(t *testing.T, useTls bool, logHook logrus.Hook) (*httptest
 		"--egress-acl-file=testdata/sample_config.yaml",
 		"--additional-error-message-on-deny=moar ctx",
 		"--deny-range=127.0.0.2/32",
+		"--allow-range=127.0.0.1/32",
 	}
 
 	var conf *smokescreen.Config
@@ -352,7 +353,6 @@ func startSmokescreen(t *testing.T, useTls bool, logHook logrus.Hook) (*httptest
 		return nil, err
 	}
 
-	conf.AllowProxyToLoopback = true
 	conf.Log.AddHook(logHook)
 
 	handler := smokescreen.BuildProxy(conf)

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -113,13 +113,6 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 		var cidrBlacklist []net.IPNet
 		var cidrBlacklistExemptions []net.IPNet
 
-		for _, cidrBlock := range smokescreen.PrivateNetworkStrings {
-			cidrBlacklist, err = smokescreen.AddCidrToSlice(cidrBlacklist, cidrBlock)
-			if err != nil {
-				return err
-			}
-		}
-
 		for _, cidrBlock := range c.StringSlice("deny-range") {
 			cidrBlacklist, err = smokescreen.AddCidrToSlice(cidrBlacklist, cidrBlock)
 			if err != nil {

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -58,7 +58,6 @@ func IsMissingRoleError(err error) bool {
 	return ok
 }
 
-
 // RFC 5280,  4.2.1.1
 type authKeyId struct {
 	Id []byte `asn1:"optional,tag:0"`

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -32,7 +32,6 @@ type Config struct {
 	ExitTimeout                  time.Duration
 	MaintenanceFile              string
 	StatsdClient                 *statsd.Client
-	AllowProxyToLoopback         bool
 	EgressAcl                    EgressAcl
 	SupportProxyProtocol         bool
 	TlsConfig                    *tls.Config

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -8,17 +8,23 @@ func Version() string {
 	return versionSemantic + "-" + versionHash[5:13]
 }
 
-var PrivateNetworkStrings = []string{
+var privateNetworkStrings = [...]string{
 	"10.0.0.0/8",
 	"172.16.0.0/12",
 	"192.168.0.0/16",
 	"fc00::/7",
 }
 
-func PrivateNetworks() []net.IPNet {
-	var privateNetworks []net.IPNet
-	for _, network := range PrivateNetworkStrings {
-		privateNetworks, _ = AddCidrToSlice(privateNetworks, network)
+var PrivateNetworkRanges []net.IPNet
+
+func init() {
+	PrivateNetworkRanges = make([]net.IPNet, len(privateNetworkStrings))
+	for i,s := range privateNetworkStrings {
+		_, rng, err := net.ParseCIDR(s)
+		if err != nil {
+			panic("Couldn't parse internal private network string")
+		}
+		PrivateNetworkRanges[i] = *rng
 	}
-	return privateNetworks
+
 }

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -19,7 +19,7 @@ var PrivateNetworkRanges []net.IPNet
 
 func init() {
 	PrivateNetworkRanges = make([]net.IPNet, len(privateNetworkStrings))
-	for i,s := range privateNetworkStrings {
+	for i, s := range privateNetworkStrings {
 		_, rng, err := net.ParseCIDR(s)
 		if err != nil {
 			panic("Couldn't parse internal private network string")

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -51,11 +51,16 @@ func (t ipType) IsAllowed() bool {
 
 func (t ipType) String() string {
 	switch t {
-	case ipAllowDefault: return "Allow: Default"
-	case ipAllowUserConfigured: return "Allow: User Configured"
-	case ipDenyNotGlobalUnicast: return "Deny: Not Global Unicast"
-	case ipDenyPrivateRange: return "Deny: Private Range"
-	case ipDenyUserConfigured: return "Deny: User Configured"
+	case ipAllowDefault:
+		return "Allow: Default"
+	case ipAllowUserConfigured:
+		return "Allow: User Configured"
+	case ipDenyNotGlobalUnicast:
+		return "Deny: Not Global Unicast"
+	case ipDenyPrivateRange:
+		return "Deny: Private Range"
+	case ipDenyUserConfigured:
+		return "Deny: User Configured"
 	default:
 		panic(fmt.Errorf("unknown ip type %d", t))
 	}
@@ -63,11 +68,16 @@ func (t ipType) String() string {
 
 func (t ipType) statsdString() string {
 	switch t {
-	case ipAllowDefault: return "resolver.allow.default"
-	case ipAllowUserConfigured: return "resolver.allow.user_configured"
-	case ipDenyNotGlobalUnicast: return "resolver.deny.not_global_unicast"
-	case ipDenyPrivateRange: return "resolver.deny.private_range"
-	case ipDenyUserConfigured: return "resolver.deny.user_configured"
+	case ipAllowDefault:
+		return "resolver.allow.default"
+	case ipAllowUserConfigured:
+		return "resolver.allow.user_configured"
+	case ipDenyNotGlobalUnicast:
+		return "resolver.deny.not_global_unicast"
+	case ipDenyPrivateRange:
+		return "resolver.deny.private_range"
+	case ipDenyUserConfigured:
+		return "resolver.deny.user_configured"
 	default:
 		panic(fmt.Errorf("unknown ip type %d", t))
 	}


### PR DESCRIPTION
Some preliminary work before landing configuration via a file:

- The `--deny-range` configuration (`CidrBlacklist` internally) now only contains user-specified entries; the default private ranges are checked independently.  `allow-range` entries will still take precedence.
- Added IP classification constant to distinguish default vs explicit denied ranges, and renamed for consistency.  Also made the constants private, tweaked the associated log strings, and added statsd-specific strings.
- Removed the `AllowProxyToLoopback` config option; `--allow-range 127.0.0.1/32` (or the IPv6 equivalent) can be used instead.
