### PR TITLE
 Don't remove X-Smokescreen-Error from our own reject responses

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -313,7 +313,8 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 	})
 
 	proxy.OnResponse().DoFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
-		if resp != nil {
+		userData := ctx.UserData.(*ctxUserData)
+		if resp != nil && userData.decision.allow {
 			resp.Header.Del(errorHeader)
 		}
 

--- a/pkg/smokescreen/testdata/acl.yaml
+++ b/pkg/smokescreen/testdata/acl.yaml
@@ -2,8 +2,9 @@
     version: v1
     services:
       - name: dummy-srv
-        project: usersec
+        project: security
         action: enforce
         allowed_domains:
-          - example.com
+          - notarealhost.com
+          - httpbin.org
     

--- a/pkg/smokescreen/testdata/acl.yaml
+++ b/pkg/smokescreen/testdata/acl.yaml
@@ -1,0 +1,9 @@
+---
+    version: v1
+    services:
+      - name: dummy-srv
+        project: usersec
+        action: enforce
+        allowed_domains:
+          - example.com
+    


### PR DESCRIPTION
## Reviewers
r? @cds2-stripe 
cc @stripe/security-infra 

## Summary
We end up removing the `X-Smokescreen-Error` header on http requests even if we're the ones setting it. This PR changes this behaviour, so we only remove the header if the request did not error (i.e. not `nil` response) _and_ smokescreen has allowed the request.

## Motivation
So we can use `X-Smokescreen-Error` to detect smokescreen errors on 407.


## Test plan
Updated some unit tests! will deploy to QA tomorrow morning and make some requests to verify the header is ok.

