### PR TITLE
conntrack: make stats more useful

### DIFF
--- a/pkg/smokescreen/conntrack/conn_tracker_test.go
+++ b/pkg/smokescreen/conntrack/conn_tracker_test.go
@@ -15,7 +15,7 @@ import (
 func TestConnTrackerDelete(t *testing.T) {
 	tr := NewTestTracker(time.Second * 1)
 
-	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testDeleteConn", "localhost")
+	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testid", "testDeleteConn", "localhost")
 	ic.Close()
 
 	tr.Range(func(k, v interface{}) bool {
@@ -29,7 +29,7 @@ func TestConnTrackerMaybeIdleIn(t *testing.T) {
 	assert := assert.New(t)
 
 	tr := NewTestTracker(1 * time.Nanosecond)
-	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testMaybeIdle", "localhost")
+	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testid", "testMaybeIdle", "localhost")
 
 	time.Sleep(time.Millisecond)
 

--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -136,9 +136,9 @@ func (ic *InstrumentedConn) Stats() *InstrumentedConnStats {
 	defer ic.Unlock()
 
 	return &InstrumentedConnStats{
-		Id:                       fmt.Sprintf("%d", &ic),
 		Role:                     ic.Role,
 		Rhost:                    ic.OutboundHost,
+		Raddr:                    ic.Conn.RemoteAddr().String(),
 		Created:                  ic.Start,
 		BytesIn:                  *ic.BytesIn,
 		BytesOut:                 *ic.BytesOut,

--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -13,6 +13,7 @@ import (
 
 type InstrumentedConn struct {
 	net.Conn
+	TraceId      string
 	Role         string
 	OutboundHost string
 
@@ -30,13 +31,14 @@ type InstrumentedConn struct {
 	CloseError error
 }
 
-func (t *Tracker) NewInstrumentedConn(conn net.Conn, role, outboundHost string) *InstrumentedConn {
+func (t *Tracker) NewInstrumentedConn(conn net.Conn, traceId, role, outboundHost string) *InstrumentedConn {
 	now := time.Now().UnixNano()
 	bytesIn := uint64(0)
 	bytesOut := uint64(0)
 
 	ic := &InstrumentedConn{
 		Conn:         conn,
+		TraceId:      traceId,
 		Role:         role,
 		OutboundHost: outboundHost,
 		tracker:      t,
@@ -136,6 +138,7 @@ func (ic *InstrumentedConn) Stats() *InstrumentedConnStats {
 	defer ic.Unlock()
 
 	return &InstrumentedConnStats{
+		TraceId:                  ic.TraceId,
 		Role:                     ic.Role,
 		Rhost:                    ic.OutboundHost,
 		Raddr:                    ic.Conn.RemoteAddr().String(),

--- a/pkg/smokescreen/conntrack/instrumented_conn_test.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn_test.go
@@ -35,7 +35,7 @@ func TestInstrumentedConnByteCounting(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		icWriter := tr.NewInstrumentedConn(conn, "test", "localhost")
+		icWriter := tr.NewInstrumentedConn(conn, "testid", "test", "localhost")
 
 		n, err := icWriter.Write(sent)
 		if err != nil {
@@ -51,7 +51,7 @@ func TestInstrumentedConnByteCounting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	icReader := tr.NewInstrumentedConn(conn, "testBytesInOut", "localhost")
+	icReader := tr.NewInstrumentedConn(conn, "testid", "testBytesInOut", "localhost")
 
 	go func() {
 		defer wg.Done()
@@ -76,7 +76,7 @@ func TestInstrumentedConnIdle(t *testing.T) {
 	assert := assert.New(t)
 
 	tr := NewTestTracker(time.Millisecond)
-	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testIdle", "localhost")
+	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testid", "testIdle", "localhost")
 
 	ic.Write([]byte("egress"))
 	assert.False(ic.Idle())

--- a/pkg/smokescreen/conntrack/stats.go
+++ b/pkg/smokescreen/conntrack/stats.go
@@ -3,7 +3,7 @@ package conntrack
 import "time"
 
 type InstrumentedConnStats struct {
-	Id                       string    `json:"id"`
+	TraceId                  string    `json:"trace_id"`
 	Role                     string    `json:"role"`
 	Rhost                    string    `json:"rhost"`
 	Raddr                    string    `json:"raddr"`

--- a/pkg/smokescreen/conntrack/stats.go
+++ b/pkg/smokescreen/conntrack/stats.go
@@ -6,6 +6,7 @@ type InstrumentedConnStats struct {
 	Id                       string    `json:"id"`
 	Role                     string    `json:"role"`
 	Rhost                    string    `json:"rhost"`
+	Raddr                    string    `json:"raddr"`
 	Created                  time.Time `json:"created"`
 	BytesIn                  uint64    `json:"bytesIn"`
 	BytesOut                 uint64    `json:"bytesOut"`

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -177,13 +177,14 @@ func safeResolve(config *Config, network, addr string) (*net.TCPAddr, string, er
 }
 
 func dial(config *Config, network, addr string, userdata interface{}) (net.Conn, error) {
-	var role, outboundHost, reason string
+	var role, outboundHost, reason, traceId string
 	var resolved *net.TCPAddr
 
 	if v, ok := userdata.(*ctxUserData); ok {
 		role = v.decision.role
 		outboundHost = v.decision.outboundHost
 		resolved = v.decision.resolvedAddr
+		traceId = v.traceId
 	}
 
 	if resolved == nil || addr != outboundHost || network != "tcp" {
@@ -211,7 +212,7 @@ func dial(config *Config, network, addr string, userdata interface{}) (net.Conn,
 		return nil, err
 	} else {
 		config.StatsdClient.Incr("cn.atpt.success.total", []string{}, 1)
-		return config.ConnTracker.NewInstrumentedConn(conn, role, outboundHost), nil
+		return config.ConnTracker.NewInstrumentedConn(conn, traceId, role, outboundHost), nil
 	}
 }
 


### PR DESCRIPTION
1. Emit the remote address of a tracked connection.
2. Plumb the trace ID (if any) through to a tracked connection.

r? @rwg-stripe 
cc @stripe/security-infra 