### PR TITLE
changed service unavailable message

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -200,6 +200,7 @@ func rejectResponse(req *http.Request, config *Config, err error) *http.Response
 		goproxy.ContentTypeText,
 		http.StatusServiceUnavailable,
 		msg+"\n")
+	resp.Status = "Request Rejected by Proxy" // change the default status message
 	resp.ProtoMajor = req.ProtoMajor
 	resp.ProtoMinor = req.ProtoMinor
 	resp.Header.Set(errorHeader, msg)

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -159,7 +159,7 @@ func TestInvalidHost(t *testing.T) {
 
 			resp, err := client.Get(fmt.Sprintf("%s://neversaynever.stripe.com", testCase.scheme))
 			if testCase.expectErr {
-				r.EqualError(err, "Get https://neversaynever.stripe.com: Service Unavailable")
+				r.EqualError(err, "Get https://neversaynever.stripe.com: Request Rejected by Proxy")
 			} else {
 				r.NoError(err)
 				r.Equal(http.StatusServiceUnavailable, resp.StatusCode)


### PR DESCRIPTION
Changes the status message from the default `"Service Unavailable"` to something more specific to smokescreen functionality to help aid in diagnosing unexpected rejection issues.