### PR TITLE
changed HTTP status code to 407 when rejecting requests

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -198,7 +198,7 @@ func rejectResponse(req *http.Request, config *Config, err error) *http.Response
 
 	resp := goproxy.NewResponse(req,
 		goproxy.ContentTypeText,
-		http.StatusServiceUnavailable,
+		http.StatusProxyAuthRequired,
 		msg+"\n")
 	resp.Status = "Request Rejected by Proxy" // change the default status message
 	resp.ProtoMajor = req.ProtoMajor

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -162,7 +162,7 @@ func TestInvalidHost(t *testing.T) {
 				r.EqualError(err, "Get https://neversaynever.stripe.com: Request Rejected by Proxy")
 			} else {
 				r.NoError(err)
-				r.Equal(http.StatusServiceUnavailable, resp.StatusCode)
+				r.Equal(http.StatusProxyAuthRequired, resp.StatusCode)
 			}
 
 			entry := findCanonicalProxyDecision(logHook.AllEntries())


### PR DESCRIPTION
This hopefully improves clarity around rejecting traffic from smokescreen.

We've identified several libraries which not only do not read the message body, but misleadingly supply their own status message rather than using the one provided in the response header :/

In this case, at least 407 has the word "proxy" in it, so even if it's not fully accurate, it'll hopefully provide some clarity and help people more quickly identify the issue.