### PR TITLE
fix integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
   - echo $TRAVIS_GO_VERSION; go test -race -v -timeout 2m -failfast ./... -tags=nointegration
   # Run integration tests hermetically to avoid nondeterministic races on environment variables
   - echo $TRAVIS_GO_VERSION; go test -race -v -timeout 2m -failfast ./cmd/... -run TestSmokescreenIntegration
-  - echo $TRAVIS_GO_VERSION; go test -race -v -timeout 2m -failfast ./cmd/... -run TestUpstreamProxySmokescreenIntegration
+  - echo $TRAVIS_GO_VERSION; go test -race -v -timeout 2m -failfast ./cmd/... -run TestInvalidUpstreamProxyConfiguration

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ before_script:
   - go vet -v ./...
 script:
   - echo $TRAVIS_GO_VERSION; go test -race -v -timeout 2m -failfast ./... -tags=nointegration
+  # Run integration tests hermetically to avoid nondeterministic races on environment variables
   - echo $TRAVIS_GO_VERSION; go test -race -v -timeout 2m -failfast ./cmd/... -run TestSmokescreenIntegration
   - echo $TRAVIS_GO_VERSION; go test -race -v -timeout 2m -failfast ./cmd/... -run TestUpstreamProxySmokescreenIntegration

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ before_script:
   - go vet -v ./...
 script:
   - echo $TRAVIS_GO_VERSION; go test -race -v -timeout 2m -failfast ./... -tags=nointegration
-  - echo $TRAVIS_GO_VERSION; go test -race -v -timeout 2m -failfast ./cmd/... # integration tests
+  - echo $TRAVIS_GO_VERSION; go test -race -v -timeout 2m -failfast ./cmd/... -run TestSmokescreenIntegration
+  - echo $TRAVIS_GO_VERSION; go test -race -v -timeout 2m -failfast ./cmd/... -run TestUpstreamProxySmokescreenIntegration

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
   - "1.13.x"
   - "1.14.x"
+
 install:
   - true # We do nothing here to avoid the default travis_install_go_dependencies script from running `go get`
 env:
@@ -9,4 +10,5 @@ env:
 before_script:
   - go vet -v ./...
 script:
