### PR TITLE
fix sample ACL yaml paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ A host can be specified with or without a globbing prefix
 | `ex*ample.com` | no |
 | `example.*` | hell no |
 
-[Here](https://github.com/stripe/smokescreen/blob/master/pkg/smokescreen/testdata/sample_config.yaml) is a sample ACL.
+[Here](https://github.com/stripe/smokescreen/blob/master/pkg/smokescreen/acl/v1/testdata/sample_config.yaml) is a sample ACL.
 
 
 #### Global Allow/Deny Lists
@@ -150,7 +150,7 @@ However, if the host specifies `malicious.com` in its `allowed_domains`, traffic
 If a domain matches both the `global_allow_list` and the `global_deny_list`, the `global_deny_list` behavior takes priority.
 
 
-[Here](https://github.com/stripe/smokescreen/blob/master/pkg/smokescreen/testdata/sample_config_with_global.yaml) is a sample ACL specifying these options.
+[Here](https://github.com/stripe/smokescreen/blob/master/pkg/smokescreen/acl/v1/testdata/sample_config_with_global.yaml) is a sample ACL specifying these options.
 
 
 # Contributors


### PR DESCRIPTION
To reflect recent yaml reorg (581f9de).