### PR TITLE
avoid mutating host header and respect URL scheme

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -224,15 +224,15 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 		ctx.UserData = &userData
 
 		// Build an address parsable by net.ResolveTCPAddr
-		remoteAddr := req.Host
-		if strings.LastIndex(remoteAddr, ":") <= strings.LastIndex(remoteAddr, "]") {
+		remoteHost := req.Host
+		if strings.LastIndex(remoteHost, ":") <= strings.LastIndex(remoteHost, "]") {
 			switch req.URL.Scheme {
 			case "http":
-				remoteAddr = net.JoinHostPort(remoteAddr, "80")
+				remoteHost = net.JoinHostPort(remoteHost, "80")
 			case "https":
-				remoteAddr = net.JoinHostPort(remoteAddr, "443")
+				remoteHost = net.JoinHostPort(remoteHost, "443")
 			default:
-				remoteAddr = net.JoinHostPort(remoteAddr, "0")
+				remoteHost = net.JoinHostPort(remoteHost, "0")
 			}
 		}
 
@@ -243,7 +243,7 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 				"url":            req.RequestURI,
 			}).Debug("received HTTP proxy request")
 
-		decision, err := checkIfRequestShouldBeProxied(config, req, remoteAddr)
+		decision, err := checkIfRequestShouldBeProxied(config, req, remoteHost)
 		userData.decision = decision
 		req.Header.Del(roleHeader)
 		if err != nil {


### PR DESCRIPTION
#62 added a check to ensure there was a `net.ResolveTCPAddr` parsable address in `req.Host`, as this field was used in `safeResolve` to split out the remote host address and port. This caused issues because it was actually mutating the host header passed to upstream services, and was also appending port 80 to non-Connect HTTPS proxy requests.

I also believe httpbin may actually be returning the host headers incorrectly, as I am getting different responses from Go's httptest.Server and httpbin. httptest.Server shows our mutated version of `req.Host` set as the host header.

This PR avoids mutating `req.Host` and moves it to a scheme-respecting variable which is passed along with the request to `safeResolve`.

https://jira.corp.stripe.com/browse/PRIVACYENG-1475?

r? @andrew-stripe
cc @edlee-stripe 
cc @rlk-stripe  
cc @abull-stripe 