### PR TITLE
Add several missing error checks

### DIFF
--- a/pkg/smokescreen/acl/v1/acl.go
+++ b/pkg/smokescreen/acl/v1/acl.go
@@ -39,7 +39,10 @@ func New(logger *logrus.Logger, loader Loader, disabledActions []string) (*ACL, 
 		return nil, err
 	}
 
-	acl.DisablePolicies(disabledActions)
+	err = acl.DisablePolicies(disabledActions)
+	if err != nil {
+		return nil, err
+	}
 
 	err = acl.Validate()
 	if err != nil {

--- a/pkg/smokescreen/acl/v1/acl_test.go
+++ b/pkg/smokescreen/acl/v1/acl_test.go
@@ -211,6 +211,15 @@ func TestACLAddPolicyDisabled(t *testing.T) {
 	a.Error(acl.Add("acl", r))
 }
 
+func TestACLMalformedPolicyDisable(t *testing.T) {
+	_, err := New(
+		logrus.New(),
+		NewYAMLLoader("testdata/no_default.yaml"), // any file will do
+		[]string{"sillystring"},
+	)
+	assert.Error(t, err)
+}
+
 func TestACLAddInvalidDomain(t *testing.T) {
 	a := assert.New(t)
 

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -123,7 +123,10 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			return err
 		}
 
-		c.SetupCrls(yc.Tls.CRLFiles)
+		err = c.SetupCrls(yc.Tls.CRLFiles)
+		if err != nil {
+			return err
+		}
 	}
 
 	c.AllowMissingRole = yc.AllowMissingRole

--- a/pkg/smokescreen/stats_server.go
+++ b/pkg/smokescreen/stats_server.go
@@ -37,7 +37,10 @@ func (s *StatsServer) Serve() {
 	os.Chmod(s.socketPath, s.config.StatsSocketFileMode)
 
 	s.ln = ln
-	http.Serve(s.ln, s.mux)
+	err = http.Serve(s.ln, s.mux)
+	if err != nil {
+		s.config.Log.Fatal("Could not start the reporting server.", err)
+	}
 }
 
 func (s *StatsServer) Shutdown() {


### PR DESCRIPTION
A `gosec` run found several instances of missing error handling, but these were the interesting ones. (Others were from things like `http.ResponseWriter.Write()` and `config.StatsdClient.Incr()` where it's not unusual to see missing error handling or it'd be unclear what to do on error.)