### PR TITLE
Rlk/config part 2

### DIFF
--- a/cmd/check_config/main.go
+++ b/cmd/check_config/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"github.com/stripe/smokescreen/pkg/smokescreen"
 )
@@ -13,28 +12,14 @@ func main() {
 		os.Exit(1)
 	}
 	filePath := os.Args[1]
-	bytes, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		fmt.Printf("Failed to read config file '%s': %v\n", filePath, err)
-		os.Exit(1)
-	}
 
-	config, err := smokescreen.UnmarshalConfig(bytes)
+	config, err := smokescreen.LoadConfig(filePath)
 	if err != nil {
 		fmt.Printf("Failed to parse config: %v\n", err);
 		os.Exit(1)
 	}
 
 	fmt.Printf("Parsed configuration:\n\n%#v\n\n", *config)
-
-	errors := config.Check()
-	if len(errors) > 0 {
-		fmt.Printf("Check() returned %d error(s):\n\n", len(errors))
-		for _, e := range errors {
-			fmt.Printf(" - %s\n", e)
-		}
-		os.Exit(1)
-	}
 
 	os.Exit(0)
 }

--- a/cmd/check_config/main.go
+++ b/cmd/check_config/main.go
@@ -25,7 +25,5 @@ func main() {
 		fmt.Printf("Invalid port: %d", config.Port)
 	}
 
-	//TODO more checks here
-
 	os.Exit(0)
 }

--- a/cmd/check_config/main.go
+++ b/cmd/check_config/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"github.com/stripe/smokescreen/pkg/smokescreen"
 )
@@ -12,14 +13,19 @@ func main() {
 		os.Exit(1)
 	}
 	filePath := os.Args[1]
-	config, err := smokescreen.LoadConfig(filePath)
-
+	bytes, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		fmt.Printf("Failed to load config: %v\n", err);
+		fmt.Printf("Failed to read config file '%s': %v\n", filePath, err)
 		os.Exit(1)
 	}
 
-	fmt.Printf("Parsed configuration:\n\n%#v\n\n", config)
+	config, err := smokescreen.UnmarshalConfig(bytes)
+	if err != nil {
+		fmt.Printf("Failed to parse config: %v\n", err);
+		os.Exit(1)
+	}
+
+	fmt.Printf("Parsed configuration:\n\n%#v\n\n", *config)
 
 	errors := config.Check()
 	if len(errors) > 0 {

--- a/cmd/check_config/main.go
+++ b/cmd/check_config/main.go
@@ -19,6 +19,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Parsed: %#v\n", config)
+	fmt.Printf("Parsed: %#v\n\n", config)
+
+	if config.Port < 1 || config.Port > 65535 {
+		fmt.Printf("Invalid port: %d", config.Port)
+	}
+
+	//TODO more checks here
+
 	os.Exit(0)
 }

