### PR TITLE
add project and domain tags for decision metrics

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -560,6 +560,7 @@ func checkIfRequestShouldBeProxied(config *Config, req *http.Request, outboundHo
 	tags := []string{
 		fmt.Sprintf("role:%s", decision.role),
 		fmt.Sprintf("def_rule:%t", defaultRuleUsed),
+		fmt.Sprintf("project:%s", decision.project),
 	}
 
 	switch action {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -561,6 +561,7 @@ func checkIfRequestShouldBeProxied(config *Config, req *http.Request, outboundHo
 		fmt.Sprintf("role:%s", decision.role),
 		fmt.Sprintf("def_rule:%t", defaultRuleUsed),
 		fmt.Sprintf("project:%s", decision.project),
+		fmt.Sprintf("dest_domain:%s", destination),
 	}
 
 	switch action {


### PR DESCRIPTION
Additional tagging for StatsD metrics

Useful for alerting on specific projects and diagnosing erroneous blocks based on domain