### PR TITLE
Bump goproxy to fix handling of https_proxy env var

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,7 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:c4d81b1b708de2c0216d765bd30d9cf339f75ecd7d4311ab9fde2da6ca9e7a8f"
+  digest = "1:22905bc7d63f5bed88597b4fe4ea97d410cfcd053aac4a534840756330c64b7b"
   name = "github.com/elazarl/goproxy"
   packages = [
     ".",
@@ -34,7 +34,7 @@
     "transport/details",
   ]
   pruneopts = ""
-  revision = "806bae1a599998b57e7ba45b89de7750b320df90"
+  revision = "9a6e5f1617e55b9bf9e2417ed8d031af98d99132"
   source = "git@github.com:stripe/goproxy.git"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,7 +17,7 @@
   # to avoid introducing a timeout bug that was introduced after that commit.
   # We've subsequently switched to our own fork of goproxy, and the master branch
   # of our fork has reverted that bug.
-  revision = "806bae1a599998b57e7ba45b89de7750b320df90"
+  revision = "9a6e5f1617e55b9bf9e2417ed8d031af98d99132"
 
 [[constraint]]
   branch = "master"

--- a/vendor/github.com/elazarl/goproxy/https.go
+++ b/vendor/github.com/elazarl/goproxy/https.go
@@ -49,7 +49,13 @@ func httpsProxyFromEnv(reqURL *url.URL) (string, error) {
 	// return anything from HTTPProxy
 	cfg.HTTPProxy = ""
 
-	proxyURL, err := cfg.ProxyFunc()(reqURL)
+	// The request URL provided to the proxy for a CONNECT request does
+	// not necessarily have an https scheme but ProxyFunc uses the scheme
+	// to determine which env var to introspect.
+	reqSchemeURL := reqURL
+	reqSchemeURL.Scheme = "https"
+
+	proxyURL, err := cfg.ProxyFunc()(reqSchemeURL)
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/elazarl/goproxy/https_test.go
+++ b/vendor/github.com/elazarl/goproxy/https_test.go
@@ -12,15 +12,14 @@ var proxytests = map[string]struct {
 	url         string
 	expectProxy string
 }{
-	"never proxy http": {"", "daproxy", "http://foo.bar/baz", ""},
-
-	"do not proxy https without a proxy configured":   {"", "", "https://foo.bar/baz", ""},
-	"proxy https with a proxy configured":             {"", "daproxy", "https://foo.bar/baz", "daproxy:http"},
-	"proxy https with a proxy configured with a port": {"", "http://daproxy:123", "https://foo.bar/baz", "daproxy:123"},
-	"proxy https with an https proxy configured":      {"", "https://daproxy", "https://foo.bar/baz", "daproxy:https"},
-	"proxy https with a non-matching no_proxy":        {"other.bar", "daproxy", "https://foo.bar/baz", "daproxy:http"},
-	"do not proxy https with a full no_proxy match":   {"foo.bar", "daproxy", "https://foo.bar/baz", ""},
-	"do not proxy https with a suffix no_proxy match": {".bar", "daproxy", "https://foo.bar/baz", ""},
+	"do not proxy without a proxy configured":   {"", "", "https://foo.bar/baz", ""},
+	"proxy with a proxy configured":             {"", "daproxy", "https://foo.bar/baz", "daproxy:http"},
+	"proxy without a scheme":                    {"", "daproxy", "//foo.bar/baz", "daproxy:http"},
+	"proxy with a proxy configured with a port": {"", "http://daproxy:123", "https://foo.bar/baz", "daproxy:123"},
+	"proxy with an https proxy configured":      {"", "https://daproxy", "https://foo.bar/baz", "daproxy:https"},
+	"proxy with a non-matching no_proxy":        {"other.bar", "daproxy", "https://foo.bar/baz", "daproxy:http"},
+	"do not proxy with a full no_proxy match":   {"foo.bar", "daproxy", "https://foo.bar/baz", ""},
+	"do not proxy with a suffix no_proxy match": {".bar", "daproxy", "https://foo.bar/baz", ""},
 }
 
 var envKeys = []string{"no_proxy", "http_proxy", "https_proxy", "NO_PROXY", "HTTP_PROXY", "HTTPS_PROXY"}


### PR DESCRIPTION
Like it says on the tin. Picks up https://github.com/stripe/goproxy/pull/6

r? @rlk-stripe 