### PR TITLE
Wait until all connections are idle before exiting

### DIFF
--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -106,7 +106,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 		},
 		cli.StringFlag{
 			Name:  "stats-socket-dir",
-			Usage: "Enable connection tracking. Will expose one UDS in the directory mentioned going by the name of `track-{pid}.sock`.",
+			Usage: "Enable connection tracking. Will expose one UDS in `DIR` going by the name of \"track-{pid}.sock\".\n\t\tThis should be an absolute path with all symlinks, if any, resolved.",
 		},
 		cli.StringFlag{
 			Name:  "stats-socket-file-mode",

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	StatsServer                  interface{} // StatsServer
 	ConnTracker                  *sync.Map   // The zero Map is empty and ready to use
 	IdleThresholdSec             time.Duration // Consider a connection idle if it has been inactive (no bytes transferred) for this many seconds.
-	WgCxns                       sync.WaitGroup // This wait group tracks *open* (active & idle) connections for graceful shutdown.
+	WgCxns                       *sync.WaitGroup // This wait group tracks *open* (active & idle) connections for graceful shutdown.
 }
 
 type missingRoleError struct {
@@ -99,7 +99,7 @@ func NewConfig() *Config {
 		ExitTimeout:             500 * time.Minute,
 		StatsSocketFileMode:     os.FileMode(0700),
 		IdleThresholdSec:        10 * time.Second,
-		WgCxns:                  sync.WaitGroup{},
+               WgCxns:                  &sync.WaitGroup{},
 	}
 }
 

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	StatsServer                  interface{} // StatsServer
 	ConnTracker                  *sync.Map   // The zero Map is empty and ready to use
 	IdleThresholdSec             time.Duration // Consider a connection idle if it has been inactive (no bytes transferred) for this many seconds.
-	WgCxns						 sync.WaitGroup
+	WgCxns                       sync.WaitGroup // This wait group tracks *open* (active & idle) connections for graceful shutdown.
 }
 
 type missingRoleError struct {
@@ -99,7 +99,7 @@ func NewConfig() *Config {
 		ExitTimeout:             500 * time.Minute,
 		StatsSocketFileMode:     os.FileMode(0700),
 		IdleThresholdSec:        10 * time.Second,
-		WgCxns:					 sync.WaitGroup{},
+		WgCxns:                  sync.WaitGroup{},
 	}
 }
 

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -43,8 +43,8 @@ type Config struct {
 	StatsSocketFileMode          os.FileMode
 	StatsServer                  interface{} // StatsServer
 	ConnTracker                  *sync.Map   // The zero Map is empty and ready to use
-	IdleThresholdSec			 time.Duration // Consider a connection idle if it has been inactive (no bytes transferred) for this many seconds.
-	WaitForAllIdleSec			 time.Duration // Wait this many seconds before checking (again) to ensure all connections are idle before exiting.
+	IdleThresholdSec             time.Duration // Consider a connection idle if it has been inactive (no bytes transferred) for this many seconds.
+	WaitForAllIdleSec            time.Duration // Wait this many seconds before checking (again) to ensure all connections are idle before exiting.
 }
 
 type missingRoleError struct {
@@ -98,7 +98,7 @@ func NewConfig() *Config {
 		Port:                    4750,
 		ExitTimeout:             500 * time.Minute,
 		StatsSocketFileMode:     os.FileMode(0700),
-		IdleThresholdSec:		 30 * time.Second,
+		IdleThresholdSec:        30 * time.Second,
 		WaitForAllIdleSec:       5 * time.Second,
 	}
 }

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	StatsServer                  interface{} // StatsServer
 	ConnTracker                  *sync.Map   // The zero Map is empty and ready to use
 	IdleThresholdSec             time.Duration // Consider a connection idle if it has been inactive (no bytes transferred) for this many seconds.
-	WaitForAllIdleSec            time.Duration // Wait this many seconds before checking (again) to ensure all connections are idle before exiting.
+	WgCxns						 sync.WaitGroup
 }
 
 type missingRoleError struct {
@@ -98,8 +98,8 @@ func NewConfig() *Config {
 		Port:                    4750,
 		ExitTimeout:             500 * time.Minute,
 		StatsSocketFileMode:     os.FileMode(0700),
-		IdleThresholdSec:        30 * time.Second,
-		WaitForAllIdleSec:       5 * time.Second,
+		IdleThresholdSec:        10 * time.Second,
+		WgCxns:					 sync.WaitGroup{},
 	}
 }
 

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -43,6 +43,8 @@ type Config struct {
 	StatsSocketFileMode          os.FileMode
 	StatsServer                  interface{} // StatsServer
 	ConnTracker                  *sync.Map   // The zero Map is empty and ready to use
+	IdleThresholdSec			 time.Duration // Consider a connection idle if it has been inactive (no bytes transferred) for this many seconds.
+	WaitForAllIdleSec			 time.Duration // Wait this many seconds before checking (again) to ensure all connections are idle before exiting.
 }
 
 type missingRoleError struct {
@@ -94,8 +96,10 @@ func NewConfig() *Config {
 		ConnTracker:             new(sync.Map),
 		Log:                     log.New(),
 		Port:                    4750,
-		ExitTimeout:             60 * time.Second,
+		ExitTimeout:             500 * time.Minute,
 		StatsSocketFileMode:     os.FileMode(0700),
+		IdleThresholdSec:		 30 * time.Second,
+		WaitForAllIdleSec:       5 * time.Second,
 	}
 }
 

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -99,7 +99,7 @@ func NewConfig() *Config {
 		ExitTimeout:             500 * time.Minute,
 		StatsSocketFileMode:     os.FileMode(0700),
 		IdleThresholdSec:        10 * time.Second,
-               WgCxns:                  &sync.WaitGroup{},
+		WgCxns:                  &sync.WaitGroup{},
 	}
 }
 

