### PR TITLE
added logging info from TLS cert

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -288,6 +288,17 @@ func logProxy(
 		fields["dest_port"] = toAddress.Port
 	}
 
+	// attempt to retrieve information about the host originating the proxy request
+	fields["src_host_common_name"] = "unknown"
+	fields["src_host_organization_unit"] = "unknown"
+	if ctx.Req.TLS != nil && len(ctx.Req.TLS.PeerCertificates) > 0 {
+		fields["src_host_common_name"] = ctx.Req.TLS.PeerCertificates[0].Subject.CommonName
+		var ou_entries = ctx.Req.TLS.PeerCertificates[0].Subject.OrganizationalUnit
+		if ou_entries != nil && len(ou_entries) > 0 {
+			fields["src_host_organization_unit"] = ou_entries[0]
+		}
+	}
+
 	if decision != nil {
 		fields["role"] = decision.role
 		fields["project"] = decision.project


### PR DESCRIPTION
CName info is needed to determine the specific host in the Stripe use case.
OU info is provided to be useful in the default use case (where CName provides the role)