### PR TITLE
timeout idle conns

### DIFF
--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -254,7 +254,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 		}
 
 		// Setup the connection tracker
-		conf.ConnTracker = conntrack.NewTracker(conf.IdleThreshold, conf.StatsdClient, conf.Log, conf.ShuttingDown)
+		conf.ConnTracker = conntrack.NewTracker(conf.IdleTimeout, conf.StatsdClient, conf.Log, conf.ShuttingDown)
 
 		configToReturn = conf
 		return nil

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -52,9 +52,12 @@ type Config struct {
 	StatsSocketFileMode          os.FileMode
 	StatsServer                  *StatsServer // StatsServer
 	ConnTracker                  *conntrack.Tracker
-	IdleThreshold                time.Duration // Consider a connection idle if it has been inactive (no bytes transferred) for this many seconds.
-	Healthcheck                  http.Handler  // User defined http.Handler for optional requests to a /healthcheck endpoint
-	ShuttingDown                 atomic.Value  // Stores a boolean value indicating whether the proxy is actively shutting down
+	Healthcheck                  http.Handler // User defined http.Handler for optional requests to a /healthcheck endpoint
+	ShuttingDown                 atomic.Value // Stores a boolean value indicating whether the proxy is actively shutting down
+
+	// A connection is idle if it has been inactive (no bytes in/out) for this many seconds.
+	// If there are no reads or writes during this period the net.Conn will time out
+	IdleTimeout time.Duration
 }
 
 type missingRoleError struct {
@@ -201,7 +204,6 @@ func NewConfig() *Config {
 		Port:                    4750,
 		ExitTimeout:             500 * time.Minute,
 		StatsSocketFileMode:     os.FileMode(0700),
-		IdleThreshold:           10 * time.Second,
 		ShuttingDown:            atomic.Value{},
 	}
 }

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -22,16 +22,18 @@ type yamlConfigTls struct {
 type yamlConfig struct {
 	Ip                   string
 	Port                 *uint16
-	DenyRanges           []string       `yaml:"deny_ranges"`
-	AllowRanges          []string       `yaml:"allow_ranges"`
-	Resolvers            []string       `yaml:"resolver_addresses"`
-	ConnectTimeout       time.Duration  `yaml:"connect_timeout"`
-	ExitTimeout          *time.Duration `yaml:"exit_timeout"`
-	StatsdAddress        string         `yaml:"statsd_address"`
-	EgressAclFile        string         `yaml:"acl_file"`
-	SupportProxyProtocol bool           `yaml:"support_proxy_protocol"`
-	DenyMessageExtra     string         `yaml:"deny_message_extra"`
-	AllowMissingRole     bool           `yaml:"allow_missing_role"`
+	DenyRanges           []string `yaml:"deny_ranges"`
+	AllowRanges          []string `yaml:"allow_ranges"`
+	Resolvers            []string `yaml:"resolver_addresses"`
+	StatsdAddress        string   `yaml:"statsd_address"`
+	EgressAclFile        string   `yaml:"acl_file"`
+	SupportProxyProtocol bool     `yaml:"support_proxy_protocol"`
+	DenyMessageExtra     string   `yaml:"deny_message_extra"`
+	AllowMissingRole     bool     `yaml:"allow_missing_role"`
+
+	ConnectTimeout time.Duration  `yaml:"connect_timeout"`
+	IdleTimeout    time.Duration  `yaml:"idle_timeout"`
+	ExitTimeout    *time.Duration `yaml:"exit_timeout"`
 
 	StatsSocketDir      string `yaml:"stats_socket_dir"`
 	StatsSocketFileMode string `yaml:"stats_socket_file_mode"`
@@ -71,6 +73,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
+	c.IdleTimeout = yc.IdleTimeout
 	c.ConnectTimeout = yc.ConnectTimeout
 	if yc.ExitTimeout != nil {
 		c.ExitTimeout = *yc.ExitTimeout

--- a/pkg/smokescreen/conntrack/conn_tracker.go
+++ b/pkg/smokescreen/conntrack/conn_tracker.go
@@ -35,7 +35,7 @@ func NewTracker(idle time.Duration, statsc *statsd.Client, logger *logrus.Logger
 }
 
 // MaybeIdleIn returns the longest amount of time it will take for all tracked
-// connections to become idle based on the configured IdleThreshold.
+// connections to become idle based on the configured IdleTimeout.
 //
 // A duration of 0 indicates all connections are idle.
 func (tr *Tracker) MaybeIdleIn() time.Duration {

--- a/pkg/smokescreen/conntrack/conn_tracker.go
+++ b/pkg/smokescreen/conntrack/conn_tracker.go
@@ -11,21 +11,26 @@ import (
 
 type Tracker struct {
 	*sync.Map
-	ShuttingDown  atomic.Value
-	Wg            *sync.WaitGroup
-	IdleThreshold time.Duration // A connection is idle if it has been inactive (no bytes in/out) for this many seconds.
-	Log           *logrus.Logger
-	statsc        *statsd.Client
+	ShuttingDown atomic.Value
+	Wg           *sync.WaitGroup
+	Log          *logrus.Logger
+	statsc       *statsd.Client
+
+	// A connection is idle if it has been inactive (no bytes in/out) for this
+	// many seconds. If there are no reads or writes during this period the
+	// net.Conn will time out. A 0 value for the duration means the connection
+	// will not time out due to inactivity.
+	IdleTimeout time.Duration
 }
 
 func NewTracker(idle time.Duration, statsc *statsd.Client, logger *logrus.Logger, sd atomic.Value) *Tracker {
 	return &Tracker{
-		Map:           &sync.Map{},
-		ShuttingDown:  sd,
-		Wg:            &sync.WaitGroup{},
-		IdleThreshold: idle,
-		Log:           logger,
-		statsc:        statsc,
+		Map:          &sync.Map{},
+		ShuttingDown: sd,
+		Wg:           &sync.WaitGroup{},
+		IdleTimeout:  idle,
+		Log:          logger,
+		statsc:       statsc,
 	}
 }
 
@@ -39,7 +44,7 @@ func (tr *Tracker) MaybeIdleIn() time.Duration {
 		c := k.(*InstrumentedConn)
 
 		lastActivity := time.Unix(0, atomic.LoadInt64(c.LastActivity))
-		idleAt := lastActivity.Add(tr.IdleThreshold)
+		idleAt := lastActivity.Add(tr.IdleTimeout)
 		idleIn := idleAt.Sub(time.Now())
 
 		if idleIn > longest {

--- a/pkg/smokescreen/conntrack/conn_tracker_test.go
+++ b/pkg/smokescreen/conntrack/conn_tracker_test.go
@@ -36,7 +36,7 @@ func TestConnTrackerMaybeIdleIn(t *testing.T) {
 	// All connections should be idle
 	assert.Zero(tr.MaybeIdleIn())
 
-	tr.IdleThreshold = time.Second
+	tr.IdleTimeout = time.Second
 	ic.Write([]byte("egress"))
 
 	idleIn := tr.MaybeIdleIn().Round(time.Second)

--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -32,7 +32,8 @@ type InstrumentedConn struct {
 }
 
 func (t *Tracker) NewInstrumentedConn(conn net.Conn, traceId, role, outboundHost string) *InstrumentedConn {
-	now := time.Now().UnixNano()
+	now := time.Now()
+	nowUnixNano := now.UnixNano()
 	bytesIn := uint64(0)
 	bytesOut := uint64(0)
 
@@ -42,14 +43,14 @@ func (t *Tracker) NewInstrumentedConn(conn net.Conn, traceId, role, outboundHost
 		Role:         role,
 		OutboundHost: outboundHost,
 		tracker:      t,
-		Start:        time.Now(),
-		LastActivity: &now,
+		Start:        now,
+		LastActivity: &nowUnixNano,
 		BytesIn:      &bytesIn,
 		BytesOut:     &bytesOut,
 	}
 
 	if t.IdleTimeout != 0 {
-		ic.Conn.SetDeadline(time.Now().Add(t.IdleTimeout))
+		ic.Conn.SetDeadline(now.Add(t.IdleTimeout))
 	}
 	ic.tracker.Store(ic, nil)
 	ic.tracker.Wg.Add(1)

--- a/pkg/smokescreen/conntrack/instrumented_conn_test.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn_test.go
@@ -96,9 +96,18 @@ func TestInstrumentedConnIdleTimeout(t *testing.T) {
 	defer serverIC.Close()
 	defer clientIC.Close()
 
-	_, err := serverIC.Read([]byte{})
-	assert.NotNil(err)
+	time.Sleep(1 * time.Second)
 
+	n, err := clientIC.Write([]byte("timeout"))
+	assert.Zero(n)
+	assert.NotNil(err)
 	netError := err.(net.Error)
 	assert.True(netError.Timeout())
+
+	n, err = serverIC.Read([]byte{})
+	assert.Zero(n)
+	assert.NotNil(err)
+	netError = err.(net.Error)
+	assert.True(netError.Timeout())
+
 }

--- a/pkg/smokescreen/conntrack/instrumented_conn_test.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn_test.go
@@ -22,7 +22,7 @@ func TestInstrumentedConnByteCounting(t *testing.T) {
 	}
 	defer ln.Close()
 
-	tr := NewTestTracker(time.Millisecond * 500)
+	tr := NewTestTracker(0)
 	sent := []byte("X-Smokescreen-Test")
 
 	var wg sync.WaitGroup
@@ -83,4 +83,22 @@ func TestInstrumentedConnIdle(t *testing.T) {
 
 	time.Sleep(time.Second)
 	assert.True(ic.Idle())
+}
+
+func TestInstrumentedConnIdleTimeout(t *testing.T) {
+	assert := assert.New(t)
+
+	tr := NewTestTracker(time.Millisecond)
+
+	server, client := net.Pipe()
+	serverIC := tr.NewInstrumentedConn(server, "testid", "testIdleTimeout", "localhost")
+	clientIC := tr.NewInstrumentedConn(client, "testid", "testIdleTimeout", "localhost")
+	defer serverIC.Close()
+	defer clientIC.Close()
+
+	_, err := serverIC.Read([]byte{})
+	assert.NotNil(err)
+
+	netError := err.(net.Error)
+	assert.True(netError.Timeout())
 }

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -473,7 +473,7 @@ func StartWithConfig(config *Config, quit <-chan interface{}) {
 	}
 
 	// Setup connection tracking
-	config.ConnTracker = conntrack.NewTracker(config.IdleThreshold, config.StatsdClient, config.Log, config.ShuttingDown)
+	config.ConnTracker = conntrack.NewTracker(config.IdleTimeout, config.StatsdClient, config.Log, config.ShuttingDown)
 
 	server := http.Server{
 		Handler: handler,

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -150,7 +150,7 @@ func TestConsistentHostHeader(t *testing.T) {
 
 	// Custom proxy config for the "remote" httptest.NewServer
 	conf := NewConfig()
-	conf.ConnTracker = conntrack.NewTracker(conf.IdleThreshold, nil, conf.Log, atomic.Value{})
+	conf.ConnTracker = conntrack.NewTracker(conf.IdleTimeout, nil, conf.Log, atomic.Value{})
 	err := conf.SetAllowAddresses([]string{"127.0.0.1"})
 	r.NoError(err)
 
@@ -191,7 +191,7 @@ func TestClearsTraceIDHeader(t *testing.T) {
 	var logHook logrustest.Hook
 	conf := NewConfig()
 	conf.Log.AddHook(&logHook)
-	conf.ConnTracker = conntrack.NewTracker(conf.IdleThreshold, nil, conf.Log, atomic.Value{})
+	conf.ConnTracker = conntrack.NewTracker(conf.IdleTimeout, nil, conf.Log, atomic.Value{})
 	err := conf.SetAllowAddresses([]string{"127.0.0.1"})
 	r.NoError(err)
 
@@ -358,7 +358,7 @@ func proxyServer() (*httptest.Server, *logrustest.Hook, error) {
 	conf.AdditionalErrorMessageOnDeny = "Proxy denied"
 	conf.Resolver = &net.Resolver{}
 	conf.Log.AddHook(&logHook)
-	conf.ConnTracker = conntrack.NewTracker(conf.IdleThreshold, nil, conf.Log, atomic.Value{})
+	conf.ConnTracker = conntrack.NewTracker(conf.IdleTimeout, nil, conf.Log, atomic.Value{})
 
 	proxy := BuildProxy(conf)
 	return httptest.NewServer(proxy), &logHook, nil


### PR DESCRIPTION
r? @adunham-stripe 
cc @stripe/platform-security 

This PR wraps `InstrumentedConn` with an optional timeout. A deadline specified by `IdleTimeout` is added to the `net.Conn` passed to `NewInstrumentedConn`. The deadline is extended by `IdleTimeout` after every call to read/write. A zero value for the timeout duration will not associate a deadline with the connection.

We have been seeing a number of `InstrumentedConn`s persist for hours past their last read/write time. This helps protect us from misbehaving clients/servers which do not correctly close their connection.