### PR TITLE
Add healthcheck stat

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net/http"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stripe/smokescreen/cmd"
 	"github.com/stripe/smokescreen/pkg/smokescreen"

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -85,9 +85,9 @@ func NewConfig() *Config {
 	return &Config{
 		CrlByAuthorityKeyId:     make(map[string]*pkix.CertificateList),
 		clientCasBySubjectKeyId: make(map[string]*x509.Certificate),
-		Log:                     log.New(),
-		Port:                    4750,
-		ExitTimeout:             60 * time.Second,
+		Log:         log.New(),
+		Port:        4750,
+		ExitTimeout: 60 * time.Second,
 	}
 }
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -371,6 +371,7 @@ func StartWithConfig(config *Config, quit <-chan interface{}) {
 		handler = &HealthcheckMiddleware{
 			App:             handler,
 			MaintenanceFile: config.MaintenanceFile,
+			StatsdClient:    config.StatsdClient,
 		}
 	}
 


### PR DESCRIPTION
r? @tremblay-stripe 

Pass `config.StatsdClient` into our `HealthcheckMiddleware`, and use it to emit stats when we receive health checks, tagged up/down/error.