### PR TITLE
wait for a maximum of ExitTimeout when shutting down

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -629,6 +629,12 @@ func runServer(config *Config, server *http.Server, listener net.Listener, quit 
 			exit <- Closed
 		}()
 
+		// Always wait for a maximum of config.ExitTimeout
+		time.AfterFunc(config.ExitTimeout, func() {
+			config.Log.Printf("ExitTimeout %v reached - timing out", config.ExitTimeout)
+			exit <- Timeout
+		})
+
 		// Sometimes, connections don't close and remain in the idle state. This subroutine
 		// waits until all open connections are idle before sending the exit signal.
 		go func() {


### PR DESCRIPTION
r? @stripe/platform-security 

Previously we had assumed that `config.IdleTimeout` would be less than `config.ExitTimeout`. As we are ramping this with a large `IdleTimeout` we have to enforce that we only wait a maximum of `ExitTimeout` during graceful shutdowns.

This PR adds a goroutine which waits for `ExitTimeout` and then signals the shutdown to continue if it hasn't proceeded already.