### PR TITLE
revert adding deadlines to instrumented connections

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -56,7 +56,6 @@ type Config struct {
 	ShuttingDown                 atomic.Value // Stores a boolean value indicating whether the proxy is actively shutting down
 
 	// A connection is idle if it has been inactive (no bytes in/out) for this many seconds.
-	// If there are no reads or writes during this period the net.Conn will time out
 	IdleTimeout time.Duration
 }
 

--- a/pkg/smokescreen/conntrack/conn_tracker.go
+++ b/pkg/smokescreen/conntrack/conn_tracker.go
@@ -17,9 +17,7 @@ type Tracker struct {
 	statsc       *statsd.Client
 
 	// A connection is idle if it has been inactive (no bytes in/out) for this
-	// many seconds. If there are no reads or writes during this period the
-	// net.Conn will time out. A 0 value for the duration means the connection
-	// will not time out due to inactivity.
+	// many seconds.
 	IdleTimeout time.Duration
 }
 

--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -49,9 +49,6 @@ func (t *Tracker) NewInstrumentedConn(conn net.Conn, traceId, role, outboundHost
 		BytesOut:     &bytesOut,
 	}
 
-	if t.IdleTimeout != 0 {
-		ic.Conn.SetDeadline(now.Add(t.IdleTimeout))
-	}
 	ic.tracker.Store(ic, nil)
 	ic.tracker.Wg.Add(1)
 
@@ -112,10 +109,6 @@ func (ic *InstrumentedConn) Read(b []byte) (int, error) {
 	now := time.Now()
 	atomic.StoreInt64(ic.LastActivity, now.UnixNano())
 
-	if ic.tracker.IdleTimeout != 0 {
-		ic.Conn.SetDeadline(now.Add(ic.tracker.IdleTimeout))
-	}
-
 	n, err := ic.Conn.Read(b)
 	atomic.AddUint64(ic.BytesIn, uint64(n))
 
@@ -125,10 +118,6 @@ func (ic *InstrumentedConn) Read(b []byte) (int, error) {
 func (ic *InstrumentedConn) Write(b []byte) (int, error) {
 	now := time.Now()
 	atomic.StoreInt64(ic.LastActivity, now.UnixNano())
-
-	if ic.tracker.IdleTimeout != 0 {
-		ic.Conn.SetDeadline(now.Add(ic.tracker.IdleTimeout))
-	}
 
 	n, err := ic.Conn.Write(b)
 	atomic.AddUint64(ic.BytesOut, uint64(n))

--- a/pkg/smokescreen/conntrack/instrumented_conn_test.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn_test.go
@@ -84,30 +84,3 @@ func TestInstrumentedConnIdle(t *testing.T) {
 	time.Sleep(time.Second)
 	assert.True(ic.Idle())
 }
-
-func TestInstrumentedConnIdleTimeout(t *testing.T) {
-	assert := assert.New(t)
-
-	tr := NewTestTracker(time.Millisecond)
-
-	server, client := net.Pipe()
-	serverIC := tr.NewInstrumentedConn(server, "testid", "testIdleTimeout", "localhost")
-	clientIC := tr.NewInstrumentedConn(client, "testid", "testIdleTimeout", "localhost")
-	defer serverIC.Close()
-	defer clientIC.Close()
-
-	time.Sleep(1 * time.Second)
-
-	n, err := clientIC.Write([]byte("timeout"))
-	assert.Zero(n)
-	assert.NotNil(err)
-	netError := err.(net.Error)
-	assert.True(netError.Timeout())
-
-	n, err = serverIC.Read([]byte{})
-	assert.Zero(n)
-	assert.NotNil(err)
-	netError = err.(net.Error)
-	assert.True(netError.Timeout())
-
-}


### PR DESCRIPTION
We were not seeing the behavior we were expecting with this change, so we are reverting to keep master clean while we investigate why connections are failing to time out.

r? @jjiang-stripe 
cc @stripe/platform-security 