### PR TITLE
conntrack: store OutboundHost in InstrumentedConn

### DIFF
--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -38,6 +38,7 @@ func (t *Tracker) NewInstrumentedConn(conn net.Conn, role, outboundHost string) 
 	ic := &InstrumentedConn{
 		Conn:         conn,
 		Role:         role,
+		OutboundHost: outboundHost,
 		tracker:      t,
 		Start:        time.Now(),
 		LastActivity: &now,


### PR DESCRIPTION
Looks like we forgot to store this value, which means that the "rhost" in the statistics is always the empty string.

r? @rwg-stripe 
cc @stripe/security-infra 