### PR TITLE
allow other processes to know about current connection statuses

### DIFF
--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -104,7 +104,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			Usage: "Disable usage of a `POLICY ACTION` such as \"open\" in the egress ACL",
 		},
 		cli.StringFlag{
-			Name: "stats-socket-dir",
+			Name:  "stats-socket-dir",
 			Usage: "Enable connection tracking. Will expose one UDS in the directory mentioned going by the name of `track-{pid}.sock`.",
 		},
 	}
@@ -164,7 +164,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 		if c.IsSet("disable-acl-policy-action") {
 			conf.DisabledAclPolicyActions = c.StringSlice("disable-acl-policy-action")
 		}
-		
+
 		if c.IsSet("stats-socket-dir") {
 			conf.StatsSocketDir = c.String("stats-socket-dir")
 		}

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -103,6 +103,10 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			Name:  "disable-acl-policy-action",
 			Usage: "Disable usage of a `POLICY ACTION` such as \"open\" in the egress ACL",
 		},
+		cli.StringFlag{
+			Name: "stats-socket-dir",
+			Usage: "Enable connection tracking. Will expose one UDS in the directory mentioned going by the name of `track-{pid}.sock`.",
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -159,6 +163,10 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 
 		if c.IsSet("disable-acl-policy-action") {
 			conf.DisabledAclPolicyActions = c.StringSlice("disable-acl-policy-action")
+		}
+		
+		if c.IsSet("stats-socket-dir") {
+			conf.StatsSocketDir = c.String("stats-socket-dir")
 		}
 
 		if c.IsSet("deny-range") {

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strconv"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -107,6 +108,11 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			Name:  "stats-socket-dir",
 			Usage: "Enable connection tracking. Will expose one UDS in the directory mentioned going by the name of `track-{pid}.sock`.",
 		},
+		cli.StringFlag{
+			Name:  "stats-socket-file-mode",
+			Value: "700",
+			Usage: "Set the filemode to `FILE_MODE` on the statistics socket",
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -167,6 +173,14 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 
 		if c.IsSet("stats-socket-dir") {
 			conf.StatsSocketDir = c.String("stats-socket-dir")
+		}
+
+		if c.IsSet("stats-socket-file-mode") {
+			filemode, err := strconv.ParseInt(c.String("stats-socket-file-mode"), 8, 9)
+			if err != nil {
+				return err
+			}
+			conf.StatsSocketFileMode = os.FileMode(filemode)
 		}
 
 		if c.IsSet("deny-range") {

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -94,7 +94,7 @@ func NewConfig() *Config {
 		Log:                     log.New(),
 		Port:                    4750,
 		ExitTimeout:             60 * time.Second,
-		StatsSocketFileMode:     os.FileMode(700),
+		StatsSocketFileMode:     os.FileMode(0700),
 	}
 }
 

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	StatsSocketDir               string
 	StatsSocketFileMode          os.FileMode
 	StatsServer                  interface{} // StatsServer
-	ConnTracker                  sync.Map    // The zero Map is empty and ready to use
+	ConnTracker                  *sync.Map   // The zero Map is empty and ready to use
 }
 
 type missingRoleError struct {
@@ -91,6 +91,7 @@ func NewConfig() *Config {
 	return &Config{
 		CrlByAuthorityKeyId:     make(map[string]*pkix.CertificateList),
 		clientCasBySubjectKeyId: make(map[string]*x509.Certificate),
+		ConnTracker:             new(sync.Map),
 		Log:                     log.New(),
 		Port:                    4750,
 		ExitTimeout:             60 * time.Second,

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -37,6 +38,9 @@ type Config struct {
 	Log                          *log.Logger
 	DisabledAclPolicyActions     []string
 	AllowMissingRole             bool
+	StatsSocketDir               string
+	StatsServer         interface{} // StatsServer
+	ConnTracker                  sync.Map // The zero Map is empty and ready to use
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -39,8 +40,9 @@ type Config struct {
 	DisabledAclPolicyActions     []string
 	AllowMissingRole             bool
 	StatsSocketDir               string
-	StatsServer         interface{} // StatsServer
-	ConnTracker                  sync.Map // The zero Map is empty and ready to use
+	StatsSocketFileMode          os.FileMode
+	StatsServer                  interface{} // StatsServer
+	ConnTracker                  sync.Map    // The zero Map is empty and ready to use
 }
 
 type missingRoleError struct {
@@ -89,9 +91,10 @@ func NewConfig() *Config {
 	return &Config{
 		CrlByAuthorityKeyId:     make(map[string]*pkix.CertificateList),
 		clientCasBySubjectKeyId: make(map[string]*x509.Certificate),
-		Log:         log.New(),
-		Port:        4750,
-		ExitTimeout: 60 * time.Second,
+		Log:                     log.New(),
+		Port:                    4750,
+		ExitTimeout:             60 * time.Second,
+		StatsSocketFileMode:     os.FileMode(700),
 	}
 }
 

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -31,6 +32,9 @@ type yamlConfig struct {
 	SupportProxyProtocol bool           `yaml:"support_proxy_protocol"`
 	DenyMessageExtra     string         `yaml:"deny_message_extra"`
 	AllowMissingRole     bool           `yaml:"allow_missing_role"`
+
+	StatsSocketDir      string `yaml:"stats_socket_dir"`
+	StatsSocketFileMode string `yaml:"stats_socket_file_mode"`
 
 	Tls *yamlConfigTls
 
@@ -87,6 +91,20 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	c.SupportProxyProtocol = yc.SupportProxyProtocol
+
+	if yc.StatsSocketDir != "" {
+		c.StatsSocketDir = yc.StatsSocketDir
+	}
+
+	if yc.StatsSocketFileMode != "" {
+		filemode, err := strconv.ParseInt(yc.StatsSocketFileMode, 8, 9)
+
+		if err != nil {
+			c.Log.Fatal(err)
+		}
+
+		c.StatsSocketFileMode = os.FileMode(filemode)
+	}
 
 	if yc.Tls != nil {
 		if yc.Tls.CertFile == "" {

--- a/pkg/smokescreen/instrumented_conn.go
+++ b/pkg/smokescreen/instrumented_conn.go
@@ -1,6 +1,7 @@
 package smokescreen
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/sirupsen/logrus"
 	"net"
@@ -9,25 +10,26 @@ import (
 )
 
 type ConnExt struct {
-	net.Conn
-	Config *Config
-	Role string
-	OutboundHost string
+	net.Conn `json:"-"`
+	Config *Config `json:"-"`
+	Role string `json:"role"`
+	OutboundHost string `json:"outbound"`
 	StartTime time.Time
 
 	BytesIn int
 	BytesOut int
 	Wakeups int
+	LastActivity time.Time
 
-	mutex sync.Mutex
+	mutex sync.Mutex `json:"-"`
 }
 
 func NewConnExt(
 	conn net.Conn,
 	config *Config, role,
 	outboundHost string,
-	startTime time.Time) *ConnExt {
-	return &ConnExt{
+	startTime time.Time) (ret *ConnExt) {
+	ret = &ConnExt{
 		conn,
 		config,
 		role,
@@ -36,11 +38,22 @@ func NewConnExt(
 		0,
 		0,
 		0,
+		time.Now(),
 		sync.Mutex{},
 	}
+
+	if config.StatsServer != nil {
+		config.ConnTracker.Store(ret, nil)
+	}
+
+	return
 }
 
 func (c *ConnExt) Close() error {
+	if c.Config.StatsServer != nil {
+		c.Config.ConnTracker.Delete(c)
+	}
+
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	endTime := time.Now()
@@ -73,6 +86,7 @@ func (c *ConnExt) Read(b []byte) (n int, err error) {
 	c.mutex.Lock()
 	c.BytesIn += len(b)
 	c.Wakeups += 1
+	c.LastActivity = time.Now()
 	c.mutex.Unlock()
 
 	return c.Conn.Read(b)
@@ -82,7 +96,36 @@ func (c *ConnExt) Write(b []byte) (n int, err error) {
 	c.mutex.Lock()
 	c.BytesOut += len(b)
 	c.Wakeups += 1
+	c.LastActivity = time.Now()
 	c.mutex.Unlock()
 
 	return c.Conn.Write(b)
+}
+
+func (c *ConnExt) JsonStats() ([]byte, error) {
+	type stats = struct {
+		Id string `json:"id"`
+		Role string `json:"role"`
+		Rhost string `json:"rhost"`
+		Created time.Time `json:"created"`
+		BytesIn int `json:"bytesIn"`
+		BytesOut int `json:"bytesOut"`
+		Wakeups int `json:"wakeups"`
+		SecondsSinceLastActivity float64 `json:"secondsSinceLastActivity"`
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	s := stats{
+		Id: fmt.Sprintf("%d", &c),
+		Role: c.Role,
+		Rhost: c.OutboundHost,
+		Created: c.StartTime,
+		BytesIn: c.BytesIn,
+		BytesOut: c.BytesOut,
+		Wakeups: c.Wakeups,
+		SecondsSinceLastActivity: time.Now().Sub(c.LastActivity).Seconds(),
+	}
+
+	return json.Marshal(s)
 }

--- a/pkg/smokescreen/instrumented_conn.go
+++ b/pkg/smokescreen/instrumented_conn.go
@@ -10,10 +10,10 @@ import (
 )
 
 type ConnExt struct {
-	net.Conn     `json:"-"`
-	Config       *Config `json:"-"`
-	Role         string  `json:"role"`
-	OutboundHost string  `json:"outbound"`
+	net.Conn
+	Config       *Config
+	Role         string
+	OutboundHost string
 	StartTime    time.Time
 
 	BytesIn      int
@@ -21,7 +21,7 @@ type ConnExt struct {
 	Wakeups      int
 	LastActivity time.Time
 
-	mutex sync.Mutex `json:"-"`
+	mutex sync.Mutex
 }
 
 func NewConnExt(

--- a/pkg/smokescreen/instrumented_conn.go
+++ b/pkg/smokescreen/instrumented_conn.go
@@ -10,15 +10,15 @@ import (
 )
 
 type ConnExt struct {
-	net.Conn `json:"-"`
-	Config *Config `json:"-"`
-	Role string `json:"role"`
-	OutboundHost string `json:"outbound"`
-	StartTime time.Time
+	net.Conn     `json:"-"`
+	Config       *Config `json:"-"`
+	Role         string  `json:"role"`
+	OutboundHost string  `json:"outbound"`
+	StartTime    time.Time
 
-	BytesIn int
-	BytesOut int
-	Wakeups int
+	BytesIn      int
+	BytesOut     int
+	Wakeups      int
 	LastActivity time.Time
 
 	mutex sync.Mutex `json:"-"`
@@ -76,8 +76,8 @@ func (c *ConnExt) Close() error {
 		"remote_addr": c.Conn.RemoteAddr(),
 		"start_time":  c.StartTime.UTC(),
 		"end_time":    endTime.UTC(),
-		"duration": duration,
-		"wakeups": c.Wakeups,
+		"duration":    duration,
+		"wakeups":     c.Wakeups,
 	}).Info("CANONICAL-PROXY-CN-CLOSE")
 	return c.Conn.Close()
 }
@@ -104,26 +104,26 @@ func (c *ConnExt) Write(b []byte) (n int, err error) {
 
 func (c *ConnExt) JsonStats() ([]byte, error) {
 	type stats = struct {
-		Id string `json:"id"`
-		Role string `json:"role"`
-		Rhost string `json:"rhost"`
-		Created time.Time `json:"created"`
-		BytesIn int `json:"bytesIn"`
-		BytesOut int `json:"bytesOut"`
-		Wakeups int `json:"wakeups"`
-		SecondsSinceLastActivity float64 `json:"secondsSinceLastActivity"`
+		Id                       string    `json:"id"`
+		Role                     string    `json:"role"`
+		Rhost                    string    `json:"rhost"`
+		Created                  time.Time `json:"created"`
+		BytesIn                  int       `json:"bytesIn"`
+		BytesOut                 int       `json:"bytesOut"`
+		Wakeups                  int       `json:"wakeups"`
+		SecondsSinceLastActivity float64   `json:"secondsSinceLastActivity"`
 	}
 
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	s := stats{
-		Id: fmt.Sprintf("%d", &c),
-		Role: c.Role,
-		Rhost: c.OutboundHost,
-		Created: c.StartTime,
-		BytesIn: c.BytesIn,
-		BytesOut: c.BytesOut,
-		Wakeups: c.Wakeups,
+		Id:                       fmt.Sprintf("%d", &c),
+		Role:                     c.Role,
+		Rhost:                    c.OutboundHost,
+		Created:                  c.StartTime,
+		BytesIn:                  c.BytesIn,
+		BytesOut:                 c.BytesOut,
+		Wakeups:                  c.Wakeups,
 		SecondsSinceLastActivity: time.Now().Sub(c.LastActivity).Seconds(),
 	}
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -410,7 +410,6 @@ func runServer(config *Config, server *http.Server, listener net.Listener, quit 
 	// can do is close the listening socket when we receive a signal, not accept
 	// new connections, and then exit the program after a timeout.
 
-	
 	if len(config.StatsSocketDir) > 0 {
 		config.StatsServer = StartStatsServer(config)
 	}
@@ -440,7 +439,7 @@ func runServer(config *Config, server *http.Server, listener net.Listener, quit 
 		config.Log.WithField("delay", config.ExitTimeout).Info("Waiting before shutting down")
 		time.Sleep(config.ExitTimeout)
 	}
-	
+
 	if config.StatsServer != nil {
 		config.StatsServer.(*StatsServer).Shutdown()
 	}

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -410,6 +410,11 @@ func runServer(config *Config, server *http.Server, listener net.Listener, quit 
 	// can do is close the listening socket when we receive a signal, not accept
 	// new connections, and then exit the program after a timeout.
 
+	
+	if len(config.StatsSocketDir) > 0 {
+		config.StatsServer = StartStatsServer(config)
+	}
+
 	semiGraceful := true
 	kill := make(chan os.Signal, 1)
 	signal.Notify(kill, syscall.SIGUSR2, syscall.SIGTERM, syscall.SIGHUP)
@@ -434,6 +439,10 @@ func runServer(config *Config, server *http.Server, listener net.Listener, quit 
 		// semi-gracefully
 		config.Log.WithField("delay", config.ExitTimeout).Info("Waiting before shutting down")
 		time.Sleep(config.ExitTimeout)
+	}
+	
+	if config.StatsServer != nil {
+		config.StatsServer.(*StatsServer).Shutdown()
 	}
 }
 

--- a/pkg/smokescreen/stats_server.go
+++ b/pkg/smokescreen/stats_server.go
@@ -1,0 +1,84 @@
+package smokescreen
+
+import (
+	"fmt"
+	"net/http"
+	"net"
+	"os"
+)
+
+
+type StatsServer struct {
+	config *Config
+	ln net.Listener
+	mux *http.ServeMux
+	socketPath string
+}
+
+func newServer(config *Config) (s *StatsServer) {
+	s = &StatsServer{
+		config: config,
+		mux: http.NewServeMux(),
+	}
+
+	s.mux.HandleFunc("/", s.stats)
+	return
+}
+
+func (s *StatsServer) Serve() {
+	pid := os.Getpid()
+	s.socketPath = fmt.Sprintf("%s/track-%d.sock", s.config.StatsSocketDir, pid)
+	ln, err := net.Listen("unix", s.socketPath)
+
+	if err != nil {
+		s.config.Log.Fatal("Could not start the reporting server.")
+	}
+
+	s.ln = ln
+	http.Serve(s.ln, s.mux)
+}
+
+func (s *StatsServer) Shutdown() {
+	os.Remove(s.socketPath)
+}
+
+func (s *StatsServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	s.mux.ServeHTTP(w, req)
+}
+
+func (s *StatsServer) stats(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	rw.Write([]byte{
+		byte('['),
+		byte('\n'),
+	})
+
+	firstRun := true
+	
+	s.config.ConnTracker.Range(func(k, v interface{}) bool {
+		if !firstRun {
+			rw.Write([]byte{byte(','), byte('\n')})
+		}
+		firstRun = false
+		instrumentedConn := k.(*ConnExt)
+		repr, err := instrumentedConn.JsonStats()
+		
+		if err != nil {
+			s.config.Log.Error(err)
+		}
+		
+		rw.Write(repr)
+		return true
+	})
+	
+	rw.Write([]byte{
+		byte(']'),
+		byte('\n'),
+	})
+}
+
+func StartStatsServer(config *Config) *StatsServer {
+	server := newServer(config)
+	go server.Serve()
+	return server
+}

--- a/pkg/smokescreen/stats_server.go
+++ b/pkg/smokescreen/stats_server.go
@@ -39,6 +39,7 @@ func (s *StatsServer) Serve() {
 }
 
 func (s *StatsServer) Shutdown() {
+	s.ln.Close()
 	os.Remove(s.socketPath)
 }
 

--- a/pkg/smokescreen/stats_server.go
+++ b/pkg/smokescreen/stats_server.go
@@ -30,7 +30,7 @@ func (s *StatsServer) Serve() {
 	ln, err := net.Listen("unix", s.socketPath)
 
 	if err != nil {
-		s.config.Log.Fatal("Could not start the reporting server.")
+		s.config.Log.Fatal("Could not start the reporting server.", err)
 	}
 	os.Chmod(s.socketPath, s.config.StatsSocketFileMode)
 


### PR DESCRIPTION
Smokescreen will open an UDS which will allow other processes (by default, from the same user or group) to know about the state of established connections.

Sample output:
```
➜  smokescreen git:(tremblay/conn-tracking) ✗ curl -vvvv --unix-socket ./track/track-19049.sock -s http://stats/ | jq .
*   Trying ./track/track-19049.sock...
* Connected to stats (track/track-19049.sock) port 80 (#0)
> GET / HTTP/1.1
> Host: stats
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Thu, 28 Mar 2019 22:46:51 GMT
< Content-Length: 190
< 
{ [190 bytes data]
* Connection #0 to host stats left intact
[
  {
    "id": "824634441944",
    "role": "",
    "rhost": "google.com:443",
    "created": "2019-03-28T15:46:31.307748-07:00",
    "bytesIn": 196608,
    "bytesOut": 520,
    "wakeups": 10,
    "secondsSinceLastActivity": 20.112740421
  }
]
```