### PR TITLE
constants: Add link-local address ranges

### DIFF
--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -15,9 +15,11 @@ const DefaultStatsdNamespace = "smokescreen."
 
 var privateNetworkStrings = [...]string{
 	"10.0.0.0/8",
+	"169.254.0.0/16",  // Link-local address range
 	"172.16.0.0/12",
 	"192.168.0.0/16",
 	"fc00::/7",
+	"fe80::/10",       // Link-local address range
 }
 
 var PrivateNetworkRanges []net.IPNet


### PR DESCRIPTION
Add link-local address ranges (IPv4 and IPv6) to the privateNetworkStrings constant.

The list is based on https://en.wikipedia.org/wiki/Link-local_address .

A possible vulnerable scenario would be a Smokescreen proxy running on EC2 machine; the end-user (attacker) can then ask the proxy to connect to `http://169.254.169.254/latest/meta-data` which will return Amazon EC2 internal information; details in https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html . With the proposed fix this request will be blocked.