### PR TITLE
simplify cert loading

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -56,7 +56,7 @@ func conformResult(t *testing.T, test *TestCase, resp *http.Response, err error,
 		if !a.NoError(err) {
 			return
 		}
-		a.Equal(200, resp.StatusCode)
+		a.Equal(200, resp.StatusCode, "TestCase was %v", test)
 	} else {
 		if !a.NoError(err) {
 			return
@@ -335,6 +335,7 @@ func startSmokescreen(t *testing.T, useTls bool, logHook logrus.Hook) (*httptest
 		"--egress-acl-file=testdata/sample_config.yaml",
 		"--additional-error-message-on-deny=moar ctx",
 		"--deny-range=127.0.0.2/32",
+		"--allow-range=127.0.0.1/32",
 	}
 
 	var conf *smokescreen.Config
@@ -352,7 +353,6 @@ func startSmokescreen(t *testing.T, useTls bool, logHook logrus.Hook) (*httptest
 		return nil, err
 	}
 
-	conf.AllowProxyToLoopback = true
 	conf.Log.AddHook(logHook)
 
 	handler := smokescreen.BuildProxy(conf)

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -113,13 +113,6 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 		var cidrBlacklist []net.IPNet
 		var cidrBlacklistExemptions []net.IPNet
 
-		for _, cidrBlock := range smokescreen.PrivateNetworkStrings {
-			cidrBlacklist, err = smokescreen.AddCidrToSlice(cidrBlacklist, cidrBlock)
-			if err != nil {
-				return err
-			}
-		}
-
 		for _, cidrBlock := range c.StringSlice("deny-range") {
 			cidrBlacklist, err = smokescreen.AddCidrToSlice(cidrBlacklist, cidrBlock)
 			if err != nil {

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -150,8 +150,18 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 		if err := conf.SetupCrls(c.StringSlice("tls-crl-file")); err != nil {
 			return err
 		}
-		if err := conf.SetupTls(c.String("tls-server-bundle-file"), c.StringSlice("tls-client-ca-file")); err != nil {
-			return err
+		// Originally, we assumed a single file with both cert and key
+		// concatenated.  That setup will continue to work, but SetupTLS now
+		// takes separate args for cert and key, so we pass the filename twice
+		// here.
+		bundleFile := c.String("tls-server-bundle-file")
+		if bundleFile != "" {
+			if err := conf.SetupTls(
+				bundleFile,
+				bundleFile,
+				c.StringSlice("tls-client-ca-file")); err != nil {
+				return err
+			}
 		}
 		if err := conf.Init(); err != nil {
 			return err

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -58,7 +58,6 @@ func IsMissingRoleError(err error) bool {
 	return ok
 }
 
-
 // RFC 5280,  4.2.1.1
 type authKeyId struct {
 	Id []byte `asn1:"optional,tag:0"`

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -32,7 +32,6 @@ type Config struct {
 	ExitTimeout                  time.Duration
 	MaintenanceFile              string
 	StatsdClient                 *statsd.Client
-	AllowProxyToLoopback         bool
 	EgressAcl                    EgressAcl
 	SupportProxyProtocol         bool
 	TlsConfig                    *tls.Config

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -8,17 +8,23 @@ func Version() string {
 	return versionSemantic + "-" + versionHash[5:13]
 }
 
-var PrivateNetworkStrings = []string{
+var privateNetworkStrings = [...]string{
 	"10.0.0.0/8",
 	"172.16.0.0/12",
 	"192.168.0.0/16",
 	"fc00::/7",
 }
 
-func PrivateNetworks() []net.IPNet {
-	var privateNetworks []net.IPNet
-	for _, network := range PrivateNetworkStrings {
-		privateNetworks, _ = AddCidrToSlice(privateNetworks, network)
+var PrivateNetworkRanges []net.IPNet
+
+func init() {
+	PrivateNetworkRanges = make([]net.IPNet, len(privateNetworkStrings))
+	for i,s := range privateNetworkStrings {
+		_, rng, err := net.ParseCIDR(s)
+		if err != nil {
+			panic("Couldn't parse internal private network string")
+		}
+		PrivateNetworkRanges[i] = *rng
 	}
-	return privateNetworks
+
 }

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -19,7 +19,7 @@ var PrivateNetworkRanges []net.IPNet
 
 func init() {
 	PrivateNetworkRanges = make([]net.IPNet, len(privateNetworkStrings))
-	for i,s := range privateNetworkStrings {
+	for i, s := range privateNetworkStrings {
 		_, rng, err := net.ParseCIDR(s)
 		if err != nil {
 			panic("Couldn't parse internal private network string")

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -51,11 +51,16 @@ func (t ipType) IsAllowed() bool {
 
 func (t ipType) String() string {
 	switch t {
-	case ipAllowDefault: return "Allow: Default"
-	case ipAllowUserConfigured: return "Allow: User Configured"
-	case ipDenyNotGlobalUnicast: return "Deny: Not Global Unicast"
-	case ipDenyPrivateRange: return "Deny: Private Range"
-	case ipDenyUserConfigured: return "Deny: User Configured"
+	case ipAllowDefault:
+		return "Allow: Default"
+	case ipAllowUserConfigured:
+		return "Allow: User Configured"
+	case ipDenyNotGlobalUnicast:
+		return "Deny: Not Global Unicast"
+	case ipDenyPrivateRange:
+		return "Deny: Private Range"
+	case ipDenyUserConfigured:
+		return "Deny: User Configured"
 	default:
 		panic(fmt.Errorf("unknown ip type %d", t))
 	}
@@ -63,11 +68,16 @@ func (t ipType) String() string {
 
 func (t ipType) statsdString() string {
 	switch t {
-	case ipAllowDefault: return "resolver.allow.default"
-	case ipAllowUserConfigured: return "resolver.allow.user_configured"
-	case ipDenyNotGlobalUnicast: return "resolver.deny.not_global_unicast"
-	case ipDenyPrivateRange: return "resolver.deny.private_range"
-	case ipDenyUserConfigured: return "resolver.deny.user_configured"
+	case ipAllowDefault:
+		return "resolver.allow.default"
+	case ipAllowUserConfigured:
+		return "resolver.allow.user_configured"
+	case ipDenyNotGlobalUnicast:
+		return "resolver.deny.not_global_unicast"
+	case ipDenyPrivateRange:
+		return "resolver.deny.private_range"
+	case ipDenyUserConfigured:
+		return "resolver.deny.user_configured"
 	default:
 		panic(fmt.Errorf("unknown ip type %d", t))
 	}


### PR DESCRIPTION
r? @tremblay-stripe 
cc @andrew-stripe 

(This is based on top of my previous PR, which isn't in master yet, so you may want to just look at the last commit's diff.)

It turns out that`tls.LoadX509KeyPair` will happily extract the relevant PEM blocks from the supplied files, so we can cut out a fair amount of manual parsing code by just passing our bundle file as both of the `certFile` and `keyFile` args.  I've also made SetupTls take two files, pushed the "use the same file twice" logic out a level to `NewConfiguration`.  (I expect a future CLI change could allow an optional key file arg, but it's not implemented yet.)

`NewConfiguration` now only calls `SetupTls` if a file is specified, and `SetupTls` errors if you call it without cert/key files.  (Client CA files remain optional.)