### PR TITLE
Disable keepalives

### DIFF
--- a/cmd/check_config/main.go
+++ b/cmd/check_config/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+
 	"github.com/stripe/smokescreen/pkg/smokescreen"
 )
 
@@ -15,7 +16,7 @@ func main() {
 
 	config, err := smokescreen.LoadConfig(filePath)
 	if err != nil {
-		fmt.Printf("Failed to load config: %v\n", err);
+		fmt.Printf("Failed to load config: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"errors"
-	"math"
 	"fmt"
+	"math"
 	"os"
 	"time"
 

--- a/main.go
+++ b/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"net/http"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/stripe/smokescreen/cmd"
 	"github.com/stripe/smokescreen/pkg/smokescreen"
-	"net/http"
 )
 
 // This default implementation of RoleFromRequest uses the CommonName of the

--- a/pkg/smokescreen/acl_loader_v1.go
+++ b/pkg/smokescreen/acl_loader_v1.go
@@ -3,11 +3,12 @@ package smokescreen
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"gopkg.in/yaml.v2"
 )
 
 type EgressAclRule struct {

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -83,11 +83,11 @@ type authKeyId struct {
 
 func NewConfig() *Config {
 	return &Config{
-		CrlByAuthorityKeyId: make(map[string]*pkix.CertificateList),
+		CrlByAuthorityKeyId:     make(map[string]*pkix.CertificateList),
 		clientCasBySubjectKeyId: make(map[string]*x509.Certificate),
-		Log: log.New(),
-		Port: 4750,
-		ExitTimeout: 60 * time.Second,
+		Log:                     log.New(),
+		Port:                    4750,
+		ExitTimeout:             60 * time.Second,
 	}
 }
 

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -21,18 +21,18 @@ type yamlConfigTls struct {
 type yamlConfig struct {
 	Ip                   string
 	Port                 *uint16
-	DenyRanges           []string      `yaml:"deny_ranges"`
-	AllowRanges          []string      `yaml:"allow_ranges"`
-	ConnectTimeout       time.Duration `yaml:"connect_timeout"`
+	DenyRanges           []string       `yaml:"deny_ranges"`
+	AllowRanges          []string       `yaml:"allow_ranges"`
+	ConnectTimeout       time.Duration  `yaml:"connect_timeout"`
 	ExitTimeout          *time.Duration `yaml:"exit_timeout"`
-	MaintenanceFile      string        `yaml:"maintenance_file"`
-	StatsdAddress        string        `yaml:"statsd_address"`
-	EgressAclFile        string        `yaml:"acl_file"`
-	SupportProxyProtocol bool          `yaml:"support_proxy_protocol"`
-	DenyMessageExtra     string        `yaml:"deny_message_extra"`
-	AllowMissingRole     bool          `yaml:"allow_missing_role"`
+	MaintenanceFile      string         `yaml:"maintenance_file"`
+	StatsdAddress        string         `yaml:"statsd_address"`
+	EgressAclFile        string         `yaml:"acl_file"`
+	SupportProxyProtocol bool           `yaml:"support_proxy_protocol"`
+	DenyMessageExtra     string         `yaml:"deny_message_extra"`
+	AllowMissingRole     bool           `yaml:"allow_missing_role"`
 
-	Tls                  *yamlConfigTls
+	Tls *yamlConfigTls
 
 	// Currently not configurable via YAML: RoleFromRequest, Log, DisabledAclPolicyActions
 }

--- a/pkg/smokescreen/role_test.go
+++ b/pkg/smokescreen/role_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -17,7 +18,7 @@ func _testGetRole(t *testing.T, rfr_s string, rfr_e error, allow_missing bool, e
 	config := Config{
 		RoleFromRequest:  mockRFR(rfr_s, rfr_e),
 		AllowMissingRole: allow_missing,
-		Log: log.New(),
+		Log:              log.New(),
 	}
 	s, e := getRole(&config, nil)
 	if e != expect_e {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -183,9 +183,9 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 	proxy.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 		config.Log.WithFields(
 			logrus.Fields{
-				"source_ip": ctx.Req.RemoteAddr,
-				"requested_host":   ctx.Req.Host,
-				"url":    ctx.Req.RequestURI,
+				"source_ip":      ctx.Req.RemoteAddr,
+				"requested_host": ctx.Req.Host,
+				"url":            ctx.Req.RequestURI,
 			}).Debug("received HTTP proxy request")
 		userData := ctxUserData{time.Now(), nil}
 		ctx.UserData = &userData
@@ -300,8 +300,8 @@ func logHTTP(config *Config, ctx *goproxy.ProxyCtx) {
 func handleConnect(config *Config, ctx *goproxy.ProxyCtx) (*net.TCPAddr, error) {
 	config.Log.WithFields(
 		logrus.Fields{
-			"remote": ctx.Req.RemoteAddr,
-			"requested_host":   ctx.Req.Host,
+			"remote":         ctx.Req.RemoteAddr,
+			"requested_host": ctx.Req.Host,
 		}).Debug("received CONNECT proxy request")
 	start := time.Now()
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -175,6 +175,10 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 		return dial(config, network, addr)
 	}
 
+	// Ensure that we don't keep old connections alive to avoid TLS errors
+	// when attempting to re-use an idle connection.
+	proxy.Tr.DisableKeepAlives = true
+
 	// Handle traditional HTTP proxy
 	proxy.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 		config.Log.WithFields(


### PR DESCRIPTION
This prevents us from running into TLS errors when re-using old connections; it's a bit of a large hammer for now, so we may want to re-visit in order to make this a bit more fine-grained.