### PR TITLE
Add {allow,deny}-address options

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -330,15 +330,25 @@ func TestSmokescreenIntegration(t *testing.T) {
 		unknownRoleAllowCase := noRoleAllowCase
 		unknownRoleAllowCase.RoleName = "unknown"
 
-		badIPCase := baseCase
-		badIPCase.Host = "127.0.0.2"
-		badIPCase.ExpectAllow = false
-		badIPCase.RoleName = generateRoleForAction(smokescreen.ConfigEnforcementPolicyOpen)
+		badIPRangeCase := baseCase
+		// This must be a global unicast, non-loopback address or other IP rules will
+		// block it regardless of the specific configuration we're trying to test.
+		badIPRangeCase.Host = "1.1.1.1"
+		badIPRangeCase.ExpectAllow = false
+		badIPRangeCase.RoleName = generateRoleForAction(smokescreen.ConfigEnforcementPolicyOpen)
+
+		badIPAddressCase := baseCase
+		// This must be a global unicast, non-loopback address or other IP rules will
+		// block it regardless of the specific configuration we're trying to test.
+		badIPAddressCase.Host = "1.0.0.1"
+		badIPAddressCase.TargetPort = 123
+		badIPAddressCase.ExpectAllow = false
+		badIPAddressCase.RoleName = generateRoleForAction(smokescreen.ConfigEnforcementPolicyOpen)
 
 		testCases = append(testCases,
 			&unknownRoleAllowCase, &unknownRoleDenyCase,
 			&noRoleAllowCase, &noRoleDenyCase,
-			&badIPCase,
+			&badIPRangeCase, &badIPAddressCase,
 		)
 	}
 
@@ -356,8 +366,9 @@ func startSmokescreen(t *testing.T, useTls bool, logHook logrus.Hook) (*httptest
 		"--listen-ip=127.0.0.1",
 		"--egress-acl-file=testdata/sample_config.yaml",
 		"--additional-error-message-on-deny=moar ctx",
-		"--deny-range=127.0.0.2/32",
+		"--deny-range=1.1.1.1/32",
 		"--allow-range=127.0.0.1/32",
+		"--deny-address=1.0.0.1:123",
 	}
 
 	if useTls {

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -75,6 +75,14 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			Name:  "allow-range",
 			Usage: "Add `RANGE` (in CIDR notation) to list of allowed IP ranges.  Repeatable.",
 		},
