### PR TITLE
connection timeouts

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,11 +26,11 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:d5f20f2b4317f195078f35bd247c5230cabbb0d63ff27f784b227a3e69aaff8b"
+  digest = "1:c99f0fa0726f2cc0ae404e57a9e8900595aa08b01de33c0ddd1fcea7deb394b2"
   name = "github.com/elazarl/goproxy"
   packages = ["."]
   pruneopts = ""
-  revision = "7f0347c4e99b2c764024a340b1af1c895cca44f8"
+  revision = "e34c7f6dab2815c58b0d891a345ab31d0d8e215d"
   source = "git@github.com:stripe/goproxy.git"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -14,7 +14,7 @@
   name = "github.com/elazarl/goproxy"
   source = "git@github.com:stripe/goproxy.git"
   # We maintain own fork of goproxy based on the v1.1 release
-  revision = "7f0347c4e99b2c764024a340b1af1c895cca44f8"
+  revision = "e34c7f6dab2815c58b0d891a345ab31d0d8e215d"
 
 [[constraint]]
   branch = "master"

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -57,6 +57,10 @@ type Config struct {
 
 	// A connection is idle if it has been inactive (no bytes in/out) for this many seconds.
 	IdleTimeout time.Duration
+
+	// These are *only* used for traditional HTTP proxy requests
+	TransportMaxIdleConns        int
+	TransportMaxIdleConnsPerHost int
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -32,6 +32,7 @@ type RuleRange struct {
 type Config struct {
 	Ip                           string
 	Port                         uint16
+	Listener                     net.Listener
 	DenyRanges                   []RuleRange
 	AllowRanges                  []RuleRange
 	Resolver                     *net.Resolver

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -38,6 +38,9 @@ type yamlConfig struct {
 	StatsSocketDir      string `yaml:"stats_socket_dir"`
 	StatsSocketFileMode string `yaml:"stats_socket_file_mode"`
 
+	TransportMaxIdleConns        int `yaml:"transport_max_idle_conns"`
+	TransportMaxIdleConnsPerHost int `yaml:"transport_max_idle_conns_per_host"`
+
 	Tls *yamlConfigTls
 
 	// Currently not configurable via YAML: RoleFromRequest, Log, DisabledAclPolicyActions

--- a/pkg/smokescreen/conntrack/conn_tracker_test.go
+++ b/pkg/smokescreen/conntrack/conn_tracker_test.go
@@ -15,7 +15,7 @@ import (
 func TestConnTrackerDelete(t *testing.T) {
 	tr := NewTestTracker(time.Second * 1)
 
-	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testid", "testDeleteConn", "localhost")
+	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testid", "testDeleteConn", "localhost", "http")
 	ic.Close()
 
 	tr.Range(func(k, v interface{}) bool {
@@ -29,7 +29,7 @@ func TestConnTrackerMaybeIdleIn(t *testing.T) {
 	assert := assert.New(t)
 
 	tr := NewTestTracker(1 * time.Nanosecond)
-	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testid", "testMaybeIdle", "localhost")
+	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testid", "testMaybeIdle", "localhost", "http")
 
 	time.Sleep(time.Millisecond)
 

--- a/pkg/smokescreen/conntrack/instrumented_conn_test.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn_test.go
@@ -2,6 +2,7 @@ package conntrack
 
 import (
 	"io"
+	"log"
 	"net"
 	"sync"
 	"testing"
@@ -83,4 +84,63 @@ func TestInstrumentedConnIdle(t *testing.T) {
 
 	time.Sleep(time.Second)
 	assert.True(ic.Idle())
+}
+
+var timeoutTests = []struct {
+	name          string
+	timeout       time.Duration
+	expectedError bool
+}{
+	{"no timeout with zero duration", 0, false},
+	{"timeout after duration", 50 * time.Millisecond, true},
+}
+
+func TestInstrumentedConnWithTimeout(t *testing.T) {
+	addr := "localhost:0"
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	handler := func(ln net.Listener) {
+		c, err := ln.Accept()
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(250 * time.Millisecond)
+		c.Write([]byte("timeout-test"))
+		defer c.Close()
+	}
+
+	tr := NewTestTracker(0)
+
+	for _, tt := range timeoutTests {
+		go handler(ln)
+
+		c, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var b [1]byte
+		ic := tr.NewInstrumentedConnWithTimeout(c, tt.timeout, "", "test", "testHost", "http")
+
+		_, err = ic.Read(b[:])
+		if err == nil && tt.expectedError {
+			t.Fatalf("%v: expected=%v got=%v", tt.name, tt.expectedError, err)
+		}
+
+		if err != nil && !tt.expectedError {
+			t.Fatalf("%v: expected=%v got=%v", tt.name, tt.expectedError, err)
+		}
+
+		if err != nil {
+			if err, ok := err.(net.Error); ok && !err.Timeout() {
+				log.Fatal(err)
+				t.Fatalf("%v: expected timeout error - got: %v", tt.name, err)
+			}
+		}
+		ic.Close()
+	}
 }

--- a/pkg/smokescreen/conntrack/instrumented_conn_test.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn_test.go
@@ -35,7 +35,7 @@ func TestInstrumentedConnByteCounting(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		icWriter := tr.NewInstrumentedConn(conn, "testid", "test", "localhost")
+		icWriter := tr.NewInstrumentedConn(conn, "testid", "test", "localhost", "http")
 
 		n, err := icWriter.Write(sent)
 		if err != nil {
@@ -51,7 +51,7 @@ func TestInstrumentedConnByteCounting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	icReader := tr.NewInstrumentedConn(conn, "testid", "testBytesInOut", "localhost")
+	icReader := tr.NewInstrumentedConn(conn, "testid", "testBytesInOut", "localhost", "http")
 
 	go func() {
 		defer wg.Done()
@@ -76,7 +76,7 @@ func TestInstrumentedConnIdle(t *testing.T) {
 	assert := assert.New(t)
 
 	tr := NewTestTracker(time.Millisecond)
-	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testid", "testIdle", "localhost")
+	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testid", "testIdle", "localhost", "egress")
 
 	ic.Write([]byte("egress"))
 	assert.False(ic.Idle())

--- a/pkg/smokescreen/conntrack/stats.go
+++ b/pkg/smokescreen/conntrack/stats.go
@@ -11,4 +11,5 @@ type InstrumentedConnStats struct {
 	BytesIn                  uint64    `json:"bytesIn"`
 	BytesOut                 uint64    `json:"bytesOut"`
 	SecondsSinceLastActivity float64   `json:"secondsSinceLastActivity"`
+	ProxyType                string    `json:"proxyType"`
 }

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -492,10 +492,14 @@ func findListener(ip string, defaultPort uint16) (net.Listener, error) {
 func StartWithConfig(config *Config, quit <-chan interface{}) {
 	config.Log.Println("starting")
 	proxy := BuildProxy(config)
+	listener := config.Listener
+	var err error
 
-	listener, err := findListener(config.Ip, config.Port)
-	if err != nil {
-		config.Log.Fatal("can't find listener", err)
+	if listener == nil {
+		listener, err = findListener(config.Ip, config.Port)
+		if err != nil {
+			config.Log.Fatal("can't find listener", err)
+		}
 	}
 
 	if config.SupportProxyProtocol {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -287,6 +287,11 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 		return proxy.Tr.RoundTrip(req.WithContext(ctx))
 	})
 
+	// Associate a timeout with the CONNECT proxy client connection
+	proxy.ConnectClientConnHandler = func(conn net.Conn) net.Conn {
+		return NewTimeoutConn(conn, config.IdleTimeout)
+	}
+
 	// Handle traditional HTTP proxy
 	proxy.OnRequest().DoFunc(func(req *http.Request, pctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 		// Attach smokescreenContext to goproxy.ProxyCtx

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -43,6 +43,7 @@ type aclDecision struct {
 }
 
 type smokescreenContext struct {
+	cfg      *Config
 	start    time.Time
 	decision *aclDecision
 	traceId  string
@@ -176,44 +177,50 @@ func safeResolve(config *Config, network, addr string) (*net.TCPAddr, string, er
 	return nil, "destination address was denied by rule, see error", denyError{fmt.Errorf("The destination address (%s) was denied by rule '%s'", resolved.IP, classification)}
 }
 
-func dialContext(pctx *goproxy.ProxyCtx, config *Config, network, addr string) (net.Conn, error) {
-	var role, outboundHost, reason, traceId string
-	var resolved *net.TCPAddr
+func proxyContext(ctx context.Context) (*goproxy.ProxyCtx, bool) {
+	pctx, ok := ctx.Value(goproxy.ProxyContextKey).(*goproxy.ProxyCtx)
+	return pctx, ok
+}
 
-	if v, ok := pctx.UserData.(*smokescreenContext); ok {
-		role = v.decision.role
-		outboundHost = v.decision.outboundHost
-		resolved = v.decision.resolvedAddr
-		traceId = v.traceId
+func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	pctx, ok := proxyContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("dialContext missing required *goproxy.ProxyCtx")
 	}
 
-	if resolved == nil || addr != outboundHost || network != "tcp" {
+	sctx, ok := pctx.UserData.(*smokescreenContext)
+	if !ok {
+		return nil, fmt.Errorf("dialContext missing required *smokescreenContext")
+	}
+	d := sctx.decision
+
+	// If an address hasn't been resolved, does not match the original outboundHost,
+	// or is not tcp we must re-resolve it before establishing the connection.
+	if d.resolvedAddr == nil || d.outboundHost != addr || network != "tcp" {
 		var err error
-		resolved, reason, err = safeResolve(config, network, addr)
-		pctx.UserData.(*smokescreenContext).decision.reason = reason
+		d.resolvedAddr, d.reason, err = safeResolve(sctx.cfg, network, addr)
 		if err != nil {
 			if _, ok := err.(denyError); ok {
-				config.Log.WithFields(
+				sctx.cfg.Log.WithFields(
 					logrus.Fields{
 						"address": addr,
 						"error":   err,
 					}).Error("unexpected illegal address in dialer")
 			}
-
 			return nil, err
 		}
 	}
 
-	config.StatsdClient.Incr("cn.atpt.total", []string{}, 1)
-	conn, err := net.DialTimeout(network, resolved.String(), config.ConnectTimeout)
-
+	sctx.cfg.StatsdClient.Incr("cn.atpt.total", []string{}, 1)
+	conn, err := net.DialTimeout(network, d.resolvedAddr.String(), sctx.cfg.ConnectTimeout)
 	if err != nil {
-		config.StatsdClient.Incr("cn.atpt.fail.total", []string{}, 1)
+		sctx.cfg.StatsdClient.Incr("cn.atpt.fail.total", []string{}, 1)
 		return nil, err
-	} else {
-		config.StatsdClient.Incr("cn.atpt.success.total", []string{}, 1)
-		return config.ConnTracker.NewInstrumentedConn(conn, traceId, role, outboundHost), nil
 	}
+
+	sctx.cfg.StatsdClient.Incr("cn.atpt.success.total", []string{}, 1)
+	// Wrap the dialed net.Conn with IntrumentedConn for tracking
+	return sctx.cfg.ConnTracker.NewInstrumentedConn(conn, sctx.traceId, d.role, d.outboundHost), nil
 }
 
 func rejectResponse(req *http.Request, config *Config, err error) *http.Response {
@@ -243,17 +250,36 @@ func rejectResponse(req *http.Request, config *Config, err error) *http.Response
 	return resp
 }
 
+func newContext(cfg *Config) *smokescreenContext {
+	return &smokescreenContext{
+		cfg:   cfg,
+		start: time.Now(),
+	}
+}
+
 func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.Verbose = false
-	proxy.ConnectDialContext = func(proxyCtx *goproxy.ProxyCtx, network, addr string) (net.Conn, error) {
-		return dialContext(proxyCtx, config, network, addr)
-	}
+
+	// dialContext will be invoked for both CONNECT and traditional proxy requests
+	proxy.Tr.DialContext = dialContext
+
+	// Use a custom goproxy.RoundTripperFunc to ensure that the correct context is attached to the request.
+	// This is only used for non-CONNECT HTTP proxy requests. For connect requests, goproxy automatically
+	// attaches goproxy.ProxyCtx prior to calling dialContext.
+	rtFn := goproxy.RoundTripperFunc(func(req *http.Request, pctx *goproxy.ProxyCtx) (*http.Response, error) {
+		ctx := context.WithValue(req.Context(), goproxy.ProxyContextKey, pctx)
+		return proxy.Tr.RoundTrip(req.WithContext(ctx))
+	})
 
 	// Handle traditional HTTP proxy
 	proxy.OnRequest().DoFunc(func(req *http.Request, pctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-		sctx := &smokescreenContext{time.Now(), nil, ""}
+		// Attach smokescreenContext to goproxy.ProxyCtx
+		sctx := newContext(config)
 		pctx.UserData = sctx
+
+		// Set this on every request as every request mints a new goproxy.ProxyCtx
+		pctx.RoundTripper = rtFn
 
 		// Build an address parsable by net.ResolveTCPAddr
 		remoteHost := req.Host
@@ -297,8 +323,8 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 
 	// Handle CONNECT proxy to TLS & other TCP protocols destination
 	proxy.OnRequest().HandleConnectFunc(func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
-		ctx.UserData = &smokescreenContext{time.Now(), nil, ""}
 		defer ctx.Req.Header.Del(traceHeader)
+		ctx.UserData = newContext(config)
 
 		err := handleConnect(config, ctx)
 		if err != nil {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -250,6 +250,20 @@ func rejectResponse(req *http.Request, config *Config, err error) *http.Response
 	return resp
 }
 
+func configureTransport(tr *http.Transport, cfg *Config) {
+	if cfg.TransportMaxIdleConns != 0 {
+		tr.MaxIdleConns = cfg.TransportMaxIdleConns
+	}
+
+	if cfg.TransportMaxIdleConnsPerHost != 0 {
+		tr.MaxIdleConnsPerHost = cfg.TransportMaxIdleConns
+	}
+
+	if cfg.IdleTimeout != 0 {
+		tr.IdleConnTimeout = cfg.IdleTimeout
+	}
+}
+
 func newContext(cfg *Config) *smokescreenContext {
 	return &smokescreenContext{
 		cfg:   cfg,
@@ -260,6 +274,7 @@ func newContext(cfg *Config) *smokescreenContext {
 func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.Verbose = false
+	configureTransport(proxy.Tr, config)
 
 	// dialContext will be invoked for both CONNECT and traditional proxy requests
 	proxy.Tr.DialContext = dialContext

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -527,6 +527,14 @@ func StartWithConfig(config *Config, quit <-chan interface{}) {
 		Handler: handler,
 	}
 
+	// This sets an IdleTimeout on _all_ client connections. CONNECT requests
+	// hijacked by goproxy inherit the deadline set here. The deadlines are
+	// reset by the proxy.ConnectClientConnHandler, which wraps the hijacked
+	// connection in a TimeoutConn which bumps the deadline for every read/write.
+	if config.IdleTimeout != 0 {
+		server.IdleTimeout = config.IdleTimeout
+	}
+
 	config.ShuttingDown.Store(false)
 	runServer(config, &server, listener, quit)
 	return

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -250,10 +250,6 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 		return dialContext(proxyCtx, config, network, addr)
 	}
 
-	// Ensure that we don't keep old connections alive to avoid TLS errors
-	// when attempting to re-use an idle connection.
-	proxy.Tr.DisableKeepAlives = true
-
 	// Handle traditional HTTP proxy
 	proxy.OnRequest().DoFunc(func(req *http.Request, pctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 		sctx := &smokescreenContext{time.Now(), nil, ""}

--- a/pkg/smokescreen/testdata/acl.yaml
+++ b/pkg/smokescreen/testdata/acl.yaml
@@ -1,10 +1,14 @@
 ---
     version: v1
     services:
-      - name: dummy-srv
+      - name: test-trusted-srv
         project: security
         action: enforce
         allowed_domains:
           - notarealhost.com
           - httpbin.org
-    
+      - name: test-local-srv
+        project: security
+        action: open
+        allowed_domains:
+          - 127.0.0.1

--- a/pkg/smokescreen/timeout_conn.go
+++ b/pkg/smokescreen/timeout_conn.go
@@ -1,0 +1,38 @@
+package smokescreen
+
+import (
+	"net"
+	"time"
+)
+
+type TimeoutConn struct {
+	net.Conn
+	timeout time.Duration
+}
+
+func NewTimeoutConn(conn net.Conn, timeout time.Duration) net.Conn {
+	return &TimeoutConn{
+		Conn:    conn,
+		timeout: timeout,
+	}
+}
+
+func (tc *TimeoutConn) Read(b []byte) (int, error) {
+	if tc.timeout != 0 {
+		err := tc.Conn.SetDeadline(time.Now().Add(tc.timeout))
+		if err != nil {
+			return 0, err
+		}
+	}
+	return tc.Conn.Read(b)
+}
+
+func (tc *TimeoutConn) Write(b []byte) (int, error) {
+	if tc.timeout != 0 {
+		err := tc.Conn.SetDeadline(time.Now().Add(tc.timeout))
+		if err != nil {
+			return 0, err
+		}
+	}
+	return tc.Conn.Write(b)
+}

--- a/vendor/github.com/elazarl/goproxy/proxy.go
+++ b/vendor/github.com/elazarl/goproxy/proxy.go
@@ -33,6 +33,15 @@ type ProxyHttpServer struct {
 	// ConnectDialContext will be used to create TCP connections for CONNECT requests
 	// if nil Tr.Dial will be used
 	ConnectDialContext func(ctx *ProxyCtx, network string, addr string) (net.Conn, error)
+
+	// ConnectCopyHandler allows users to implement a custom copy routine when forwarding data
+	// between the proxy client and proxy target for CONNECT requests
+	ConnectCopyHandler func(ctx *ProxyCtx, client, target net.Conn)
+
+	// ConnectClientConnHandler allows users to set a callback function which gets passed
+	// the hijacked proxy client net.Conn. This is useful for wrapping the connection
+	// to implement timeouts or additional tracing.
+	ConnectClientConnHandler func(net.Conn) net.Conn
 }
 
 var hasPort = regexp.MustCompile(`:\d+$`)


### PR DESCRIPTION
r? @hans-stripe 
cc @stripe/platform-security 

Smokescreen was originally developed as a local proxy to prevent SSRF to local IP addresses. Over time, Smokescreen's usage has evolved to act as a proxy to arbitrary hosts on the internet. We now need to add guardrails to prevent hosts from keeping idle connections open and leaking file descriptors.

This PR adds support for specifying granular connection timeouts for CONNECT and traditional HTTP proxy requests in Smokescreen. This duration is configured by setting the `IdleTimeout` field in the config.

There are four codepaths where we now set timeouts:
* Client HTTP proxy requests 694f384 - This was implemented by setting the `IdleTimeout` field on Smokescreen's `http.Server`.
* Server HTTP proxy targets 07f85fa - We add timeouts to the connection returned by Smokescreen's `dialContext` by wrapping the connection with a `TimeoutConn`. We do not wrap traditional HTTP proxy requests with an `InstrumentedConn` because of the way the standard library does connection pooling. Doing so would end up with reused `InstrumentedConns` and inaccurate connection statistics due to interface pollution. Additionally, the `http.Transport.IdleConnTimeout` setting only applies to the length of time the connection spends idle in the connection pool. It does _not_ include time spent in blocking read/write operations.
* Client HTTP CONNECT proxy requests 82528b2 - We added an additional callback field to our forked version of goproxy. After the connection is hijacked it is passed to the callback handler which wraps it in a `TimeoutConn` and an associated deadline if `IdleTimeout` is configured.
* Server HTTP CONNECT proxy targets 07f85fa - This is also set in our custom dialer `dialContext`. All CONNECT proxy requests are wrapped in an `InstrumentedConn` and a deadline if they are configured.

In addition to setting configurable timeouts, traditional HTTP proxy requests are now handled exclusively by the configured `http.Transport`. Connections are pooled and reused based on the destination host. Previously, this functionality was disabled because we explicitly disabled keepalives on the transport. We also expose `TransportMaxIdleConns` and `TransportMaxIdleConnsPerHost` as configuration options to override the default transport settings.

One more thing to note is that prior to Go 1.13 the default behavior for connections accepted from Smokescreen's `net.Listener` would _not_ set keepalives on the connection. This was changed with https://go-review.googlesource.com/c/go/+/170678.

I wrote unit tests to test to verify the expected timeout behavior and have also tested this extensively in qa and on canary hosts.

More resources on timeouts and Go:
https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
https://blog.gopheracademy.com/advent-2016/exposing-go-on-the-internet/