--- a/pkg/smokescreen/instrumented_conn.go
+++ b/pkg/smokescreen/instrumented_conn.go
@@ -23,7 +23,7 @@ type ConnExt struct {
 
 	mutex sync.Mutex
 
-	isClosed	 bool
+	isClosed     bool
 	errorOnClose error
 }
 

--- a/pkg/smokescreen/instrumented_conn.go
+++ b/pkg/smokescreen/instrumented_conn.go
@@ -46,6 +46,8 @@ func NewConnExt(
 		config.ConnTracker.Store(ret, nil)
 	}
 
+	config.WgCxns.Add(1)
+
 	return
 }
 
@@ -79,6 +81,9 @@ func (c *ConnExt) Close() error {
 		"duration":    duration,
 		"wakeups":     c.Wakeups,
 	}).Info("CANONICAL-PROXY-CN-CLOSE")
+	
+	c.Config.WgCxns.Done()
+	
 	return c.Conn.Close()
 }
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -434,7 +434,7 @@ func runServer(config *Config, server *http.Server, listener net.Listener, quit 
 	}
 
 	if graceful {
-		// The program has exited normally, so wait for all connections to close or become idle before
+		// Wait for all connections to close or become idle before
 		// continuing in an attempt to shutdown gracefully.
 		exit := make(chan bool, 1)
 
@@ -474,7 +474,7 @@ func runServer(config *Config, server *http.Server, listener net.Listener, quit 
 		<- exit
 	}
 
-	// Close all open (and idle) connections to send their metrics to Splunk.
+	// Close all open (and idle) connections to send their metrics to log.
 	config.ConnTracker.Range(func(k, v interface{}) bool {
 		k.(*ConnExt).Close()
 		return true

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -437,16 +437,15 @@ func runServer(config *Config, server *http.Server, listener net.Listener, quit 
 		// the program has exited normally, wait for all connections to become idle before
 		// continuing in an attempt to shutdown gracefully
 		beginTs := time.Now()
-		alerted := false
 		for {
 			if config.StatsServer.(*StatsServer).GetNumActiveConn() > 0 {
-				config.Log.Info(fmt.Sprintf("There are still active connections. Waiting %v before checking again.", config.WaitForAllIdleSec))
-				if time.Now().Sub(beginTs) > config.ExitTimeout && !alerted {
-					config.Log.Info(fmt.Sprintf("We've been waiting for %v to shut down but there are still active connections.", config.ExitTimeout))
-					// Do alerting here
-					alerted = true
+				if time.Now().Sub(beginTs) > config.ExitTimeout {
+					config.Log.Info(fmt.Sprintf("Timed out at %v while waiting for all active connections to become idle.", config.ExitTimeout))
+					break
+				} else {
+					config.Log.Info(fmt.Sprintf("There are still active connections. Waiting %v before checking again.", config.WaitForAllIdleSec))
+					time.Sleep(config.WaitForAllIdleSec)
 				}
-				time.Sleep(config.WaitForAllIdleSec)
 			} else {
 				config.Log.Info("All connections are idle. Continuing with shutdown...")
 				break

--- a/pkg/smokescreen/stats_server.go
+++ b/pkg/smokescreen/stats_server.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"time"
 )
 
 type StatsServer struct {
@@ -45,6 +46,18 @@ func (s *StatsServer) Shutdown() {
 
 func (s *StatsServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	s.mux.ServeHTTP(w, req)
+}
+
+func (s *StatsServer) GetNumActiveConn() int {
+	n := 0
+	s.config.ConnTracker.Range(func(k, v interface{}) bool {
+		c := k.(*ConnExt)
+		if time.Now().Sub(c.LastActivity) < s.config.IdleThresholdSec {
+			n++
+		}
+		return true
+	})
+	return n
 }
 
 func (s *StatsServer) stats(rw http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
So I tested this on my laptop by running:
`go run main.go --stats-socket-dir=track`
and then kicked two "long" curl commands a few seconds apart:
`curl --limit-rate 160000 -vvvvx http://localhost:4750 https://raw.githubusercontent.com/dwyl/english-words/master/words.txt`
I then sent a SIGTERM to the process using `kill -15`

I think this should work with deploys if we restart smokescreen-srv with `--stats-socket-dir` and pass in the path to the current deploy _with the symlinks resolved_. Then each deploy will have it's own "track" directory. In the case where the process panics and is restarted by einhorn, each process still has its own UDS file and knows which one to communicate with.

For AWS instance lifecycle restarts, I will just make the terminator script send it a SIGTERM and wait until the process gracefully shuts down.

Still have to add alerting, and test actual deploys but can you guys take a look and see if this on the right track? r? @tremblay-stripe @rlk-stripe 