### PR TITLE
Fix Read/Write after Close on ConnExt

### DIFF
--- a/pkg/smokescreen/instrumented_conn.go
+++ b/pkg/smokescreen/instrumented_conn.go
@@ -60,6 +60,7 @@ func (c *ConnExt) Close() error {
 	if c.isClosed {
 		return c.errorOnClose
 	}
+
 	c.isClosed = true
 
 	if c.Config.StatsServer != nil {
@@ -106,11 +107,8 @@ func (c *ConnExt) Read(b []byte) (n int, err error) {
 	c.mutex.Unlock()
 
 	n, err = c.Conn.Read(b)
-	if c.isClosed {
-		return 1, nil
-	} else {
-		return n, err
-	}
+
+	return n, err
 }
 
 func (c *ConnExt) Write(b []byte) (n int, err error) {
@@ -121,11 +119,8 @@ func (c *ConnExt) Write(b []byte) (n int, err error) {
 	c.mutex.Unlock()
 
 	n, err = c.Conn.Write(b)
-	if c.isClosed {
-		return 1, nil
-	} else {
-		return n, err
-	}
+
+	return n, err
 }
 
 func (c *ConnExt) JsonStats() ([]byte, error) {


### PR DESCRIPTION
This PR fixes `ConnExt` to behave properly on a `Read`/`Write` after close.

`goproxy` instantiates a `ConnExt` and  then passes it as a `Reader`, along with the downstream connection to `io.Copy` (https://github.com/stripe/goproxy/blob/master/proxy.go#L32). `io.Copy` reads until an error on the stream, `io.EOF` or the number of bytes returned is `0`.  https://sourcegraph.com/github.com/golang/go/-/blob/src/io/io.go#L403-416

`io.Copy` never checks whether `Close` has been called on the connection, and will continue writing forever, hitting the `c.isClosed` case. This behavior results in `Goproxy` holding connections open forever and writing an infinite stream of null bytes to clients on the TLS connection (one record at a time). This can be extremely expensive to buffer on the client side and result in memory pressure.

This PR changes the semantics of `Read` & `Write` to always return the `Read` and `Write` methods of the underlying `net.Conn` stream, which I assume to be correct, even after the `net.Conn` is closed.

r? @mdoan-stripe 