--- a/cmd/check_config/main.go
+++ b/cmd/check_config/main.go
@@ -19,12 +19,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Parsed: %#v\n\n", config)
+	fmt.Printf("Parsed configuration:\n\n%#v\n\n", config)
 
 	errors := config.Check()
 	if len(errors) > 0 {
-		for e := range errors {
-			fmt.Println(e)
+		fmt.Printf("Check() returned %d error(s):\n\n", len(errors))
+		for _, e := range errors {
+			fmt.Printf(" - %s\n", e)
 		}
 		os.Exit(1)
 	}

--- a/cmd/check_config/main.go
+++ b/cmd/check_config/main.go
@@ -21,8 +21,12 @@ func main() {
 
 	fmt.Printf("Parsed: %#v\n\n", config)
 
-	if config.Port < 1 || config.Port > 65535 {
-		fmt.Printf("Invalid port: %d", config.Port)
+	errors := config.Check()
+	if len(errors) > 0 {
+		for e := range errors {
+			fmt.Println(e)
+		}
+		os.Exit(1)
 	}
 
 	os.Exit(0)

--- a/cmd/check_config/main.go
+++ b/cmd/check_config/main.go
@@ -15,7 +15,7 @@ func main() {
 
 	config, err := smokescreen.LoadConfig(filePath)
 	if err != nil {
-		fmt.Printf("Failed to parse config: %v\n", err);
+		fmt.Printf("Failed to load config: %v\n", err);
 		os.Exit(1)
 	}
 

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -361,8 +361,6 @@ func startSmokescreen(t *testing.T, useTls bool, logHook logrus.Hook) (*httptest
 		"--allow-range=127.0.0.1/32",
 	}
 
-	var conf *smokescreen.Config
-	var err error
 	if useTls {
 		args = append(args,
 			"--tls-server-bundle-file=testdata/pki/server-bundle.pem",
@@ -370,10 +368,10 @@ func startSmokescreen(t *testing.T, useTls bool, logHook logrus.Hook) (*httptest
 			"--tls-crl-file=testdata/pki/crl.pem",
 		)
 	}
-	conf, err = NewConfiguration(args, nil)
 
+	conf, err := NewConfiguration(args, nil)
 	if err != nil {
-		return nil, err
+		t.Fatalf("Failed to create configuration: %v", err)
 	}
 
 	if (useTls) {
@@ -382,6 +380,7 @@ func startSmokescreen(t *testing.T, useTls bool, logHook logrus.Hook) (*httptest
 		conf.RoleFromRequest = testRFRHeader
 	}
 
+	fmt.Printf("2 %#v\n", conf)
 	conf.Log.AddHook(logHook)
 
 	handler := smokescreen.BuildProxy(conf)

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -114,7 +114,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			conf.Log = logger
 		}
 
-		conf.Ip =                           c.String("listen-ip")
+		conf.Ip = c.String("listen-ip")
 		conf.Port = c.Int("listen-port")
 		conf.ConnectTimeout = c.Duration("timeout")
 		conf.ExitTimeout = 60 * time.Second

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"errors"
+	"math"
 	"os"
+	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -42,7 +44,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			Name:  "listen-ip",
 			Usage: "Listen on interface with address `IP`.\n\t\tThis argument is ignored when running under Einhorn. (default: any)",
 		},
-		cli.IntFlag{
+		cli.UintFlag{
 			Name:  "listen-port",
 			Value: 4750,
 			Usage: "Listen on port `PORT`.\n\t\tThis argument is ignored when running under Einhorn.",
@@ -115,7 +117,13 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 		}
 
 		conf.Ip = c.String("listen-ip")
-		conf.Port = c.Int("listen-port")
+
+		port := c.Uint("listen-port")
+		if port > math.MaxUint16 {
+			return fmt.Errorf("Invalid listen-port: %d", port)
+		}
+		conf.Port = uint16(port)
+
 		conf.ConnectTimeout = c.Duration("timeout")
 		conf.ExitTimeout = 60 * time.Second
 		conf.MaintenanceFile = c.String("maintenance-file")

--- a/main.go
+++ b/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"net/http"
 	log "github.com/sirupsen/logrus"
 	"github.com/stripe/smokescreen/cmd"
 	"github.com/stripe/smokescreen/pkg/smokescreen"
+	"net/http"
 )
 
 // This default implementation of RoleFromRequest uses the CommonName of the

--- a/main.go
+++ b/main.go
@@ -18,22 +18,6 @@ func defaultRoleFromRequest(req *http.Request) (string, error) {
 	return req.TLS.PeerCertificates[0].Subject.CommonName, nil
 }
 
-// This is an example of another way to obtain a role from a request, using an
-// HTTP header.  Note that this is not reliable in the face of a malicious
-// client with the ability to construct arbitrary HTTP requests.
-/*
-func headerRoleFromRequest(req *http.Request) (string, error) {
-	idHeader := req.Header["X-Smokescreen-Role"]
-	if len(idHeader) == 0 {
-		return "", smokescreen.MissingRoleError("client did not send 'X-Smokescreen-Role' header")
-	} else if len(idHeader) > 1 {
-		return "", smokescreen.MissingRoleError("client sent multiple 'X-Smokescreen-Role' headers")
-	}
-	return idHeader[0], nil
-}
-*/
-
-
 func main() {
 	conf, err := cmd.NewConfiguration(nil, nil)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,17 +1,46 @@
 package main
 
 import (
+	"net/http"
 	log "github.com/sirupsen/logrus"
 	"github.com/stripe/smokescreen/cmd"
 	"github.com/stripe/smokescreen/pkg/smokescreen"
 )
 
-func main() {
+// This default implementation of RoleFromRequest uses the CommonName of the
+// client's certificate.  If no certificate is provided, the AllowMissingRole
+// configuration option will control whether the request is rejected, or the
+// default ACL is applied.
+func defaultRoleFromRequest(req *http.Request) (string, error) {
+	if len(req.TLS.PeerCertificates) == 0 {
+		return "", smokescreen.MissingRoleError("client did not provide certificate")
+	}
+	return req.TLS.PeerCertificates[0].Subject.CommonName, nil
+}
 
+// This is an example of another way to obtain a role from a request, using an
+// HTTP header.  Note that this is not reliable in the face of a malicious
+// client with the ability to construct arbitrary HTTP requests.
+/*
+func headerRoleFromRequest(req *http.Request) (string, error) {
+	idHeader := req.Header["X-Smokescreen-Role"]
+	if len(idHeader) == 0 {
+		return "", smokescreen.MissingRoleError("client did not send 'X-Smokescreen-Role' header")
+	} else if len(idHeader) > 1 {
+		return "", smokescreen.MissingRoleError("client sent multiple 'X-Smokescreen-Role' headers")
+	}
+	return idHeader[0], nil
+}
+*/
+
+
+func main() {
 	conf, err := cmd.NewConfiguration(nil, nil)
 	if err != nil {
 		log.Fatalf("Could not create configuration: %v", err)
 	} else if conf != nil {
+		conf.RoleFromRequest = defaultRoleFromRequest
+
 		smokescreen.StartWithConfig(conf, nil)
 	} else {
 		// --help or --version was passed and handled by NewConfiguration, so do nothing

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -89,6 +89,16 @@ func NewConfig() *Config {
 	}
 }
 
+func (config *Config) Check() []error {
+	errors := make([]error, 0)
+
+	if config.Port < 1 || config.Port > 65535 {
+		errors = append(errors, fmt.Errorf("Invalid port: %d", config.Port))
+	}
+
+	return errors
+}
+
 func (config *Config) SetupCrls(crlFiles []string) error {
 	fail := func(err error) error { fmt.Print(err); return err }
 

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -92,28 +92,6 @@ func (config *Config) Init() error {
 		config.Log = log.New()
 	}
 
-	// Configure RoleFromRequest for default behavior. It is ultimately meant to be replaced by the user.
-	if config.TlsConfig != nil && config.TlsConfig.ClientCAs != nil { // If client certs are set, pick the CN.
-		config.RoleFromRequest = func(req *http.Request) (string, error) {
-			fail := func(err error) (string, error) { return "", err }
-			if len(req.TLS.PeerCertificates) == 0 {
-				return fail(MissingRoleError("client did not provide certificate"))
-			}
-			return req.TLS.PeerCertificates[0].Subject.CommonName, nil
-		}
-	} else { // Use a custom header
-		config.RoleFromRequest = func(req *http.Request) (string, error) {
-			fail := func(err error) (string, error) { return "", err }
-			idHeader := req.Header["X-Smokescreen-Role"]
-			if len(idHeader) == 0 {
-				return fail(MissingRoleError("client did not send 'X-Smokescreen-Role' header"))
-			} else if len(idHeader) > 1 {
-				return fail(MissingRoleError("client sent multiple 'X-Smokescreen-Role' headers"))
-			}
-			return idHeader[0], nil
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -20,7 +20,7 @@ import (
 
 type Config struct {
 	Ip                           string
-	Port                         int
+	Port                         uint16
 	CidrBlacklist                []net.IPNet
 	CidrBlacklistExemptions      []net.IPNet
 	ConnectTimeout               time.Duration
@@ -86,6 +86,7 @@ func NewConfig() *Config {
 		CrlByAuthorityKeyId: make(map[string]*pkix.CertificateList),
 		clientCasBySubjectKeyId: make(map[string]*x509.Certificate),
 		Log: log.New(),
+		Port: 4750,
 	}
 }
 

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	AdditionalErrorMessageOnDeny string
 	Log                          *log.Logger
 	DisabledAclPolicyActions     []string
+	AllowMissingRole             bool
 }
 
 type missingRoleError struct {
@@ -266,8 +267,8 @@ func (config *Config) SetupTls(certFile, keyFile string, clientCAFiles []string)
 
 	config.TlsConfig = &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
-		ClientAuth: clientAuth,
-		ClientCAs: clientCAs,
+		ClientAuth:   clientAuth,
+		ClientCAs:    clientCAs,
 	}
 
 	return nil

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -90,16 +90,6 @@ func NewConfig() *Config {
 	}
 }
 
-func (config *Config) Check() []error {
-	errors := make([]error, 0)
-
-	if config.Port < 1 || config.Port > 65535 {
-		errors = append(errors, fmt.Errorf("Invalid port: %d", config.Port))
-	}
-
-	return errors
-}
-
 func (config *Config) SetupCrls(crlFiles []string) error {
 	fail := func(err error) error { fmt.Print(err); return err }
 

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -81,18 +81,12 @@ type authKeyId struct {
 	Id []byte `asn1:"optional,tag:0"`
 }
 
-func (config *Config) Init() error {
-	if config.CrlByAuthorityKeyId == nil {
-		config.CrlByAuthorityKeyId = make(map[string]*pkix.CertificateList)
+func NewConfig() *Config {
+	return &Config{
+		CrlByAuthorityKeyId: make(map[string]*pkix.CertificateList),
+		clientCasBySubjectKeyId: make(map[string]*x509.Certificate),
+		Log: log.New(),
 	}
-	if config.clientCasBySubjectKeyId == nil {
-		config.clientCasBySubjectKeyId = make(map[string]*x509.Certificate)
-	}
-	if config.Log == nil {
-		config.Log = log.New()
-	}
-
-	return nil
 }
 
 func (config *Config) SetupCrls(crlFiles []string) error {

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -10,24 +10,26 @@ import (
 )
 
 type yamlConfigTls struct {
-	CertFile string `yaml:"cert_file"`
-	KeyFile string `yaml:"key_file"`
+	CertFile      string   `yaml:"cert_file"`
+	KeyFile       string   `yaml:"key_file"`
 	ClientCAFiles []string `yaml:"client_ca_files"`
 }
 
-type yamlConfig struct{
-	Ip string
-	Port int
-	DenyRanges	[]string `yaml:"deny_ranges"`
-	AllowRanges	[]string `yaml:"allow_ranges"`
-	ConnectTimeout time.Duration `yaml:"connect_timeout"`
-	ExitTimeout time.Duration `yaml:"exit_timeout"`
-	MaintenanceFile	string `yaml:"maintenance_file"`
-	StatsdAddress string `yaml:"statsd_address"`
-	EgressAclFile string `yaml:"acl_file"`
-	SupportProxyProtocol bool `yaml:"support_proxy_protocol"`
-	Tls *yamlConfigTls
-	DenyMessageExtra string `yaml:"deny_message_extra"`
+type yamlConfig struct {
+	Ip                   string
+	Port                 int
+	DenyRanges           []string      `yaml:"deny_ranges"`
+	AllowRanges          []string      `yaml:"allow_ranges"`
+	ConnectTimeout       time.Duration `yaml:"connect_timeout"`
+	ExitTimeout          time.Duration `yaml:"exit_timeout"`
+	MaintenanceFile      string        `yaml:"maintenance_file"`
+	StatsdAddress        string        `yaml:"statsd_address"`
+	EgressAclFile        string        `yaml:"acl_file"`
+	SupportProxyProtocol bool          `yaml:"support_proxy_protocol"`
+	DenyMessageExtra     string `yaml:"deny_message_extra"`
+	AllowMissingRole     bool	`yaml:"allow_missing_role"`
+
+	Tls                  *yamlConfigTls
 
 	// Currently not configurable via YAML: RoleFromRequest, Log, DisabledAclPolicyActions
 }
@@ -83,7 +85,7 @@ func UnmarshalConfig(rawYaml []byte) (Config, error) {
 		}
 
 		key_file := yc.Tls.KeyFile
-		if  key_file == "" {
+		if key_file == "" {
 			// Assume CertFile is a cert+key bundle
 			key_file = yc.Tls.CertFile
 		}
@@ -94,6 +96,7 @@ func UnmarshalConfig(rawYaml []byte) (Config, error) {
 		}
 	}
 
+	c.AllowMissingRole = yc.AllowMissingRole
 	c.AdditionalErrorMessageOnDeny = yc.DenyMessageExtra
 
 	return c, nil

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -2,7 +2,6 @@ package smokescreen
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"time"
@@ -114,14 +113,11 @@ func LoadConfig(filePath string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	config, err := UnmarshalConfig(bytes)
 	if err != nil {
 		return nil, err
 	}
 
-	errs := config.Check()
-	if len(errs) > 0 {
-		return nil, fmt.Errorf("Invalid Config: %v", errs)
-	}
 	return config, nil
 }

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -26,8 +26,8 @@ type yamlConfig struct {
 	StatsdAddress        string        `yaml:"statsd_address"`
 	EgressAclFile        string        `yaml:"acl_file"`
 	SupportProxyProtocol bool          `yaml:"support_proxy_protocol"`
-	DenyMessageExtra     string `yaml:"deny_message_extra"`
-	AllowMissingRole     bool	`yaml:"allow_missing_role"`
+	DenyMessageExtra     string        `yaml:"deny_message_extra"`
+	AllowMissingRole     bool          `yaml:"allow_missing_role"`
 
 	Tls                  *yamlConfigTls
 

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -27,8 +27,8 @@ var PrivateNetworkRanges []net.IPNet
 // handing out Regexps from a pool doesn't save us anything either, so we'll
 // just live with it.
 const hostExtractPattern = "^([^:]*)(:\\d+)?$"
-var hostExtractRE *regexp.Regexp
 
+var hostExtractRE *regexp.Regexp
 
 func init() {
 	PrivateNetworkRanges = make([]net.IPNet, len(privateNetworkStrings))

--- a/pkg/smokescreen/role_test.go
+++ b/pkg/smokescreen/role_test.go
@@ -1,0 +1,47 @@
+package smokescreen
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func mockRFR(s string, e error) func(req *http.Request) (string, error) {
+	return func(req *http.Request) (string, error) {
+		return s, e
+	}
+}
+
+func _testGetRole(t *testing.T, rfr_s string, rfr_e error, allow_missing bool, expect_s string, expect_e error) {
+	config := Config{
+		RoleFromRequest:  mockRFR(rfr_s, rfr_e),
+		AllowMissingRole: allow_missing,
+	}
+	s, e := getRole(&config, nil)
+	if (e == nil) != (expect_e == nil) {
+		t.Fatalf("expected err %v got %v\n", expect_e, e)
+	}
+	if s != expect_s {
+		t.Fatalf("expected role %v got %v\n", expect_s, s)
+	}
+}
+
+func TestGetRole(t *testing.T) {
+	role := "some role"
+	genErr := errors.New("general error")
+	mre := MissingRoleError("missing role")
+
+	t.Run("good", func(t *testing.T) {
+		_testGetRole(t, role, nil, false, role, nil)
+	})
+	t.Run("bad", func(t *testing.T) {
+		_testGetRole(t, "", genErr, false, "", genErr)
+	})
+
+	t.Run("missing not allowed", func(t *testing.T) {
+		_testGetRole(t, "", mre, false, "", genErr)
+	})
+	t.Run("missing allowed", func(t *testing.T) {
+		_testGetRole(t, "", mre, true, "", nil)
+	})
+}

--- a/pkg/smokescreen/role_test.go
+++ b/pkg/smokescreen/role_test.go
@@ -38,10 +38,10 @@ func TestGetRole(t *testing.T) {
 		_testGetRole(t, "", genErr, false, "", genErr)
 	})
 
-	t.Run("missing not allowed", func(t *testing.T) {
+	t.Run("missing not allowed -> err", func(t *testing.T) {
 		_testGetRole(t, "", mre, false, "", mre)
 	})
-	t.Run("missing allowed", func(t *testing.T) {
+	t.Run("missing allowed -> empty role", func(t *testing.T) {
 		_testGetRole(t, "", mre, true, "", nil)
 	})
 }

--- a/pkg/smokescreen/role_test.go
+++ b/pkg/smokescreen/role_test.go
@@ -18,7 +18,7 @@ func _testGetRole(t *testing.T, rfr_s string, rfr_e error, allow_missing bool, e
 		AllowMissingRole: allow_missing,
 	}
 	s, e := getRole(&config, nil)
-	if (e == nil) != (expect_e == nil) {
+	if e != expect_e {
 		t.Fatalf("expected err %v got %v\n", expect_e, e)
 	}
 	if s != expect_s {
@@ -39,7 +39,7 @@ func TestGetRole(t *testing.T) {
 	})
 
 	t.Run("missing not allowed", func(t *testing.T) {
-		_testGetRole(t, "", mre, false, "", genErr)
+		_testGetRole(t, "", mre, false, "", mre)
 	})
 	t.Run("missing allowed", func(t *testing.T) {
 		_testGetRole(t, "", mre, true, "", nil)

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -419,6 +419,11 @@ func runServer(config *Config, server *http.Server, listener net.Listener, quit 
 	}
 }
 
+// Extract the client's ACL role from the HTTP request, using the configured
+// RoleFromRequest function.  Returns the role, or an error if the role cannot
+// be determined (including no RoleFromRequest configured), unless
+// AllowMissingRole is configured, in which case an empty role and no error is
+// returned.
 func getRole(config *Config, req *http.Request) (string, error) {
 	var role string
 	var err error

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -419,6 +419,26 @@ func runServer(config *Config, server *http.Server, listener net.Listener, quit 
 	}
 }
 
+func getRole(config *Config, req *http.Request) (string, error) {
+	var role string
+	var err error
+
+	if config.RoleFromRequest != nil {
+		role, err = config.RoleFromRequest(req)
+	} else {
+		err = MissingRoleError("RoleFromRequest not configured")
+	}
+
+	switch {
+	case err == nil:
+		return role, nil
+	case IsMissingRoleError(err) && config.AllowMissingRole:
+		return "", nil
+	default:
+		return "", err
+	}
+}
+
 func checkIfRequestShouldBeProxied(config *Config, req *http.Request, outboundHost string) (*aclDecision, error) {
 	decision := &aclDecision{}
 
@@ -428,13 +448,12 @@ func checkIfRequestShouldBeProxied(config *Config, req *http.Request, outboundHo
 		return decision, nil
 	}
 
-	role, roleErr := config.RoleFromRequest(req)
-	// A missing role is OK at this point since we may have a default
-	if roleErr != nil && !IsMissingRoleError(roleErr) {
+	role, roleErr := getRole(config, req)
+	if roleErr != nil {
 		return nil, roleErr
 	}
-	decision.role = role
 
+	decision.role = role
 	decision.project, _ = config.EgressAcl.Project(role)
 
 	submatch := hostExtractRE.FindStringSubmatch(outboundHost)
@@ -442,6 +461,7 @@ func checkIfRequestShouldBeProxied(config *Config, req *http.Request, outboundHo
 	result, err := config.EgressAcl.Decide(role, submatch[1])
 	if err != nil {
 		if rerr, ok := err.(UnknownRoleError); ok {
+			//XXX TODO confirm this is still right
 			var msg string
 			if roleErr != nil {
 				msg = fmt.Sprintf("unable to extract a role from your request and no default is provided (%s)", err.Error())

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -328,7 +328,7 @@ func handleConnect(config *Config, ctx *goproxy.ProxyCtx) (*net.TCPAddr, error) 
 	return resolved, nil
 }
 
-func findListener(ip string, defaultPort int) (net.Listener, error) {
+func findListener(ip string, defaultPort uint16) (net.Listener, error) {
 	if einhorn.IsWorker() {
 		listener, err := einhorn.GetListener(0)
 		if err != nil {


### PR DESCRIPTION
r? @tremblay-stripe 

- Pull default RoleFromRequest implementation out of `config.go` / package `smokescreen`.
  - A cert-only version is created in the `main` package for our `smokescreen` executable.
  - The integration test uses both cert and header-based implementations.
- Replaced `Init()` method which needed to be called after setting up other config with `NewConfig`, which returns a pointer to a new Config object with maps and the Log member initialized.
- Extracted logic around calling RoleFromRequest into a `getRole` function.
- Misc cleanup of formatting and integration test output.