### PR TITLE
default to exit_timeout for shutdown timeout

### DIFF
--- a/pkg/smokescreen/conntrack/conn_tracker.go
+++ b/pkg/smokescreen/conntrack/conn_tracker.go
@@ -36,13 +36,13 @@ func NewTracker(idle time.Duration, statsc *statsd.Client, logger *logrus.Logger
 // connections to become idle based on the configured IdleTimeout.
 //
 // A duration of 0 indicates all connections are idle.
-func (tr *Tracker) MaybeIdleIn() time.Duration {
+func (tr *Tracker) MaybeIdleIn(d time.Duration) time.Duration {
 	longest := 0 * time.Nanosecond
 	tr.Range(func(k, v interface{}) bool {
 		c := k.(*InstrumentedConn)
 
 		lastActivity := time.Unix(0, atomic.LoadInt64(c.LastActivity))
-		idleAt := lastActivity.Add(tr.IdleTimeout)
+		idleAt := lastActivity.Add(d)
 		idleIn := idleAt.Sub(time.Now())
 
 		if idleIn > longest {

--- a/pkg/smokescreen/conntrack/conn_tracker_test.go
+++ b/pkg/smokescreen/conntrack/conn_tracker_test.go
@@ -28,18 +28,17 @@ func TestConnTrackerDelete(t *testing.T) {
 func TestConnTrackerMaybeIdleIn(t *testing.T) {
 	assert := assert.New(t)
 
-	tr := NewTestTracker(1 * time.Nanosecond)
+	tr := NewTestTracker(time.Nanosecond)
 	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testid", "testMaybeIdle", "localhost", "http")
 
 	time.Sleep(time.Millisecond)
 
 	// All connections should be idle
-	assert.Zero(tr.MaybeIdleIn())
+	assert.Zero(tr.MaybeIdleIn(time.Nanosecond))
 
-	tr.IdleTimeout = time.Second
 	ic.Write([]byte("egress"))
 
-	idleIn := tr.MaybeIdleIn().Round(time.Second)
+	idleIn := tr.MaybeIdleIn(time.Second).Round(time.Second)
 	assert.Equal(time.Second, idleIn)
 }
 


### PR DESCRIPTION
If `idle_timeout` is set to 0, an exit signal to Smokescreen will immediately kill all connections and bypass the configured `exit_timeout`. This PR ensures that if `idle_timeout` is 0 Smokescreen waits at least `exit_timeout` before terminating any active connections.

I also added additional logging so that it's easier to determine the state of the connections when Smokescreen terminates.

r? @stripe/platform-security 