### PR TITLE
added project tag to metric

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -571,6 +571,7 @@ func checkIfRequestShouldBeProxied(config *Config, req *http.Request, outboundHo
 	tags := []string{
 		fmt.Sprintf("role:%s", decision.role),
 		fmt.Sprintf("def_rule:%t", defaultRuleUsed),
+		fmt.Sprintf("project:%s", decision.project),
 	}
 
 	switch action {


### PR DESCRIPTION
Adds project tag which was removed as part of https://github.com/stripe/smokescreen/pull/59

The revert was targeted at `dest_domains`, but pulled `project` with it.

`project` is useful for alerting specific project owners on blocked egress.