### PR TITLE
Rlk/config part 3

### DIFF
--- a/pkg/smokescreen/acl_loader_v1_test.go
+++ b/pkg/smokescreen/acl_loader_v1_test.go
@@ -19,7 +19,7 @@ var testCases = map[string]struct {
 	expectDecision          EgressAclDecision
 	expectProject           string
 }{
-	"allowed by whitelist when enforcing": {
+	"allowed by list when enforcing": {
 		"sample_config.yaml",
 		"enforce-dummy-srv",
 		"example1.com",
@@ -33,7 +33,7 @@ var testCases = map[string]struct {
 		EgressAclDecisionDeny,
 		"usersec",
 	},
-	"allowed by whitelist when reporting": {
+	"allowed by list when reporting": {
 		"sample_config.yaml",
 		"report-dummy-srv",
 		"example3.com",
@@ -82,7 +82,7 @@ var testCases = map[string]struct {
 		EgressAclDecisionDeny,
 		"other",
 	},
-	"allow from default whitelist": {
+	"allow from default list": {
 		"sample_config.yaml",
 		"unknown-service",
 		"default.example.com",

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -91,15 +91,10 @@ func NewConfig() *Config {
 }
 
 func (config *Config) SetupCrls(crlFiles []string) error {
-	fail := func(err error) error { fmt.Print(err); return err }
-
-	config.CrlByAuthorityKeyId = make(map[string]*pkix.CertificateList)
-	config.clientCasBySubjectKeyId = make(map[string]*x509.Certificate)
-
 	for _, crlFile := range crlFiles {
 		crlBytes, err := ioutil.ReadFile(crlFile)
 		if err != nil {
-			return fail(err)
+			return err
 		}
 
 		certList, err := x509.ParseCRL(crlBytes)

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -87,6 +87,7 @@ func NewConfig() *Config {
 		clientCasBySubjectKeyId: make(map[string]*x509.Certificate),
 		Log: log.New(),
 		Port: 4750,
+		ExitTimeout: 60 * time.Second,
 	}
 }
 

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -21,8 +21,8 @@ import (
 type Config struct {
 	Ip                           string
 	Port                         uint16
-	CidrBlacklist                []net.IPNet
-	CidrBlacklistExemptions      []net.IPNet
+	DenyRanges                   []net.IPNet
+	AllowRanges                  []net.IPNet
 	ConnectTimeout               time.Duration
 	ExitTimeout                  time.Duration
 	MaintenanceFile              string
@@ -66,13 +66,13 @@ func parseRanges(rangeStrings []string) ([]net.IPNet, error) {
 
 func (config *Config) SetDenyRanges(rangeStrings []string) error {
 	var err error
-	config.CidrBlacklist, err = parseRanges(rangeStrings)
+	config.DenyRanges, err = parseRanges(rangeStrings)
 	return err
 }
 
 func (config *Config) SetAllowRanges(rangeStrings []string) error {
 	var err error
-	config.CidrBlacklistExemptions, err = parseRanges(rangeStrings)
+	config.AllowRanges, err = parseRanges(rangeStrings)
 	return err
 }
 

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -16,15 +16,15 @@ type yamlConfigTls struct {
 	CRLFiles      []string `yaml:"crl_files"`
 }
 
+// Port and ExitTimeout use a pointer so we can distinguish unset vs explicit
+// zero, to avoid overriding a non-zero default when the value is not set.
 type yamlConfig struct {
 	Ip                   string
-	// use a pointer here so we can distinguish unset vs explicit zero, as we
-	// may be overriding a non-zero default
 	Port                 *uint16
 	DenyRanges           []string      `yaml:"deny_ranges"`
 	AllowRanges          []string      `yaml:"allow_ranges"`
 	ConnectTimeout       time.Duration `yaml:"connect_timeout"`
-	ExitTimeout          time.Duration `yaml:"exit_timeout"`
+	ExitTimeout          *time.Duration `yaml:"exit_timeout"`
 	MaintenanceFile      string        `yaml:"maintenance_file"`
 	StatsdAddress        string        `yaml:"statsd_address"`
 	EgressAclFile        string        `yaml:"acl_file"`
@@ -63,7 +63,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	c.ConnectTimeout = yc.ConnectTimeout
-	c.ExitTimeout = yc.ExitTimeout
+	if yc.ExitTimeout != nil {
+		c.ExitTimeout = *yc.ExitTimeout
+	}
 
 	c.MaintenanceFile = yc.MaintenanceFile
 	if c.MaintenanceFile != "" {

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -13,6 +13,7 @@ type yamlConfigTls struct {
 	CertFile      string   `yaml:"cert_file"`
 	KeyFile       string   `yaml:"key_file"`
 	ClientCAFiles []string `yaml:"client_ca_files"`
+	CRLFiles      []string `yaml:"crl_files"`
 }
 
 type yamlConfig struct {
@@ -100,6 +101,8 @@ func UnmarshalConfig(rawYaml []byte) (*Config, error) {
 		if err != nil {
 			return c, err
 		}
+
+		c.SetupCrls(yc.Tls.CRLFiles)
 	}
 
 	c.AllowMissingRole = yc.AllowMissingRole

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -97,16 +97,16 @@ func ipIsInSetOfNetworks(nets []net.IPNet, ip net.IP) bool {
 
 func classifyIP(config *Config, ip net.IP) ipType {
 	if !ip.IsGlobalUnicast() || ip.IsLoopback() {
-		if ipIsInSetOfNetworks(config.CidrBlacklistExemptions, ip) {
+		if ipIsInSetOfNetworks(config.AllowRanges, ip) {
 			return ipAllowUserConfigured
 		} else {
 			return ipDenyNotGlobalUnicast
 		}
 	}
 
-	if ipIsInSetOfNetworks(config.CidrBlacklistExemptions, ip) {
+	if ipIsInSetOfNetworks(config.AllowRanges, ip) {
 		return ipAllowUserConfigured
-	} else if ipIsInSetOfNetworks(config.CidrBlacklist, ip) {
+	} else if ipIsInSetOfNetworks(config.DenyRanges, ip) {
 		return ipDenyUserConfigured
 	} else if ipIsInSetOfNetworks(PrivateNetworkRanges, ip) {
 		return ipDenyPrivateRange


### PR DESCRIPTION
r? @tremblay-stripe 

With this PR, YAML-based configuration is basically feature-complete.  🎉 

- Add config file field for CRLs
- Replace `UnmarshalConfig` function with implementation of `UnmarshalYAML` from the`Unmarshaler` interface (for compatibility with other things that load YAML.)
- Add CLI flag to load a config file, and support overriding individual fields from args.
- Naming, etc, cleanup