### PR TITLE
Remove X-Smokescreen-Trace-ID header from requests 

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -71,7 +71,6 @@ func conformResult(t *testing.T, test *TestCase, resp *http.Response, err error,
 	t.Logf("HTTP Response: %#v", resp)
 
 	a := assert.New(t)
-	// a.Empty(resp.Header.Get("X-Smokescreen-Trace-ID"))
 	if test.ExpectAllow {
 		if !a.NoError(err) {
 			return
@@ -255,7 +254,6 @@ func generateRequestForTest(t *testing.T, test *TestCase) *http.Request {
 		req.Header.Add("X-Smokescreen-Role", "egressneedingservice-"+test.RoleName)
 		req.Header.Add("X-Random-Trace", fmt.Sprintf("%d", test.RandomTrace))
 	}
-	//req.Header.Set("X-Smokescreen-Trace-ID", "7fa4587f-7362-4515-ba44-e44490241af0")
 
 	t.Logf("HTTP Request: %#v", req)
 	return req

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -71,6 +71,7 @@ func conformResult(t *testing.T, test *TestCase, resp *http.Response, err error,
 	t.Logf("HTTP Response: %#v", resp)
 
 	a := assert.New(t)
+	// a.Empty(resp.Header.Get("X-Smokescreen-Trace-ID"))
 	if test.ExpectAllow {
 		if !a.NoError(err) {
 			return
@@ -254,6 +255,7 @@ func generateRequestForTest(t *testing.T, test *TestCase) *http.Request {
 		req.Header.Add("X-Smokescreen-Role", "egressneedingservice-"+test.RoleName)
 		req.Header.Add("X-Random-Trace", fmt.Sprintf("%d", test.RandomTrace))
 	}
+	//req.Header.Set("X-Smokescreen-Trace-ID", "7fa4587f-7362-4515-ba44-e44490241af0")
 
 	t.Logf("HTTP Request: %#v", req)
 	return req

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -272,10 +272,10 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 
 		config.Log.WithFields(
 			logrus.Fields{
-				"source_ip":            req.RemoteAddr,
-				"requested_host":       req.Host,
-				"url":                  req.RequestURI,
-				"smokescreen_trace_id": req.Header.Get(traceHeader),
+				"source_ip":      req.RemoteAddr,
+				"requested_host": req.Host,
+				"url":            req.RequestURI,
+				"trace_id":       req.Header.Get(traceHeader),
 			}).Debug("received HTTP proxy request")
 
 		decision, err := checkIfRequestShouldBeProxied(config, req, remoteHost)
@@ -355,13 +355,13 @@ func logProxy(
 	fromHost, fromPort, _ := net.SplitHostPort(ctx.Req.RemoteAddr)
 
 	fields := logrus.Fields{
-		"proxy_type":           proxyType,
-		"src_host":             fromHost,
-		"src_port":             fromPort,
-		"requested_host":       ctx.Req.Host,
-		"start_time":           start.Unix(),
-		"content_length":       contentLength,
-		"smokescreen_trace_id": traceID,
+		"proxy_type":     proxyType,
+		"src_host":       fromHost,
+		"src_port":       fromPort,
+		"requested_host": ctx.Req.Host,
+		"start_time":     start.Unix(),
+		"content_length": contentLength,
+		"trace_id":       traceID,
 	}
 
 	if toAddress != nil {
@@ -418,9 +418,9 @@ func logHTTP(config *Config, ctx *goproxy.ProxyCtx) {
 func handleConnect(config *Config, ctx *goproxy.ProxyCtx) error {
 	config.Log.WithFields(
 		logrus.Fields{
-			"remote":               ctx.Req.RemoteAddr,
-			"requested_host":       ctx.Req.Host,
-			"smokescreen_trace_id": ctx.Req.Header.Get(traceHeader),
+			"remote":         ctx.Req.RemoteAddr,
+			"requested_host": ctx.Req.Host,
+			"trace_id":       ctx.Req.Header.Get(traceHeader),
 		}).Debug("received CONNECT proxy request")
 	start := time.Now()
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -44,6 +44,7 @@ type aclDecision struct {
 type ctxUserData struct {
 	start    time.Time
 	decision *aclDecision
+	traceId  string
 }
 
 type denyError struct {
@@ -253,7 +254,7 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 
 	// Handle traditional HTTP proxy
 	proxy.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-		userData := ctxUserData{time.Now(), nil}
+		userData := ctxUserData{time.Now(), nil, ""}
 		ctx.UserData = &userData
 
 		// Build an address parsable by net.ResolveTCPAddr
@@ -281,10 +282,11 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 		userData.decision = decision
 		req.Header.Del(roleHeader)
 
-		if req.Header.Get(traceHeader) == "" {
+		if v := req.Header.Get(traceHeader); v == "" {
 			config.StatsdClient.Incr("req.missing_trace_id", []string{}, 1)
 		} else {
 			req.Header.Del(traceHeader)
+			userData.traceId = v
 		}
 
 		if err != nil {
@@ -301,8 +303,15 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 
 	// Handle CONNECT proxy to TLS & other TCP protocols destination
 	proxy.OnRequest().HandleConnectFunc(func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
-		ctx.UserData = &ctxUserData{time.Now(), nil}
+		ctx.UserData = &ctxUserData{time.Now(), nil, ""}
 		err := handleConnect(config, ctx)
+
+		if ctx.Req.Header.Get(traceHeader) == "" {
+			config.StatsdClient.Incr("req.missing_trace_id", []string{}, 1)
+		} else {
+			ctx.Req.Header.Del(traceHeader)
+		}
+
 		if err != nil {
 			ctx.Resp = rejectResponse(ctx.Req, config, err)
 			return goproxy.RejectConnect, ""
@@ -334,6 +343,7 @@ func logProxy(
 	proxyType string,
 	toAddress *net.TCPAddr,
 	decision *aclDecision,
+	traceID string,
 	start time.Time,
 	err error,
 ) {
@@ -351,7 +361,7 @@ func logProxy(
 		"requested_host":       ctx.Req.Host,
 		"start_time":           start.Unix(),
 		"content_length":       contentLength,
-		"smokescreen_trace_id": ctx.Req.Header.Get(traceHeader),
+		"smokescreen_trace_id": traceID,
 	}
 
 	if toAddress != nil {
@@ -402,7 +412,7 @@ func logHTTP(config *Config, ctx *goproxy.ProxyCtx) {
 
 	userData := ctx.UserData.(*ctxUserData)
 
-	logProxy(config, ctx, "http", toAddr, userData.decision, userData.start, ctx.Error)
+	logProxy(config, ctx, "http", toAddr, userData.decision, userData.traceId, userData.start, ctx.Error)
 }
 
 func handleConnect(config *Config, ctx *goproxy.ProxyCtx) error {
@@ -417,7 +427,8 @@ func handleConnect(config *Config, ctx *goproxy.ProxyCtx) error {
 	// Check if requesting role is allowed to talk to remote
 	decision, err := checkIfRequestShouldBeProxied(config, ctx.Req, ctx.Req.Host)
 	ctx.UserData.(*ctxUserData).decision = decision
-	logProxy(config, ctx, "connect", decision.resolvedAddr, decision, start, err)
+	ctx.UserData.(*ctxUserData).traceId = ctx.Req.Header.Get(traceHeader)
+	logProxy(config, ctx, "connect", decision.resolvedAddr, decision, ctx.Req.Header.Get(traceHeader), start, err)
 	if err != nil {
 		return err
 	}

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -344,12 +344,13 @@ func logProxy(
 	fromHost, fromPort, _ := net.SplitHostPort(ctx.Req.RemoteAddr)
 
 	fields := logrus.Fields{
-		"proxy_type":     proxyType,
-		"src_host":       fromHost,
-		"src_port":       fromPort,
-		"requested_host": ctx.Req.Host,
-		"start_time":     start.Unix(),
-		"content_length": contentLength,
+		"proxy_type":           proxyType,
+		"src_host":             fromHost,
+		"src_port":             fromPort,
+		"requested_host":       ctx.Req.Host,
+		"start_time":           start.Unix(),
+		"content_length":       contentLength,
+		"smokescreen_trace_id": ctx.Req.Header.Get(traceHeader),
 	}
 
 	if toAddress != nil {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -271,9 +271,10 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 
 		config.Log.WithFields(
 			logrus.Fields{
-				"source_ip":      req.RemoteAddr,
-				"requested_host": req.Host,
-				"url":            req.RequestURI,
+				"source_ip":            req.RemoteAddr,
+				"requested_host":       req.Host,
+				"url":                  req.RequestURI,
+				"smokescreen_trace_id": req.Header.Get(traceHeader),
 			}).Debug("received HTTP proxy request")
 
 		decision, err := checkIfRequestShouldBeProxied(config, req, remoteHost)
@@ -407,8 +408,9 @@ func logHTTP(config *Config, ctx *goproxy.ProxyCtx) {
 func handleConnect(config *Config, ctx *goproxy.ProxyCtx) error {
 	config.Log.WithFields(
 		logrus.Fields{
-			"remote":         ctx.Req.RemoteAddr,
-			"requested_host": ctx.Req.Host,
+			"remote":               ctx.Req.RemoteAddr,
+			"requested_host":       ctx.Req.Host,
+			"smokescreen_trace_id": ctx.Req.Header.Get(traceHeader),
 		}).Debug("received CONNECT proxy request")
 	start := time.Now()
 

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -203,7 +203,7 @@ func TestClearsTraceIDHeader(t *testing.T) {
 
 	req, err := http.NewRequest("GET", ts.URL, nil)
 	r.NoError(err)
-	req.Header.Set("X-Smokescreen-Trace-ID", "7fa4587f-7362-4515-ba44-e44490241af0")
+	req.Header.Set("X-Smokescreen-Trace-ID", "6c4aa514e3da13ef")
 
 	go func() {
 		client.Do(req)

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -221,7 +221,7 @@ func TestClearsTraceIDHeader(t *testing.T) {
 	case <-respCh:
 		entry := findCanonicalProxyDecision(logHook.AllEntries())
 		r.NotNil(entry)
-		a.NotEmpty(entry.Data["smokescreen_trace_id"])
+		a.NotEmpty(entry.Data["trace_id"])
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for server response")
 	}


### PR DESCRIPTION
## Reviewers
r? @cds2-stripe 
cc @stripe/security-infra 

## Summary
This strips the `X-Smokescreen-Trace-ID` header from requests and adds the id as a field to the logs. 

I added the trace id as a field on the `userdata` so we didn't lose it when logging response.

## Motivation
Clients can add the `X-Smokescreen-Trace-ID` header to requests and use it to identify useful debugging information (e.g. service name) when there are egress denials. We shouldn't forward this header to the destination though so we need to remove it in the proxy and log it.


## Test plan
Unit tests!