-  - echo $TRAVIS_GO_VERSION; go test -race -v -timeout 60s ./... -tags=nointegration
+  - echo $TRAVIS_GO_VERSION; go test -race -v -timeout 2m -failfast ./... -tags=nointegration
+  - echo $TRAVIS_GO_VERSION; go test -race -v -timeout 2m -failfast ./cmd/... # integration tests

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -132,12 +132,12 @@ func conformResult(t *testing.T, test *TestCase, resp *http.Response, err error,
 	}
 
 	if len(entries) > 0 {
-		lastEntryIndex := len(entries) - 1
-		entry := entries[lastEntryIndex]
+		entry := findLogEntry(entries, smokescreen.LOGLINE_CANONICAL_PROXY_DECISION)
+		a.NotNil(entry)
 		a.Equal(entry.Message, smokescreen.LOGLINE_CANONICAL_PROXY_DECISION)
 
 		a.Contains(entry.Data, "allow")
-		a.Equal(test.ExpectAllow, entries[lastEntryIndex].Data["allow"])
+		a.Equal(test.ExpectAllow, entry.Data["allow"])
 
 		a.Contains(entry.Data, "proxy_type")
 		if test.OverConnect {

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -289,7 +289,7 @@ func TestSmokescreenIntegration(t *testing.T) {
 		proxyServers[useTLS] = proxyServer
 
 		if useTLS {
-			externalHosts[useTLS] = "https://api.github.com:443"
+			externalHosts[useTLS] = "https://api.stripe.com:443"
 
 			httpServer := httptest.NewTLSServer(ProxyTargetHandler)
 			defer httpServer.Close()
@@ -373,6 +373,10 @@ func TestSmokescreenIntegration(t *testing.T) {
 
 					if expectAllow {
 						testCase.ExpectStatus = http.StatusOK
+						if overTLS && !authorizedHost {
+							// The Stripe API returns a 403 to a bare HTTP GET request
+							testCase.ExpectStatus = http.StatusUnauthorized
+						}
 					} else {
 						testCase.ExpectStatus = http.StatusProxyAuthRequired
 					}
@@ -470,10 +474,11 @@ func TestInvalidUpstreamProxyConfiguration(t *testing.T) {
 			var proxyTarget string
 			var upstreamProxy string
 
-			// These proxy targets don't actually matter, as
+			// These proxy targets don't actually matter as the requests wont be sent.
+			// because the resolution of the upstream proxy will fail.
 			if overConnect {
 				upstreamProxy = "https://notaproxy.prxy.svc:443"
-				proxyTarget = "https://api.github.com:443"
+				proxyTarget = "https://api.stripe.com:443"
 			} else {
 				upstreamProxy = "http://notaproxy.prxy.svc:80"
 				proxyTarget = "http://checkip.amazonaws.com:80"

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -3,10 +3,11 @@
 package cmd
 
 import (
-	"bytes"
+	"bufio"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -18,6 +19,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/sirupsen/logrus"
@@ -32,7 +34,8 @@ import (
 type DummyHandler struct{}
 
 func (s *DummyHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	io.WriteString(rw, "ok")
+	time.Sleep(50 * time.Millisecond)
+	io.WriteString(rw, "okok")
 }
 
 func NewDummyServer() *http.Server {
@@ -58,12 +61,15 @@ func testRFRCert(req *http.Request) (string, error) {
 
 type TestCase struct {
 	ExpectAllow   bool
+	Action        acl.EnforcementPolicy
+	ExpectStatus  int
 	OverTls       bool
 	OverConnect   bool
 	ProxyURL      string
 	TargetPort    int
 	RandomTrace   int
-	Host          string
+	TargetHost    string
+	TargetScheme  string
 	RoleName      string
 	UpstreamProxy string
 }
@@ -73,21 +79,34 @@ func conformResult(t *testing.T, test *TestCase, resp *http.Response, err error,
 
 	a := assert.New(t)
 	if test.ExpectAllow {
-		if !a.NoError(err) {
+		// In some cases we expect the proxy to allow the request but the upstream to return an error
+		if test.ExpectStatus != 0 {
+			if resp == nil {
+				t.Fatal(err)
+			}
+			a.Equal(test.ExpectStatus, resp.StatusCode, "Expected HTTP response code did not match")
 			return
 		}
-		a.Equal(200, resp.StatusCode, "HTTP Response code should indicate success.")
+		// CONNECT requests which return a non-200 return an error and a nil response
+		if resp == nil {
+			a.Error(err)
+			return
+		}
+		a.Equal(http.StatusOK, resp.StatusCode, "HTTP Response code should indicate success.")
 	} else {
-		if !a.NoError(err) {
+		// CONNECT requests which return a non-200 return an error and a nil response
+		if resp == nil {
+			a.Error(err)
 			return
 		}
-		a.Equal(503, resp.StatusCode)
+		// If there is a response returned, it should contain smokescreen's error message
 		body, err := ioutil.ReadAll(resp.Body)
-		if !a.NoError(err) {
-			return
+		if err != nil {
+			t.Fatal(err)
 		}
+		defer resp.Body.Close()
 		a.Contains(string(body), "denied")
-		a.Contains(string(body), "moar ctx")
+		a.Contains(string(body), "more ctx")
 	}
 
 	var entries []*logrus.Entry
@@ -115,29 +134,8 @@ func conformResult(t *testing.T, test *TestCase, resp *http.Response, err error,
 		}
 
 		a.Contains(entry.Data, "requested_host")
-		a.Equal(fmt.Sprintf("%s:%d", test.Host, test.TargetPort), entry.Data["requested_host"])
+		a.Equal(fmt.Sprintf("%s:%d", test.TargetHost, test.TargetPort), entry.Data["requested_host"])
 	}
-}
-
-func conformIllegalProxyResult(t *testing.T, test *TestCase, resp *http.Response, err error, logs []*logrus.Entry) {
-	r := require.New(t)
-	a := assert.New(t)
-	t.Logf("HTTP Response: %#v", resp)
-
-	r.NoError(err)
-
-	var expectStatus int
-	if test.OverConnect {
-		expectStatus = 502
-	} else {
-		expectStatus = 503
-
-	}
-	a.Equal(expectStatus, resp.StatusCode)
-
-	entry := findLogEntry(logs, "unexpected illegal address in dialer")
-	r.NotNil(entry)
-	a.Equal("127.0.0.2:80", entry.Data["address"])
 }
 
 func generateRoleForAction(action acl.EnforcementPolicy) string {
@@ -155,39 +153,37 @@ func generateRoleForAction(action acl.EnforcementPolicy) string {
 func generateClientForTest(t *testing.T, test *TestCase) *http.Client {
 	a := assert.New(t)
 
-	client := cleanhttp.DefaultClient()
+	var client *http.Client
+	proxyURL, err := url.Parse(test.ProxyURL)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if test.OverConnect {
+		client = cleanhttp.DefaultClient()
 		client.Transport.(*http.Transport).DialContext =
 			func(ctx context.Context, network, addr string) (net.Conn, error) {
-				fmt.Println(addr)
-
 				var conn net.Conn
 
 				connectProxyReq, err := http.NewRequest(
 					"CONNECT",
-					fmt.Sprintf("http://%s", addr),
+					fmt.Sprintf("%s://%s", test.TargetScheme, addr),
 					nil)
 				if err != nil {
 					return nil, err
 				}
 
-				proxyURL, err := url.Parse(test.ProxyURL)
-				if err != nil {
-					return nil, err
-				}
 				if test.OverTls {
 					var certs []tls.Certificate
 
+					// Load client cert for role
 					if test.RoleName != "" {
-						// Client certs
 						certPath := fmt.Sprintf("testdata/pki/%s-client.pem", test.RoleName)
 						keyPath := fmt.Sprintf("testdata/pki/%s-client-key.pem", test.RoleName)
 						cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 						if err != nil {
 							return nil, err
 						}
-
 						certs = append(certs, cert)
 					}
 
@@ -207,7 +203,6 @@ func generateClientForTest(t *testing.T, test *TestCase) *http.Client {
 						return nil, err
 					}
 					conn = connRaw
-
 				} else {
 					connRaw, err := net.Dial(network, proxyURL.Host)
 					if err != nil {
@@ -217,20 +212,37 @@ func generateClientForTest(t *testing.T, test *TestCase) *http.Client {
 
 					// If we're not talking to the proxy over TLS, let's use headers as identifiers
 					connectProxyReq.Header.Add("X-Smokescreen-Role", "egressneedingservice-"+test.RoleName)
-					connectProxyReq.Header.Add("X-Random-Trace", fmt.Sprintf("%d", test.RandomTrace))
+					connectProxyReq.Header.Add("X-Smokescreen-Trace-ID", fmt.Sprintf("%d", test.RandomTrace))
 				}
 
-				buf := bytes.NewBuffer([]byte{})
-				connectProxyReq.Write(buf)
-				buf.Write([]byte{'\n'})
+				t.Logf("connect request: %#v", connectProxyReq)
+				connectProxyReq.Write(conn)
 
-				t.Logf("connect request: %#v", buf.String())
-
-				buf.WriteTo(conn)
-
-				// Todo: Catch the proxy response here and act on it.
+				// Read the response from the connect request and return an error for any non-200
+				// from smokescreen
+				br := bufio.NewReader(conn)
+				resp, err := http.ReadResponse(br, connectProxyReq)
+				if err != nil {
+					conn.Close()
+					return nil, err
+				}
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					resp, err := ioutil.ReadAll(resp.Body)
+					if err != nil {
+						return nil, err
+					}
+					conn.Close()
+					return nil, errors.New(string(resp))
+				}
 				return conn, nil
 			}
+	} else {
+		client = &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyURL(proxyURL),
+			},
+		}
 	}
 	return client
 }
@@ -238,22 +250,14 @@ func generateClientForTest(t *testing.T, test *TestCase) *http.Client {
 func generateRequestForTest(t *testing.T, test *TestCase) *http.Request {
 	a := assert.New(t)
 
-	var req *http.Request
-	var err error
-	if test.OverConnect {
-		// Target the external destination
-		target := fmt.Sprintf("http://%s:%d", test.Host, test.TargetPort)
-		req, err = http.NewRequest("GET", target, nil)
-	} else {
-		// Target the proxy
-		req, err = http.NewRequest("GET", test.ProxyURL, nil)
-		req.Host = fmt.Sprintf("%s:%d", test.Host, test.TargetPort)
-	}
+	target := fmt.Sprintf("%s://%s:%d", test.TargetScheme, test.TargetHost, test.TargetPort)
+	req, err := http.NewRequest("GET", target, nil)
 	a.NoError(err)
 
-	if !test.OverTls && !test.OverConnect { // If we're not talking to the proxy over TLS, let's use headers as identifiers
+	if !test.OverTls && !test.OverConnect {
+		// If we're not talking to the proxy over TLS, let's use headers as identifiers
 		req.Header.Add("X-Smokescreen-Role", "egressneedingservice-"+test.RoleName)
-		req.Header.Add("X-Random-Trace", fmt.Sprintf("%d", test.RandomTrace))
+		req.Header.Add("X-Smokescreen-Trace-ID", fmt.Sprintf("%d", test.RandomTrace))
 	}
 
 	t.Logf("HTTP Request: %#v", req)
@@ -264,11 +268,14 @@ func executeRequestForTest(t *testing.T, test *TestCase, logHook *logrustest.Hoo
 	t.Logf("Executing Request for test case %#v", test)
 
 	logHook.Reset()
-	client := generateClientForTest(t, test)
-	req := generateRequestForTest(t, test)
 
 	os.Setenv("http_proxy", test.UpstreamProxy)
 	os.Setenv("https_proxy", test.UpstreamProxy)
+	defer os.Unsetenv("http_proxy")
+	defer os.Unsetenv("https_proxy")
+
+	client := generateClientForTest(t, test)
+	req := generateRequestForTest(t, test)
 
 	return client.Do(req)
 }
@@ -276,13 +283,15 @@ func executeRequestForTest(t *testing.T, test *TestCase, logHook *logrustest.Hoo
 func TestSmokescreenIntegration(t *testing.T) {
 	r := require.New(t)
 
-	dummyServer := NewDummyServer()
+	// This local listener is used as the `authorizedHost` and given to
+	// dummyServer to return simple HTTP requests.
 	outsideListener, err := net.Listen("tcp4", "127.0.0.1:")
 	outsideListenerUrl, err := url.Parse(fmt.Sprintf("http://%s", outsideListener.Addr().String()))
 	r.NoError(err)
 	outsideListenerPort, err := strconv.Atoi(outsideListenerUrl.Port())
 	r.NoError(err)
 
+	dummyServer := NewDummyServer()
 	go dummyServer.Serve(outsideListener)
 
 	var logHook logrustest.Hook
@@ -306,30 +315,53 @@ func TestSmokescreenIntegration(t *testing.T) {
 
 	var testCases []*TestCase
 
+	// This generates all the permutations for the common test cases
 	for _, overConnect := range overConnectDomain {
 		for _, overTls := range overTlsDomain {
+			// Do not support this test case
 			if overTls && !overConnect {
-				// Is a super sketchy use case, let's not do that.
 				continue
 			}
 
 			for _, authorizedHost := range authorizedHostsDomain {
 				var host string
+				var port int
 				if authorizedHost {
 					host = "127.0.0.1"
-				} else { // localhost is not in the list of authorized targets
-					host = "localhost"
+					port = outsideListenerPort
+				} else {
+					host = "api.github.com"
+					port = 80
 				}
 
 				for _, action := range actionsDomain {
+					var expectAllow bool
+					// If a host is authorized, it is allowed by the config
+					// and will always be allowed.
+					if authorizedHost {
+						expectAllow = true
+					}
+
+					// Report and open modes should always allow requests.
+					if action != acl.Enforce {
+						expectAllow = true
+					}
+
+					targetScheme := "http"
+					if overTls {
+						targetScheme = "https"
+					}
+
 					testCase := &TestCase{
-						ExpectAllow: authorizedHost || action != acl.Enforce,
-						OverTls:     overTls,
-						OverConnect: overConnect,
-						ProxyURL:    servers[overTls].URL,
-						TargetPort:  outsideListenerPort,
-						Host:        host,
-						RoleName:    generateRoleForAction(action),
+						ExpectAllow:  expectAllow,
+						Action:       action,
+						OverTls:      overTls,
+						OverConnect:  overConnect,
+						ProxyURL:     servers[overTls].URL,
+						TargetPort:   port,
+						TargetHost:   host,
+						TargetScheme: targetScheme,
+						RoleName:     generateRoleForAction(action),
 					}
 					testCases = append(testCases, testCase)
 				}
@@ -337,54 +369,55 @@ func TestSmokescreenIntegration(t *testing.T) {
 		}
 
 		baseCase := TestCase{
-			OverConnect: overConnect,
-			ProxyURL:    servers[false].URL,
-			TargetPort:  outsideListenerPort,
+			OverConnect:  overConnect,
+			ProxyURL:     servers[false].URL,
+			TargetPort:   outsideListenerPort,
+			TargetScheme: "http",
 		}
 
+		// Empty roles should default deny per the test config
 		noRoleDenyCase := baseCase
-		noRoleDenyCase.Host = "127.0.0.1"
+		noRoleDenyCase.TargetHost = "127.0.0.1"
 		noRoleDenyCase.ExpectAllow = false
 
-		noRoleAllowCase := baseCase
-		noRoleAllowCase.Host = "localhost"
-		noRoleAllowCase.ExpectAllow = true
-
-		unknownRoleDenyCase := noRoleDenyCase
+		// Unknown roles should default deny per the test config
+		unknownRoleDenyCase := baseCase
+		unknownRoleDenyCase.TargetHost = "127.0.0.1"
 		unknownRoleDenyCase.RoleName = "unknown"
+		unknownRoleDenyCase.ExpectAllow = false
 
-		unknownRoleAllowCase := noRoleAllowCase
-		unknownRoleAllowCase.RoleName = "unknown"
-
-		badIPRangeCase := baseCase
 		// This must be a global unicast, non-loopback address or other IP rules will
 		// block it regardless of the specific configuration we're trying to test.
-		badIPRangeCase.Host = "1.1.1.1"
+		badIPRangeCase := baseCase
+		badIPRangeCase.TargetHost = "1.1.1.1"
 		badIPRangeCase.ExpectAllow = false
 		badIPRangeCase.RoleName = generateRoleForAction(acl.Open)
 
-		badIPAddressCase := baseCase
 		// This must be a global unicast, non-loopback address or other IP rules will
 		// block it regardless of the specific configuration we're trying to test.
-		badIPAddressCase.Host = "1.0.0.1"
+		badIPAddressCase := baseCase
+		badIPAddressCase.TargetHost = "1.0.0.1"
 		badIPAddressCase.TargetPort = 123
 		badIPAddressCase.ExpectAllow = false
 		badIPAddressCase.RoleName = generateRoleForAction(acl.Open)
 
-		proxyCase := baseCase
 		// We expect this URL to always return a non-200 status code so that
 		// this test will fail if we're not respecting the UpstreamProxy setting
 		// and instead going straight to this host.
-		proxyCase.Host = "aws.s3.amazonaws.com"
-		proxyCase.UpstreamProxy = outsideListenerUrl.String()
-		proxyCase.ExpectAllow = true
-		proxyCase.RoleName = generateRoleForAction(acl.Open)
+		if overConnect {
+			proxyCase := baseCase
+			proxyCase.TargetScheme = "https"
+			proxyCase.TargetHost = "aws.s3.amazonaws.com"
+			proxyCase.TargetPort = 443
+			proxyCase.UpstreamProxy = outsideListenerUrl.String()
+			proxyCase.ExpectAllow = true
+			proxyCase.RoleName = generateRoleForAction(acl.Open)
+			testCases = append(testCases, &proxyCase)
+		}
 
 		testCases = append(testCases,
-			&unknownRoleAllowCase, &unknownRoleDenyCase,
-			&noRoleAllowCase, &noRoleDenyCase,
+			&unknownRoleDenyCase, &noRoleDenyCase,
 			&badIPRangeCase, &badIPAddressCase,
-			&proxyCase,
 		)
 	}
 
@@ -393,24 +426,6 @@ func TestSmokescreenIntegration(t *testing.T) {
 			testCase.RandomTrace = rand.Int()
 			resp, err := executeRequestForTest(t, testCase, &logHook)
 			conformResult(t, testCase, resp, err, logHook.AllEntries())
-		})
-	}
-
-	// Passing an illegal upstream proxy value is not designed to be an especially well
-	// handled error so it would fail many of the checks in our other tests. We really
-	// only care to ensure that these requests never succeed.
-	for _, overConnect := range overConnectDomain {
-		t.Run(fmt.Sprintf("illegal proxy with CONNECT %t", overConnect), func(t *testing.T) {
-			testCase := &TestCase{
-				OverConnect:   overConnect,
-				ProxyURL:      servers[false].URL,
-				TargetPort:    outsideListenerPort,
-				Host:          "google.com",
-				UpstreamProxy: "http://127.0.0.2:80",
-				RoleName:      generateRoleForAction(acl.Open),
-			}
-			resp, err := executeRequestForTest(t, testCase, &logHook)
-			conformIllegalProxyResult(t, testCase, resp, err, logHook.AllEntries())
 		})
 	}
 }
@@ -429,7 +444,7 @@ func startSmokescreen(t *testing.T, useTls bool, logHook logrus.Hook) (*httptest
 		"smokescreen",
 		"--listen-ip=127.0.0.1",
 		"--egress-acl-file=testdata/sample_config.yaml",
-		"--additional-error-message-on-deny=moar ctx",
+		"--additional-error-message-on-deny=more ctx",
 		"--deny-range=1.1.1.1/32",
 		"--allow-range=127.0.0.1/32",
 		"--deny-address=1.0.0.1:123",
@@ -453,6 +468,8 @@ func startSmokescreen(t *testing.T, useTls bool, logHook logrus.Hook) (*httptest
 	} else {
 		conf.RoleFromRequest = testRFRHeader
 	}
+
+	conf.ConnectTimeout = time.Second
 
 	fmt.Printf("2 %#v\n", conf)
 	conf.Log.AddHook(logHook)

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -63,8 +63,8 @@ type TestCase struct {
 	UpstreamProxy string
 }
 
-// isValidProxyResponse validates tests cases and expected responses from TestSmokescreenIntegration
-func isValidProxyResponse(t *testing.T, test *TestCase, resp *http.Response, err error, logs []*logrus.Entry) {
+// validateProxyResponse validates tests cases and expected responses from TestSmokescreenIntegration
+func validateProxyResponse(t *testing.T, test *TestCase, resp *http.Response, err error, logs []*logrus.Entry) {
 	t.Logf("HTTP Response: %#v", resp)
 
 	a := assert.New(t)
@@ -430,17 +430,17 @@ func TestSmokescreenIntegration(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			testCase.RandomTrace = rand.Int()
 			resp, err := executeRequestForTest(t, testCase, &logHook)
-			isValidProxyResponse(t, testCase, resp, err, logHook.AllEntries())
+			validateProxyResponse(t, testCase, resp, err, logHook.AllEntries())
 		})
 	}
 }
 
-// isValidProxyResponseWithUpstream validates tests cases and expected responses
+// validateProxyResponseWithUpstream validates tests cases and expected responses
 // from TestUpstreamProxySmokescreenIntegration. This validates that requests
 // sent to a smokescreen instance with an additional upstream proxy set
 // (proxy chaining) forwards the request to the next proxy hop instead of directly
 // to the proxy target.
-func isValidProxyResponseWithUpstream(t *testing.T, test *TestCase, resp *http.Response, err error, logs []*logrus.Entry) {
+func validateProxyResponseWithUpstream(t *testing.T, test *TestCase, resp *http.Response, err error, logs []*logrus.Entry) {
 	a := assert.New(t)
 	t.Logf("HTTP Response: %#v", resp)
 
@@ -474,7 +474,7 @@ func TestInvalidUpstreamProxyConfiguration(t *testing.T) {
 			var proxyTarget string
 			var upstreamProxy string
 
-			// These proxy targets don't actually matter as the requests wont be sent.
+			// These proxy targets don't actually matter as the requests won't be sent.
 			// because the resolution of the upstream proxy will fail.
 			if overConnect {
 				upstreamProxy = "https://notaproxy.prxy.svc:443"
@@ -497,7 +497,7 @@ func TestInvalidUpstreamProxyConfiguration(t *testing.T) {
 			os.Setenv("https_proxy", testCase.UpstreamProxy)
 
 			resp, err := executeRequestForTest(t, testCase, &logHook)
-			isValidProxyResponseWithUpstream(t, testCase, resp, err, logHook.AllEntries())
+			validateProxyResponseWithUpstream(t, testCase, resp, err, logHook.AllEntries())
 
 			os.Unsetenv("http_proxy")
 			os.Unsetenv("https_proxy")

--- a/cmd/testdata/sample_config.yaml
+++ b/cmd/testdata/sample_config.yaml
@@ -6,15 +6,11 @@ services:
     project: test
     action: enforce
     allowed_domains:
-      - example.com
       - 127.0.0.1
-      - 2example.com
 
   - name: egressneedingservice-report
     project: test
     action: report
-    allowed_domains:
-      - 127.0.0.1
 
   - name: egressneedingservice-open
     project: test
@@ -24,5 +20,3 @@ default:
   name: unknown-role
   project: security
   action: enforce
-  allowed_domains:
-      - localhost


### PR DESCRIPTION
This PR fixes our long forgotten integration tests. They've been broken since I started working on Smokescreen and were never included as part of the CI pipeline.

There were a number of latent bugs and race conditions that made fixing these tests quite difficult.
* By not reading the response from the initial CONNECT request we were actually creating a race condition where the response was returned unsolicited to the returned HTTP client. These surfaced as runtime errors: `Unsolicited response received on idle HTTP channel`.
* It turns out setting and unsetting shared environment variables during tests is also not a good idea. Some of these tests depend on state in `http_proxy` and `https_proxy` and would race with one another. I've side stepped this by breaking out the dependent tests into their own test commands.
* We were incorrectly assuming that the `index-1` last log entry was the entry for `CANONICAL-PROXY-DECISION`. This was another race against the `CANONICAL-PROXY-CN-CLOSE` log line.

I also added comments to describe the intentions behind the checks and setup routines to hopefully make this easier for the next person who has to work with these tests. They still aren't perfect but should be in a much better state.

r? @ransford-stripe 
cc @stripe/platform-security 