### PR TITLE
log killed connections

### DIFF
--- a/pkg/smokescreen/instrumented_conn.go
+++ b/pkg/smokescreen/instrumented_conn.go
@@ -94,7 +94,7 @@ func (c *ConnExt) Close() error {
 	c.Config.StatsdClient.Histogram("cn.bytes_out", float64(c.BytesOut), tags, 1)
 
 	// This helps us track when we kill active connections during a shutdown
-	var idle bool
+	idle := true
 	if c.Config.IsShuttingDown.Load() == true {
 		idle = c.Idle()
 		if !idle {

--- a/pkg/smokescreen/instrumented_conn.go
+++ b/pkg/smokescreen/instrumented_conn.go
@@ -94,11 +94,11 @@ func (c *ConnExt) Close() error {
 	c.Config.StatsdClient.Histogram("cn.bytes_out", float64(c.BytesOut), tags, 1)
 
 	// This helps us track when we kill active connections during a shutdown
-	killed := false
+	idle := true
 	if c.Config.IsShuttingDown.Load() == true {
-		if !c.Idle() {
-			killed = true
-			c.Config.StatsdClient.Incr("cn.killed", tags, 1)
+		idle = c.Idle()
+		if !idle {
+			c.Config.StatsdClient.Incr("cn.active_at_termination", tags, 1)
 		}
 	}
 
@@ -112,7 +112,7 @@ func (c *ConnExt) Close() error {
 		"end_time":    endTime.UTC(),
 		"duration":    duration,
 		"wakeups":     c.Wakeups,
-		"killed":      killed,
+		"idle":        idle,
 	}).Info("CANONICAL-PROXY-CN-CLOSE")
 
 	c.Config.WgCxns.Done()


### PR DESCRIPTION
We have no visibility into when we are killing active connections during a shutdown after the `ExitTimeout` expires. This PR logs and emits a `killed` metric if we are actually closing an active connection (at least according to our configured threshold).

I've tested this locally and in QA and it does what we expect.

r? @hans-stripe 
cc @stripe/security-infra 