### PR TITLE
log connection timeouts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,8 @@ require (
 	github.com/sirupsen/logrus v1.0.6
 	github.com/stretchr/testify v1.3.0
 	github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b
-	github.com/stripe/goproxy v0.0.0-20200414174713-2865e63fc811
+	github.com/stripe/goproxy v0.0.0-20200427190316-05fc299d1e72
+	golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 // indirect
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,11 +33,15 @@ github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b h1:RjOPjQht0WXH5
 github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b/go.mod h1:hkb6IH5oGd1qYMSCC8kjJCLwbCY8yFn/fABFwClTXTA=
 github.com/stripe/goproxy v0.0.0-20200414174713-2865e63fc811 h1:vOFzUYK4e73VQyZO6uTMQTyLceGnWuvCpjVtF/wwEKk=
 github.com/stripe/goproxy v0.0.0-20200414174713-2865e63fc811/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20200427190316-05fc299d1e72 h1:3DTs/WnMXgNtgdSGBGNq77az7y3cQ+Zqj4GYrJYt/8M=
+github.com/stripe/goproxy v0.0.0-20200427190316-05fc299d1e72/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 h1:Jcxah/M+oLZ/R4/z5RzfPzGbPXnVDPkEDtf2JnuxN+U=
+golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -248,7 +248,9 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	// Only wrap CONNECT conns with an InstrumentedConn. Connections used for traditional HTTP proxy
 	// requests are pooled and reused by net.Transport.
 	if sctx.proxyType == connectProxy {
-		conn = sctx.cfg.ConnTracker.NewInstrumentedConnWithTimeout(conn, sctx.cfg.IdleTimeout, sctx.traceId, d.role, d.outboundHost, sctx.proxyType)
+		ic := sctx.cfg.ConnTracker.NewInstrumentedConnWithTimeout(conn, sctx.cfg.IdleTimeout, sctx.traceId, d.role, d.outboundHost, sctx.proxyType)
+		pctx.ConnErrorHandler = ic.Error
+		conn = ic
 	} else {
 		conn = NewTimeoutConn(conn, sctx.cfg.IdleTimeout)
 	}

--- a/vendor/github.com/stripe/goproxy/ctx.go
+++ b/vendor/github.com/stripe/goproxy/ctx.go
@@ -19,6 +19,8 @@ type ProxyCtx struct {
 	// Will be invoked to return a custom response to clients when goproxy fails to connect
 	// to a proxy target
 	HTTPErrorHandler func(io.WriteCloser, *ProxyCtx, error)
+	// Used to pass back errors returned during calls to copyAndWarn() for TLS CONNECT requests
+	ConnErrorHandler func(error)
 	// A handle for the user to keep data in the context, from the call of ReqHandler to the
 	// call of RespHandler
 	UserData interface{}

--- a/vendor/github.com/stripe/goproxy/https.go
+++ b/vendor/github.com/stripe/goproxy/https.go
@@ -149,14 +149,30 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 			go copyAndClose(ctx, proxyClientTCP, targetTCP)
 		} else {
 			go func() {
+				var err error
 				var wg sync.WaitGroup
 				wg.Add(2)
-				go copyOrWarn(ctx, targetSiteCon, proxyClient, &wg)
-				go copyOrWarn(ctx, proxyClient, targetSiteCon, &wg)
+				// Only capture an error from one of the calls to copyOrWarn.
+				// copyOrWarn() is called twice with the same net.Conn pair with
+				// the src and dst parameters inverted. When the connection is
+				// terminated prematurely the net.Error type is the same, but
+				// the directionality of the Error() message changes.
+				go func() {
+					err = copyOrWarn(ctx, targetSiteCon, proxyClient)
+					wg.Done()
+				}()
+				go func() {
+					copyOrWarn(ctx, proxyClient, targetSiteCon)
+					wg.Done()
+				}()
 				wg.Wait()
+
+				if err != nil && ctx.ConnErrorHandler != nil {
+					ctx.ConnErrorHandler(err)
+				}
+
 				proxyClient.Close()
 				targetSiteCon.Close()
-
 			}()
 		}
 
@@ -330,11 +346,12 @@ func httpError(w io.WriteCloser, ctx *ProxyCtx, err error) {
 	}
 }
 
-func copyOrWarn(ctx *ProxyCtx, dst io.Writer, src io.Reader, wg *sync.WaitGroup) {
-	if _, err := io.Copy(dst, src); err != nil {
+func copyOrWarn(ctx *ProxyCtx, dst io.Writer, src io.Reader) error {
+	_, err := io.Copy(dst, src)
+	if err != nil {
 		ctx.Warnf("Error copying to client: %s", err)
 	}
-	wg.Done()
+	return err
 }
 
 func copyAndClose(ctx *ProxyCtx, dst, src *net.TCPConn) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -16,11 +16,11 @@ github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b
 github.com/stripe/go-einhorn/einhorn
-# github.com/stripe/goproxy v0.0.0-20200414174713-2865e63fc811
+# github.com/stripe/goproxy v0.0.0-20200427190316-05fc299d1e72
 github.com/stripe/goproxy
 # golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 golang.org/x/crypto/ssh/terminal
-# golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
+# golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0
 golang.org/x/net/http/httpproxy
 golang.org/x/net/idna
 # golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd


### PR DESCRIPTION
This PR logs errors returned by goproxy's `io.Copy` loop in `CANONICAL-PROXY-CN-CLOSE` log events. This feature was added in `stripe/goproxy` here: https://github.com/stripe/goproxy/pull/12.

The motivation for this PR is to log information which indicates a connection was closed due to a timeout.

I tested this overnight in QA and everything looks good. You can search for the new `timed_out` field in Splunk.

r? @hans-stripe 
cc @stripe/platform-security 