### PR TITLE
Error handling cleanup

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -84,7 +84,7 @@ func conformResult(t *testing.T, test *TestCase, resp *http.Response, err error,
 		if !a.NoError(err) {
 			return
 		}
-		a.Contains(string(body), "egress proxying denied")
+		a.Contains(string(body), "denied")
 		a.Contains(string(body), "moar ctx")
 	}
 

--- a/main.go
+++ b/main.go
@@ -12,6 +12,9 @@ import (
 // configuration option will control whether the request is rejected, or the
 // default ACL is applied.
 func defaultRoleFromRequest(req *http.Request) (string, error) {
+	if req.TLS == nil {
+		return "", smokescreen.MissingRoleError("defaultRoleFromRequest requires TLS")
+	}
 	if len(req.TLS.PeerCertificates) == 0 {
 		return "", smokescreen.MissingRoleError("client did not provide certificate")
 	}

--- a/pkg/smokescreen/acl_loader_v1_test.go
+++ b/pkg/smokescreen/acl_loader_v1_test.go
@@ -119,11 +119,11 @@ func TestUnknownServiceWithoutDefault(t *testing.T) {
 	a.NotNil(acl)
 
 	proj, err := acl.Project("unk")
-	a.Equal(UnknownRoleError{"unk"}, err)
+	a.Equal("unknown role: 'unk'", err.Error())
 	a.Empty(proj)
 
 	decision, err := acl.Decide("unk", "example.com")
-	a.Equal(UnknownRoleError{"unk"}, err)
+	a.Equal("unknown role: 'unk'", err.Error())
 	a.Empty(decision)
 }
 

--- a/pkg/smokescreen/egressacl.go
+++ b/pkg/smokescreen/egressacl.go
@@ -1,16 +1,6 @@
 package smokescreen
 
-import "fmt"
-
 type EgressAcl interface {
 	Decide(fromService string, toHost string) (EgressAclDecision, error)
 	Project(fromService string) (string, error)
-}
-
-type UnknownRoleError struct {
-	Role string
-}
-
-func (u UnknownRoleError) Error() string {
-	return fmt.Sprintf("unknown role role=%s", u.Role)
 }

--- a/pkg/smokescreen/role_test.go
+++ b/pkg/smokescreen/role_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	log "github.com/sirupsen/logrus"
 )
 
 func mockRFR(s string, e error) func(req *http.Request) (string, error) {
@@ -16,6 +17,7 @@ func _testGetRole(t *testing.T, rfr_s string, rfr_e error, allow_missing bool, e
 	config := Config{
 		RoleFromRequest:  mockRFR(rfr_s, rfr_e),
 		AllowMissingRole: allow_missing,
+		Log: log.New(),
 	}
 	s, e := getRole(&config, nil)
 	if e != expect_e {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -443,6 +443,11 @@ func getRole(config *Config, req *http.Request) (string, error) {
 	case IsMissingRoleError(err) && config.AllowMissingRole:
 		return "", nil
 	default:
+		config.Log.WithFields(logrus.Fields{
+			"error": err,
+			"is_missing_role": IsMissingRoleError(err),
+			"allow_missing_role": config.AllowMissingRole,
+		}).Info("Unable to get role for request")
 		return "", err
 	}
 }

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -148,6 +148,9 @@ func rejectResponse(req *http.Request, config *Config, err error) *http.Response
 	case denyError:
 		msg = fmt.Sprintf(denyMsgTmpl, req.Host, err.Error())
 	default:
+		config.Log.WithFields(logrus.Fields{
+			"error": err,
+		}).Warn("rejectResponse called with unexpected error")
 		msg = "an unexpected error occurred."
 	}
 


### PR DESCRIPTION
- Consolidate error handling.
  - `checkIfRequestShouldBeProxied` handles errors internally, and always returns a decision with a user-visible reason.
  - This allows us to remove `UnknownRoleError` entirely.
- Normalize error message formatting: capitalization, colons, (mostly) active voice sentences.
- Add some more logging.

Also fixed a crashing bug when trying to use the default `RoleFromRequest` without TLS.