### PR TITLE
Fix bug in handling HTTP requests without a port in the host header

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -221,6 +221,10 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 		userData := ctxUserData{time.Now(), nil}
 		ctx.UserData = &userData
 
+		if strings.LastIndex(req.Host, ":") <= strings.LastIndex(req.Host, "]") {
+			req.Host = net.JoinHostPort(req.Host, "80")
+		}
+
 		config.Log.WithFields(
 			logrus.Fields{
 				"source_ip":      req.RemoteAddr,

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -223,12 +223,12 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 
 		config.Log.WithFields(
 			logrus.Fields{
-				"source_ip":      ctx.Req.RemoteAddr,
-				"requested_host": ctx.Req.Host,
-				"url":            ctx.Req.RequestURI,
+				"source_ip":      req.RemoteAddr,
+				"requested_host": req.Host,
+				"url":            req.RequestURI,
 			}).Debug("received HTTP proxy request")
 
-		userData.decision = checkIfRequestShouldBeProxied(config, ctx.Req, ctx.Req.Host)
+		userData.decision = checkIfRequestShouldBeProxied(config, req, req.Host)
 		req.Header.Del(roleHeader)
 		if !userData.decision.allow {
 			return req, rejectResponse(req, config, denyError{errors.New(userData.decision.reason)})

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -154,7 +154,7 @@ func dial(config *Config, network, addr string, userdata interface{}) (net.Conn,
 	if resolved == nil || addr != outboundHost || network != "tcp" {
 		var err error
 		resolved, err = safeResolve(config, network, addr)
-	if err != nil {
+		if err != nil {
 			if _, ok := err.(denyError); ok {
 				config.Log.WithFields(
 					logrus.Fields{
@@ -163,8 +163,8 @@ func dial(config *Config, network, addr string, userdata interface{}) (net.Conn,
 					}).Error("unexpected illegal address in dialer")
 			}
 
-		return nil, err
-	}
+			return nil, err
+		}
 	}
 
 	config.StatsdClient.Incr("cn.atpt.total", []string{}, 1)


### PR DESCRIPTION
In #49 we started calling `safeResolve` on `req.Host` which in turn calls `SplitHostPort`. HTTP requests do not necessarily include a port in their host header since they default to port 80. In that case, SplitHostPort would return an error because it requires the port.

The primary fix here is only a few lines and is in the last commit. I confirmed that modifying `req.Host` does not change the host header passed to the upstream service by making a manual request against httpbin. I don't *think* this matters but I could imagine a poorly written service not handling it properly.

The remaining commits are described in their commit messages.

r? @rlk-stripe 