### PR TITLE
remove unnecessary type assertions

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -47,7 +47,7 @@ type Config struct {
 	AllowMissingRole             bool
 	StatsSocketDir               string
 	StatsSocketFileMode          os.FileMode
-	StatsServer                  interface{}     // StatsServer
+	StatsServer                  *StatsServer    // StatsServer
 	ConnTracker                  *sync.Map       // The zero Map is empty and ready to use
 	IdleThresholdSec             time.Duration   // Consider a connection idle if it has been inactive (no bytes transferred) for this many seconds.
 	WgCxns                       *sync.WaitGroup // This wait group tracks *open* (active & idle) connections for graceful shutdown.

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -506,7 +506,7 @@ func runServer(config *Config, server *http.Server, listener net.Listener, quit 
 			config.Log.Print("Waiting for all connections to become idle...")
 			beginTs := time.Now()
 			for {
-				checkAgainIn := config.StatsServer.(*StatsServer).MaybeIdleIn() // ns
+				checkAgainIn := config.StatsServer.MaybeIdleIn() // ns
 				if checkAgainIn > 0 {
 					if time.Now().Sub(beginTs) > config.ExitTimeout {
 						config.Log.Print(fmt.Sprintf("Timed out at %v while waiting for all open connections to become idle.", config.ExitTimeout))
@@ -535,7 +535,7 @@ func runServer(config *Config, server *http.Server, listener net.Listener, quit 
 	})
 
 	if config.StatsServer != nil {
-		config.StatsServer.(*StatsServer).Shutdown()
+		config.StatsServer.Shutdown()
 	}
 }
 

--- a/pkg/smokescreen/stats_server.go
+++ b/pkg/smokescreen/stats_server.go
@@ -58,7 +58,7 @@ func (s *StatsServer) MaybeIdleIn() time.Duration {
 		defer c.mutex.Unlock()
 		idleAt := c.LastActivity.Add(s.config.IdleThresholdSec)
 		idleIn := idleAt.Sub(time.Now())
-		if  idleIn > longest {
+		if idleIn > longest {
 			longest = idleIn
 		}
 		return true


### PR DESCRIPTION
I'm working on another PR to improve the metrics we are emitting from smokescreen, and I found that this type assertion isn't actually necessary.

I spoke with tremblay who thought at one point this was needed to handle a circular dependency which is no longer present.

I've built and deployed this in our QA environment and not seen any issues.

r? @hans-stripe 
cc @stripe/security-infra 