### PR TITLE
replace the std log's output writer by our writter (in the example)

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"log"
 	"net/http"
-
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stripe/smokescreen/cmd"
 	"github.com/stripe/smokescreen/pkg/smokescreen"
 )
@@ -25,10 +25,19 @@ func defaultRoleFromRequest(req *http.Request) (string, error) {
 func main() {
 	conf, err := cmd.NewConfiguration(nil, nil)
 	if err != nil {
-		log.Fatalf("Could not create configuration: %v", err)
+		logrus.Fatalf("Could not create configuration: %v", err)
 	} else if conf != nil {
 		conf.RoleFromRequest = defaultRoleFromRequest
 
+		conf.Log.Formatter = &logrus.JSONFormatter{}
+
+		adapter := &smokescreen.Log2LogrusWriter{
+			Entry: conf.Log.WithField("stdlog", "1"),
+		}
+
+		// Set the standard logger to use our logger's writter as output.
+		log.SetOutput(adapter)
+		log.SetFlags(0)
 		smokescreen.StartWithConfig(conf, nil)
 	} else {
 		// --help or --version was passed and handled by NewConfiguration, so do nothing

--- a/pkg/smokescreen/logruswriter.go
+++ b/pkg/smokescreen/logruswriter.go
@@ -1,0 +1,19 @@
+// From https://github.com/sirupsen/logrus/issues/436
+package smokescreen
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+type Log2LogrusWriter struct {
+	Entry *logrus.Entry
+}
+
+func (w *Log2LogrusWriter) Write(b []byte) (int, error) {
+	n := len(b)
+	if n > 0 && b[n-1] == '\n' {
+		b = b[:n-1]
+	}
+	w.Entry.Warning(string(b))
+	return n, nil
+}


### PR DESCRIPTION
r? @rlk-stripe

Description:
All in the title