### PR TITLE
modified global list behavior slightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,15 @@ A host can be specified with or without a globbing prefix
 
 #### Global Allow/Deny Lists
 Optionally, you may specify a global allow list and a global deny list in your ACL config.
-This overrides the settings for any individual ACL entry, including the action.
-For example, specifying `example.com` in your global_allow_list will allow traffic for that domain on a host, even if that host is set to `enforce` and does not specify `example.com` in its allowed domains.
-Similarly, specifying `malicious.com` in your global_deny_list will deny traffic for that domain on a host, even if that host is set to `report` or `open`, regardless of whether or not that host specifies `malicious.com` in its allowed domains.
+
+These lists override the policy, but do not override the `allowed_domains` list for each role.
+
+For example, specifying `example.com` in your global_allow_list will allow traffic for that domain on that role, even if that role is set to `enforce` and does not specify `example.com` in its allowed domains.
+
+Similarly, specifying `malicious.com` in your global_deny_list will deny traffic for that domain on a role, even if that role is set to `report` or `open`.
+However, if the host specifies `malicious.com` in its `allowed_domains`, traffic to `malicious.com` will be allowed on that role, regardless of policy.
+
+If a domain matches both the `global_allow_list` and the `global_deny_list`, the `global_deny_list` behavior takes priority.
 
 
 [Here](https://github.com/stripe/smokescreen/blob/master/pkg/smokescreen/testdata/sample_config_with_global.yaml) is a sample ACL specifying these options.

--- a/pkg/smokescreen/acl_loader_v1.go
+++ b/pkg/smokescreen/acl_loader_v1.go
@@ -35,8 +35,8 @@ func (ew *EgressAclConfig) Decide(fromService string, toHost string) (EgressAclD
 
 	defaultRuleUsed := rule == ew.Default
 
-	// if the host matches any of the global allow list, allow
-	for _, domainGlob := range ew.GlobalAllowList {
+	// if the host matches any of the rule's allowed domains, allow
+	for _, domainGlob := range rule.DomainGlob {
 		if hostMatchesGlob(toHost, domainGlob) {
 			return EgressAclDecisionAllow, defaultRuleUsed, nil
 		}
@@ -49,8 +49,8 @@ func (ew *EgressAclConfig) Decide(fromService string, toHost string) (EgressAclD
 		}
 	}
 
-	// if the host matches any of the rule's allowed domains, allow
-	for _, domainGlob := range rule.DomainGlob {
+	// if the host matches any of the global allow list, allow
+	for _, domainGlob := range ew.GlobalAllowList {
 		if hostMatchesGlob(toHost, domainGlob) {
 			return EgressAclDecisionAllow, defaultRuleUsed, nil
 		}

--- a/pkg/smokescreen/acl_loader_v1_test.go
+++ b/pkg/smokescreen/acl_loader_v1_test.go
@@ -103,6 +103,13 @@ var testCases = map[string]struct {
 		EgressAclDecisionAllow,
 		"other",
 	},
+	"allow despite global denylist with allowed domains override": {
+		"sample_config_with_global.yaml",
+		"enforce-dummy-srv",
+		"badexample1.com",
+		EgressAclDecisionAllow,
+		"usersec",
+	},
 	"deny from global denylist report service": {
 		"sample_config_with_global.yaml",
 		"report-dummy-srv",
@@ -121,6 +128,13 @@ var testCases = map[string]struct {
 		"sample_config_with_global.yaml",
 		"open-dummy-srv",
 		"badexample2.com",
+		EgressAclDecisionDeny,
+		"automation",
+	},
+	"deny from conflicting lists open service": {
+		"sample_config_with_global.yaml",
+		"open-dummy-srv",
+		"conflictingexample.com",
 		EgressAclDecisionDeny,
 		"automation",
 	},
@@ -182,8 +196,8 @@ func TestLoadFromYaml(t *testing.T) {
 		a.Nil(err)
 		a.NotNil(acl)
 		a.Equal(4, len(acl.Services))
-		a.Equal(2, len(acl.GlobalDenyList))
-		a.Equal(3, len(acl.GlobalAllowList))
+		a.Equal(3, len(acl.GlobalDenyList))
+		a.Equal(4, len(acl.GlobalAllowList))
 	}
 
 	// Load a broken config

--- a/pkg/smokescreen/testdata/sample_config_with_global.yaml
+++ b/pkg/smokescreen/testdata/sample_config_with_global.yaml
@@ -7,6 +7,7 @@ services:
     allowed_domains:
       - example1.com
       - example2.com
+      - badexample1.com # overrides global deny list
 
   - name: report-dummy-srv
     project: security
@@ -35,7 +36,9 @@ global_allow_list:
   - goodexample1.com
   - goodexample2.com
   - goodexample3.com
+  - conflictingexample.com
 
 global_deny_list:
   - badexample1.com
   - badexample2.com
+  - conflictingexample.com


### PR DESCRIPTION
My bad. We want to preserve the ability for specific hosts to override the `global_deny_list`.

I doubt that anyone has consumed the previous behavior in the last few hours, so hopefully this change is okay.

I took this opportunity to also specify what happens in the edge case of conflicting global lists.

Of course, added tests to confirm the new expected behavior.

Sorry, 100% my fault I didn't think rigorously through the desired behavior before submitting the previous PR.

r? @rlk-stripe 