### PR TITLE
Move einhorn.Ack closer to be closer when we're actually calling Accept on the socket

### DIFF
--- a/pkg/smokescreen/listener.go
+++ b/pkg/smokescreen/listener.go
@@ -1,0 +1,49 @@
+package smokescreen
+
+import (
+	"net"
+
+	"github.com/stripe/go-einhorn/einhorn"
+)
+
+// einhornListener is a net.Listener that will send an ACK to the einhorn
+// master the first time its Accept method is called.
+//
+// Its implementation leaves a short time window between the sending the ACK
+// and when a thread is actively blocked by an Accept syscall. Because there is
+// a gap here it is possible for the process to freeze/crash/etc and never
+// reach the Accept call. This may lead to sadness because of dropped
+// connections (if the accept queue overflows) or timeouts because nothing
+// realized this process died.
+//
+// The alternatives to work around this are complex, introduce concurrency
+// and create several new classes of errors, so I've erred on the side
+// of simplicity so far, hoping that by moving the ACK as close to the Accept
+// as possible.
+type einhornListener struct {
+	net.Listener
+
+	accept func() (net.Conn, error)
+}
+
+func (el *einhornListener) firstAccept() (net.Conn, error) {
+	// Switch to the embedded Listener's Accept for all future calls
+	el.accept = el.Listener.Accept
+
+	// TODO: Should we just fire this into a goroutine so it will probably
+	// happen after we start blocking on Accept and then log.Fatal if it
+	// fails instead of returning an error?
+	if err := einhorn.Ack(); err != nil {
+		return nil, err
+	}
+
+	return el.Accept()
+}
+
+func (el *einhornListener) Accept() (net.Conn, error) {
+	if el.accept == nil {
+		return el.firstAccept()
+	}
+
+	return el.accept()
+}

--- a/pkg/smokescreen/listener.go
+++ b/pkg/smokescreen/listener.go
@@ -24,16 +24,12 @@ import (
 type einhornListener struct {
 	net.Listener
 
-	firstAcceptLock sync.Mutex
 	firstAcceptOnce sync.Once
 
 	accept func() (net.Conn, error)
 }
 
 func (el *einhornListener) firstAccept() (conn net.Conn, err error) {
-	el.firstAcceptLock.Lock()
-	defer el.firstAcceptLock.Unlock()
-
 	el.firstAcceptOnce.Do(func() {
 		// Switch to the embedded Listener's Accept for all future calls
 		el.accept = el.Listener.Accept

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -345,9 +345,7 @@ func findListener(ip string, defaultPort uint16) (net.Listener, error) {
 			return nil, err
 		}
 
-		err = einhorn.Ack()
-
-		return listener, err
+		return &einhornListener{Listener: listener}, err
 	} else {
 		return net.Listen("tcp", fmt.Sprintf("%s:%d", ip, defaultPort))
 	}


### PR DESCRIPTION
r? @tremblay-stripe 
cc? @adunham-stripe @rlk-stripe 

### Summary

`einhorn.Ack()` is currently pretty far away from where where it actually gets used. This means that there is a time window in which the previous worker may be dead and the new smokescreen isn't yet ready to Accept new connections. In high QPS situations this leads to overflowing the TCP Accept Queue and clients getting unhappy.

### How to reproduce the problem

1. Deploy finishes
2. Einhorn gets a HUP saying launch the new worker code
3. New worker process launched.
4. The new worker immediately ACKs Einhorn.
5. Einhorn SIGTERM's the previous worker
6. Previous worker stops and now there is no thread calling `listener.Accept()`

_Pending TCP connections begin to queue up_

7. Some arbitrary amount of time later the new worker starts calling `listener.Accept()`

If the requests hitting smokescreen are large enough to overflow the listen buffer before Step 7 this will lead to dropped connections.

### Concerns

This PR just delays Ack-ing Einhorn until right before we call the underlying socket's Accept. There is still a window there, but it is much smaller now. The alternatives to completely remove this window are non-trivial and introduce several new classes of errors. So for now I think I want to err on the side of simplicity