+		cli.StringSliceFlag{
+			Name:  "deny-address",
+			Usage: "Add IP[:PORT] to list of blocked IPs.  Repeatable.",
+		},
+		cli.StringSliceFlag{
+			Name:  "allow-address",
+			Usage: "Add IP[:PORT] to list of allowed IPs.  Repeatable.",
+		},
 		cli.StringFlag{
 			Name:  "egress-acl-file",
 			Usage: "Validate egress traffic against `FILE`",
@@ -191,6 +199,18 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 
 		if c.IsSet("allow-range") {
 			if err := conf.SetAllowRanges(c.StringSlice("allow-range")); err != nil {
+				return err
+			}
+		}
+
+		if c.IsSet("deny-address") {
+			if err := conf.SetDenyAddresses(c.StringSlice("deny-address")); err != nil {
+				return err
+			}
+		}
+
+		if c.IsSet("allow-address") {
+			if err := conf.SetAllowAddresses(c.StringSlice("allow-address")); err != nil {
 				return err
 			}
 		}

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -20,11 +21,16 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type RuleRange struct {
+	Net  net.IPNet
+	Port int
+}
+
 type Config struct {
 	Ip                           string
 	Port                         uint16
-	DenyRanges                   []net.IPNet
-	AllowRanges                  []net.IPNet
+	DenyRanges                   []RuleRange
+	AllowRanges                  []RuleRange
 	ConnectTimeout               time.Duration
 	ExitTimeout                  time.Duration
 	MaintenanceFile              string
@@ -58,28 +64,94 @@ func IsMissingRoleError(err error) bool {
 	return ok
 }
 
-func parseRanges(rangeStrings []string) ([]net.IPNet, error) {
-	outRanges := make([]net.IPNet, len(rangeStrings))
+func parseRanges(rangeStrings []string) ([]RuleRange, error) {
+	outRanges := make([]RuleRange, len(rangeStrings))
 	for i, str := range rangeStrings {
 		_, ipnet, err := net.ParseCIDR(str)
 		if err != nil {
 			return outRanges, err
 		}
-		outRanges[i] = *ipnet
+		outRanges[i].Net = *ipnet
+	}
+	return outRanges, nil
+}
+
+func parseAddresses(addressStrings []string) ([]RuleRange, error) {
+	outRanges := make([]RuleRange, len(addressStrings))
+	for i, str := range addressStrings {
+		ip := net.ParseIP(str)
+		if ip == nil {
+			ipStr, portStr, err := net.SplitHostPort(str)
+			if err != nil {
+				return outRanges, fmt.Errorf("address must be in the form ip[:port], got %s", str)
+			}
+
+			ip = net.ParseIP(ipStr)
+			if ip == nil {
+				return outRanges, fmt.Errorf("invalid IP address '%s'", ipStr)
+			}
+
+			port, err := strconv.Atoi(portStr)
+			if err != nil {
+				return outRanges, fmt.Errorf("invalid port number '%s'", portStr)
+			}
+
+			outRanges[i].Port = port
+		}
+
+		var mask net.IPMask
+		if ip.To4() != nil {
+			mask = net.CIDRMask(32, 32)
+		} else {
+			mask = net.CIDRMask(128, 128)
+		}
+
+		outRanges[i].Net = net.IPNet{
+			IP:   ip,
+			Mask: mask,
+		}
 	}
 	return outRanges, nil
 }
 
 func (config *Config) SetDenyRanges(rangeStrings []string) error {
 	var err error
-	config.DenyRanges, err = parseRanges(rangeStrings)
-	return err
+	ranges, err := parseRanges(rangeStrings)
+	if err != nil {
+		return err
+	}
+	config.DenyRanges = append(config.DenyRanges, ranges...)
+	return nil
 }
 
 func (config *Config) SetAllowRanges(rangeStrings []string) error {
 	var err error
-	config.AllowRanges, err = parseRanges(rangeStrings)
-	return err
+	ranges, err := parseRanges(rangeStrings)
+	if err != nil {
+		return err
+	}
+	config.AllowRanges = append(config.AllowRanges, ranges...)
+	return nil
+}
+
+func (config *Config) SetDenyAddresses(addressStrings []string) error {
+	var err error
+	ranges, err := parseAddresses(addressStrings)
+	if err != nil {
+		return err
+	}
+	config.DenyRanges = append(config.DenyRanges, ranges...)
+	return nil
+}
+
+func (config *Config) SetAllowAddresses(addressStrings []string) error {
+	var err error
+	ranges, err := parseAddresses(addressStrings)
+	if err != nil {
+		return err
+	}
+	config.AllowRanges = append(config.AllowRanges, ranges...)
+	return nil
 }
 
 // RFC 5280,  4.2.1.1

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -20,7 +20,7 @@ var privateNetworkStrings = [...]string{
 	"fc00::/7",
 }
 
-var PrivateNetworkRanges []net.IPNet
+var PrivateRuleRanges []RuleRange
 
 // Using a globally-shared Regexp can impact performace due to lock contention,
 // but calling Copy() for each connection is much worse, and it looks like
@@ -31,13 +31,13 @@ const hostExtractPattern = "^([^:]*)(:\\d+)?$"
 var hostExtractRE *regexp.Regexp
 
 func init() {
-	PrivateNetworkRanges = make([]net.IPNet, len(privateNetworkStrings))
+	PrivateRuleRanges = make([]RuleRange, len(privateNetworkStrings))
 	for i, s := range privateNetworkStrings {
 		_, rng, err := net.ParseCIDR(s)
 		if err != nil {
 			panic("Couldn't parse internal private network string")
 		}
-		PrivateNetworkRanges[i] = *rng
+		PrivateRuleRanges[i].Net = *rng
 	}
 
 	hostExtractRE = regexp.MustCompile(hostExtractPattern)

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -68,8 +68,11 @@ func TestClassifyIP(t *testing.T) {
 			t.Errorf("Could not parse IP from string: %s", test.ip)
 			continue
 		}
+		localAddr := net.TCPAddr{
+			IP: localIP,
+		}
 
-		got := classifyIP(conf, localIP)
+		got := classifyAddr(conf, &localAddr)
 		if got != test.expected {
 			t.Errorf("Misclassified IP (%s): should be %s, but is instead %s.", localIP, test.expected, got)
 		}

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -21,45 +21,61 @@ var allowRanges = []string{
 	"192.168.1.0/24",
 	"127.0.1.0/24",
 }
+var allowAddresses = []string{
+	"10.0.0.1:321",
+}
+var denyRanges = []string{
+	"1.1.1.1/32",
+}
+var denyAddresses = []string{
+	"8.8.8.8:321",
+}
 
 type testCase struct {
 	ip       string
+	port     int
 	expected ipType
 }
 
-func TestClassifyIP(t *testing.T) {
+func TestClassifyAddr(t *testing.T) {
 	a := assert.New(t)
 
 	conf := NewConfig()
+	a.NoError(conf.SetDenyRanges(denyRanges))
+	a.NoError(conf.SetDenyAddresses(denyAddresses))
 	a.NoError(conf.SetAllowRanges(allowRanges))
+	a.NoError(conf.SetAllowAddresses(allowAddresses))
 	conf.ConnectTimeout = 10 * time.Second
 	conf.ExitTimeout = 10 * time.Second
 	conf.AdditionalErrorMessageOnDeny = "Proxy denied"
 
 	testIPs := []testCase{
-		testCase{"8.8.8.8", ipAllowDefault},
-		testCase{"8.8.9.8", ipAllowUserConfigured},
+		testCase{"8.8.8.8", 1, ipAllowDefault},
+		testCase{"8.8.9.8", 1, ipAllowUserConfigured},
 
 		// Specific blocked networks
-		testCase{"10.0.0.1", ipDenyPrivateRange},
-		testCase{"10.0.1.1", ipAllowUserConfigured},
-		testCase{"172.16.0.1", ipDenyPrivateRange},
-		testCase{"172.16.1.1", ipAllowUserConfigured},
-		testCase{"192.168.0.1", ipDenyPrivateRange},
-		testCase{"192.168.1.1", ipAllowUserConfigured},
+		testCase{"10.0.0.1", 1, ipDenyPrivateRange},
+		testCase{"10.0.0.1", 321, ipAllowUserConfigured},
+		testCase{"10.0.1.1", 1, ipAllowUserConfigured},
+		testCase{"172.16.0.1", 1, ipDenyPrivateRange},
+		testCase{"172.16.1.1", 1, ipAllowUserConfigured},
+		testCase{"192.168.0.1", 1, ipDenyPrivateRange},
+		testCase{"192.168.1.1", 1, ipAllowUserConfigured},
+		testCase{"8.8.8.8", 321, ipDenyUserConfigured},
+		testCase{"1.1.1.1", 1, ipDenyUserConfigured},
 
 		// localhost
-		testCase{"127.0.0.1", ipDenyNotGlobalUnicast},
-		testCase{"127.255.255.255", ipDenyNotGlobalUnicast},
-		testCase{"::1", ipDenyNotGlobalUnicast},
-		testCase{"127.0.1.1", ipAllowUserConfigured},
+		testCase{"127.0.0.1", 1, ipDenyNotGlobalUnicast},
+		testCase{"127.255.255.255", 1, ipDenyNotGlobalUnicast},
+		testCase{"::1", 1, ipDenyNotGlobalUnicast},
+		testCase{"127.0.1.1", 1, ipAllowUserConfigured},
 
 		// ec2 metadata endpoint
-		testCase{"169.254.169.254", ipDenyNotGlobalUnicast},
+		testCase{"169.254.169.254", 1, ipDenyNotGlobalUnicast},
 
 		// Broadcast addresses
-		testCase{"255.255.255.255", ipDenyNotGlobalUnicast},
-		testCase{"ff02:0:0:0:0:0:0:2", ipDenyNotGlobalUnicast},
+		testCase{"255.255.255.255", 1, ipDenyNotGlobalUnicast},
+		testCase{"ff02:0:0:0:0:0:0:2", 1, ipDenyNotGlobalUnicast},
 	}
 
 	for _, test := range testIPs {
@@ -69,7 +85,8 @@ func TestClassifyIP(t *testing.T) {
 			continue
 		}
 		localAddr := net.TCPAddr{
-			IP: localIP,
+			IP:   localIP,
+			Port: test.port,
 		}
 
 		got := classifyAddr(conf, &localAddr)


### PR DESCRIPTION
This adds `--allow-address` and `--deny-address` options that operate similarly to the range options but allow for specifying a particular port to allow/block. My immediate use for this is allowing the proxy to chain to another proxy running on localhost while preventing it from accessing other services on localhost.