### PR TITLE
log error on deny when present

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -279,10 +279,6 @@ func logProxy(
 		"content_length": contentLength,
 	}
 
-	if _, ok := err.(denyError); !ok && err != nil {
-		fields["error"] = err
-	}
-
 	if toAddress != nil {
 		fields["dest_ip"] = toAddress.IP.String()
 		fields["dest_port"] = toAddress.Port
@@ -311,9 +307,13 @@ func logProxy(
 	}
 	fields["allow"] = allow
 
+	if err != nil && allow == false {
+		fields["error"] = err.Error()
+	}
+
 	entry := config.Log.WithFields(fields)
 	var logMethod func(...interface{})
-	if _, ok := fields["error"]; ok {
+	if _, ok := err.(denyError); !ok && err != nil {
 		logMethod = entry.Error
 	} else if allow {
 		logMethod = entry.Info


### PR DESCRIPTION
Currently, if a request is blocked due to ip ranges, an error is supplied but it is not logged due to `logProxy` logic. The decision reason erroneously presents the request as if it should have passed.

In the short term, any time traffic is blocked and an error is present, we can log the error to aid in diagnosis. In the long term, we may want to refactor the logic for populating `decision_reason` to become more accurate.

This PR should preserve the log level previously. Blocked traffic will warn, and the log will only be an error line if the error is an unexpected (non-`denyError`) type.