### PR TITLE
Revert "add project and domain tags for decision metrics"

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -571,8 +571,6 @@ func checkIfRequestShouldBeProxied(config *Config, req *http.Request, outboundHo
 	tags := []string{
 		fmt.Sprintf("role:%s", decision.role),
 		fmt.Sprintf("def_rule:%t", defaultRuleUsed),
-		fmt.Sprintf("project:%s", decision.project),
-		fmt.Sprintf("dest_domain:%s", destination),
 	}
 
 	switch action {


### PR DESCRIPTION
Reverts stripe/smokescreen#54.

The metric cardinality is too high for our system, so we're removing these metrics.