### PR TITLE
small collection of logging improvements

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -110,9 +110,9 @@ func validateProxyResponse(t *testing.T, test *TestCase, resp *http.Response, er
 	}
 
 	if len(entries) > 0 {
-		entry := findLogEntry(entries, smokescreen.LOGLINE_CANONICAL_PROXY_DECISION)
+		entry := findLogEntry(entries, smokescreen.CanonicalProxyDecision)
 		a.NotNil(entry)
-		a.Equal(entry.Message, smokescreen.LOGLINE_CANONICAL_PROXY_DECISION)
+		a.Equal(entry.Message, smokescreen.CanonicalProxyDecision)
 
 		a.Contains(entry.Data, "allow")
 		a.Equal(test.ExpectAllow, entry.Data["allow"])

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.0.0-20171218145408-d5fe4b57a186
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
+	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.0.6
 	github.com/stretchr/testify v1.3.0
 	github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-charset v0.0.0-20190617161244-0dc95cdf6f31/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
+github.com/rs/xid v1.2.1 h1:mhH9Nq+C1fY2l1XIpgxIiUOfNpRBYH1kKcr+qfKgjRc=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/sirupsen/logrus v1.0.6 h1:hcP1GmhGigz/O7h1WVUM5KklBp1JoNS9FggWKdj/j3s=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
@@ -31,8 +33,6 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b h1:RjOPjQht0WXH5A3LBzhYmx/35THM/mxH/QvjmzTABcQ=
 github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b/go.mod h1:hkb6IH5oGd1qYMSCC8kjJCLwbCY8yFn/fABFwClTXTA=
-github.com/stripe/goproxy v0.0.0-20200414174713-2865e63fc811 h1:vOFzUYK4e73VQyZO6uTMQTyLceGnWuvCpjVtF/wwEKk=
-github.com/stripe/goproxy v0.0.0-20200414174713-2865e63fc811/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/stripe/goproxy v0.0.0-20200427190316-05fc299d1e72 h1:3DTs/WnMXgNtgdSGBGNq77az7y3cQ+Zqj4GYrJYt/8M=
 github.com/stripe/goproxy v0.0.0-20200427190316-05fc299d1e72/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=

--- a/pkg/smokescreen/conntrack/conn_tracker.go
+++ b/pkg/smokescreen/conntrack/conn_tracker.go
@@ -13,7 +13,6 @@ type Tracker struct {
 	*sync.Map
 	ShuttingDown atomic.Value
 	Wg           *sync.WaitGroup
-	Log          *logrus.Logger
 	statsc       *statsd.Client
 
 	// A connection is idle if it has been inactive (no bytes in/out) for this
@@ -27,7 +26,6 @@ func NewTracker(idle time.Duration, statsc *statsd.Client, logger *logrus.Logger
 		ShuttingDown: sd,
 		Wg:           &sync.WaitGroup{},
 		IdleTimeout:  idle,
-		Log:          logger,
 		statsc:       statsc,
 	}
 }

--- a/pkg/smokescreen/conntrack/conn_tracker_test.go
+++ b/pkg/smokescreen/conntrack/conn_tracker_test.go
@@ -10,12 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var testLogger = logrus.New()
+
 // TestConnTrackerDelete is a sanity check to ensure we aren't leaking
 // connection references in the tracker's sync.Map
 func TestConnTrackerDelete(t *testing.T) {
 	tr := NewTestTracker(time.Second * 1)
 
-	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testid", "testDeleteConn", "localhost", "http")
+	ic := tr.NewInstrumentedConn(&net.UnixConn{}, logrus.NewEntry(testLogger), "testDeleteConn", "localhost", "http")
 	ic.Close()
 
 	tr.Range(func(k, v interface{}) bool {
@@ -29,7 +31,7 @@ func TestConnTrackerMaybeIdleIn(t *testing.T) {
 	assert := assert.New(t)
 
 	tr := NewTestTracker(time.Nanosecond)
-	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testid", "testMaybeIdle", "localhost", "http")
+	ic := tr.NewInstrumentedConn(&net.UnixConn{}, logrus.NewEntry(testLogger), "testMaybeIdle", "localhost", "http")
 
 	time.Sleep(time.Millisecond)
 

--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -112,11 +112,11 @@ func (ic *InstrumentedConn) Close() error {
 		}
 	}
 
-	var dstIP, dstIPStr string
+	var dstIP, dstPortStr string
 	var dstPort int
 	if remoteAddr := ic.Conn.RemoteAddr(); remoteAddr != nil {
-		dstIP, dstIPStr, _ = net.SplitHostPort(remoteAddr.String())
-		dstPort, _ = strconv.Atoi(dstIPStr)
+		dstIP, dstPortStr, _ = net.SplitHostPort(remoteAddr.String())
+		dstPort, _ = strconv.Atoi(dstPortStr)
 	}
 
 	ic.logger.WithFields(logrus.Fields{

--- a/pkg/smokescreen/conntrack/instrumented_conn_test.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,7 +37,7 @@ func TestInstrumentedConnByteCounting(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		icWriter := tr.NewInstrumentedConn(conn, "testid", "test", "localhost", "http")
+		icWriter := tr.NewInstrumentedConn(conn, logrus.NewEntry(testLogger), "test", "localhost", "http")
 
 		n, err := icWriter.Write(sent)
 		if err != nil {
@@ -52,7 +53,7 @@ func TestInstrumentedConnByteCounting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	icReader := tr.NewInstrumentedConn(conn, "testid", "testBytesInOut", "localhost", "http")
+	icReader := tr.NewInstrumentedConn(conn, logrus.NewEntry(testLogger), "testBytesInOut", "localhost", "http")
 
 	go func() {
 		defer wg.Done()
@@ -77,7 +78,7 @@ func TestInstrumentedConnIdle(t *testing.T) {
 	assert := assert.New(t)
 
 	tr := NewTestTracker(time.Millisecond)
-	ic := tr.NewInstrumentedConn(&net.UnixConn{}, "testid", "testIdle", "localhost", "egress")
+	ic := tr.NewInstrumentedConn(&net.UnixConn{}, logrus.NewEntry(testLogger), "testIdle", "localhost", "egress")
 
 	ic.Write([]byte("egress"))
 	assert.False(ic.Idle())
@@ -124,7 +125,7 @@ func TestInstrumentedConnWithTimeout(t *testing.T) {
 		}
 
 		var b [1]byte
-		ic := tr.NewInstrumentedConnWithTimeout(c, tt.timeout, "", "test", "testHost", "http")
+		ic := tr.NewInstrumentedConnWithTimeout(c, tt.timeout, logrus.NewEntry(testLogger), "test", "testHost", "http")
 
 		_, err = ic.Read(b[:])
 		if err == nil && tt.expectedError {

--- a/pkg/smokescreen/conntrack/stats.go
+++ b/pkg/smokescreen/conntrack/stats.go
@@ -3,7 +3,6 @@ package conntrack
 import "time"
 
 type InstrumentedConnStats struct {
-	TraceId                  string    `json:"trace_id"`
 	Role                     string    `json:"role"`
 	Rhost                    string    `json:"rhost"`
 	Raddr                    string    `json:"raddr"`

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -538,7 +538,7 @@ func TestProxyTimeouts(t *testing.T) {
 
 func findCanonicalProxyDecision(logs []*logrus.Entry) *logrus.Entry {
 	for _, entry := range logs {
-		if entry.Message == LOGLINE_CANONICAL_PROXY_DECISION {
+		if entry.Message == CanonicalProxyDecision {
 			return entry
 		}
 	}

--- a/vendor/github.com/rs/xid/.appveyor.yml
+++ b/vendor/github.com/rs/xid/.appveyor.yml
@@ -1,0 +1,27 @@
+version: 1.0.0.{build}
+
+platform: x64
+
+branches:
+  only:
+    - master
+
+clone_folder: c:\gopath\src\github.com\rs\xid
+
+environment:
+  GOPATH: c:\gopath
+
+install:
+  - echo %PATH%
+  - echo %GOPATH%
+  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
+  - go version
+  - go env
+  - go get -t .
+
+build_script:
+  - go build
+
+test_script:
+  - go test
+

--- a/vendor/github.com/rs/xid/.travis.yml
+++ b/vendor/github.com/rs/xid/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go:
+- "1.9"
+- "1.10"
+- "master"
+matrix:
+  allow_failures:
+      - go: "master"

--- a/vendor/github.com/rs/xid/LICENSE
+++ b/vendor/github.com/rs/xid/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015 Olivier Poitrey <rs@dailymotion.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/rs/xid/README.md
+++ b/vendor/github.com/rs/xid/README.md
@@ -1,0 +1,112 @@
+# Globally Unique ID Generator
+
+[![godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/rs/xid) [![license](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://raw.githubusercontent.com/rs/xid/master/LICENSE) [![Build Status](https://travis-ci.org/rs/xid.svg?branch=master)](https://travis-ci.org/rs/xid) [![Coverage](http://gocover.io/_badge/github.com/rs/xid)](http://gocover.io/github.com/rs/xid)
+
+Package xid is a globally unique id generator library, ready to be used safely directly in your server code.
+
+Xid is using Mongo Object ID algorithm to generate globally unique ids with a different serialization (base64) to make it shorter when transported as a string:
+https://docs.mongodb.org/manual/reference/object-id/
+
+- 4-byte value representing the seconds since the Unix epoch,
+- 3-byte machine identifier,
+- 2-byte process id, and
+- 3-byte counter, starting with a random value.
+
+The binary representation of the id is compatible with Mongo 12 bytes Object IDs.
+The string representation is using base32 hex (w/o padding) for better space efficiency
+when stored in that form (20 bytes). The hex variant of base32 is used to retain the
+sortable property of the id.
+
+Xid doesn't use base64 because case sensitivity and the 2 non alphanum chars may be an
+issue when transported as a string between various systems. Base36 wasn't retained either
+because 1/ it's not standard 2/ the resulting size is not predictable (not bit aligned)
+and 3/ it would not remain sortable. To validate a base32 `xid`, expect a 20 chars long,
+all lowercase sequence of `a` to `v` letters and `0` to `9` numbers (`[0-9a-v]{20}`).
+
+UUIDs are 16 bytes (128 bits) and 36 chars as string representation. Twitter Snowflake
+ids are 8 bytes (64 bits) but require machine/data-center configuration and/or central
+generator servers. xid stands in between with 12 bytes (96 bits) and a more compact
+URL-safe string representation (20 chars). No configuration or central generator server
+is required so it can be used directly in server's code.
+
+| Name        | Binary Size | String Size    | Features
+|-------------|-------------|----------------|----------------
+| [UUID]      | 16 bytes    | 36 chars       | configuration free, not sortable
+| [shortuuid] | 16 bytes    | 22 chars       | configuration free, not sortable
+| [Snowflake] | 8 bytes     | up to 20 chars | needs machin/DC configuration, needs central server, sortable
+| [MongoID]   | 12 bytes    | 24 chars       | configuration free, sortable
+| xid         | 12 bytes    | 20 chars       | configuration free, sortable
+
+[UUID]: https://en.wikipedia.org/wiki/Universally_unique_identifier
+[shortuuid]: https://github.com/stochastic-technologies/shortuuid
+[Snowflake]: https://blog.twitter.com/2010/announcing-snowflake
+[MongoID]: https://docs.mongodb.org/manual/reference/object-id/
+
+Features:
+
+- Size: 12 bytes (96 bits), smaller than UUID, larger than snowflake
+- Base32 hex encoded by default (20 chars when transported as printable string, still sortable)
+- Non configured, you don't need set a unique machine and/or data center id
+- K-ordered
+- Embedded time with 1 second precision
+- Unicity guaranteed for 16,777,216 (24 bits) unique ids per second and per host/process
+- Lock-free (i.e.: unlike UUIDv1 and v2)
+
+Best used with [zerolog](https://github.com/rs/zerolog)'s
+[RequestIDHandler](https://godoc.org/github.com/rs/zerolog/hlog#RequestIDHandler).
+
+Notes:
+
+- Xid is dependent on the system time, a monotonic counter and so is not cryptographically secure. If unpredictability of IDs is important, you should not use Xids. It is worth noting that most of the other UUID like implementations are also not cryptographically secure. You shoud use libraries that rely on cryptographically secure sources (like /dev/urandom on unix, crypto/rand in golang), if you want a truly random ID generator.
+
+References:
+
+- http://www.slideshare.net/davegardnerisme/unique-id-generation-in-distributed-systems
+- https://en.wikipedia.org/wiki/Universally_unique_identifier
+- https://blog.twitter.com/2010/announcing-snowflake
+- Python port by [Graham Abbott](https://github.com/graham): https://github.com/graham/python_xid
+- Scala port by [Egor Kolotaev](https://github.com/kolotaev): https://github.com/kolotaev/ride
+
+## Install
+
+    go get github.com/rs/xid
+
+## Usage
+
+```go
+guid := xid.New()
+
+println(guid.String())
+// Output: 9m4e2mr0ui3e8a215n4g
+```
+
+Get `xid` embedded info:
+
+```go
+guid.Machine()
+guid.Pid()
+guid.Time()
+guid.Counter()
+```
+
+## Benchmark
+
+Benchmark against Go [Maxim Bublis](https://github.com/satori)'s [UUID](https://github.com/satori/go.uuid).
+
+```
+BenchmarkXID        	20000000	        91.1 ns/op	      32 B/op	       1 allocs/op
+BenchmarkXID-2      	20000000	        55.9 ns/op	      32 B/op	       1 allocs/op
+BenchmarkXID-4      	50000000	        32.3 ns/op	      32 B/op	       1 allocs/op
+BenchmarkUUIDv1     	10000000	       204 ns/op	      48 B/op	       1 allocs/op
+BenchmarkUUIDv1-2   	10000000	       160 ns/op	      48 B/op	       1 allocs/op
+BenchmarkUUIDv1-4   	10000000	       195 ns/op	      48 B/op	       1 allocs/op
+BenchmarkUUIDv4     	 1000000	      1503 ns/op	      64 B/op	       2 allocs/op
+BenchmarkUUIDv4-2   	 1000000	      1427 ns/op	      64 B/op	       2 allocs/op
+BenchmarkUUIDv4-4   	 1000000	      1452 ns/op	      64 B/op	       2 allocs/op
+```
+
+Note: UUIDv1 requires a global lock, hence the performence degrading as we add more CPUs.
+
+## Licenses
+
+All source code is licensed under the [MIT License](https://raw.github.com/rs/xid/master/LICENSE).

--- a/vendor/github.com/rs/xid/go.mod
+++ b/vendor/github.com/rs/xid/go.mod
@@ -1,0 +1,1 @@
+module github.com/rs/xid

--- a/vendor/github.com/rs/xid/hostid_darwin.go
+++ b/vendor/github.com/rs/xid/hostid_darwin.go
@@ -1,0 +1,9 @@
+// +build darwin
+
+package xid
+
+import "syscall"
+
+func readPlatformMachineID() (string, error) {
+	return syscall.Sysctl("kern.uuid")
+}

--- a/vendor/github.com/rs/xid/hostid_fallback.go
+++ b/vendor/github.com/rs/xid/hostid_fallback.go
@@ -1,0 +1,9 @@
+// +build !darwin,!linux,!freebsd,!windows
+
+package xid
+
+import "errors"
+
+func readPlatformMachineID() (string, error) {
+	return "", errors.New("not implemented")
+}

--- a/vendor/github.com/rs/xid/hostid_freebsd.go
+++ b/vendor/github.com/rs/xid/hostid_freebsd.go
@@ -1,0 +1,9 @@
+// +build freebsd
+
+package xid
+
+import "syscall"
+
+func readPlatformMachineID() (string, error) {
+	return syscall.Sysctl("kern.hostuuid")
+}

--- a/vendor/github.com/rs/xid/hostid_linux.go
+++ b/vendor/github.com/rs/xid/hostid_linux.go
@@ -1,0 +1,10 @@
+// +build linux
+
+package xid
+
+import "io/ioutil"
+
+func readPlatformMachineID() (string, error) {
+	b, err := ioutil.ReadFile("/sys/class/dmi/id/product_uuid")
+	return string(b), err
+}

--- a/vendor/github.com/rs/xid/hostid_windows.go
+++ b/vendor/github.com/rs/xid/hostid_windows.go
@@ -1,0 +1,38 @@
+// +build windows
+
+package xid
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+func readPlatformMachineID() (string, error) {
+	// source: https://github.com/shirou/gopsutil/blob/master/host/host_syscall.go
+	var h syscall.Handle
+	err := syscall.RegOpenKeyEx(syscall.HKEY_LOCAL_MACHINE, syscall.StringToUTF16Ptr(`SOFTWARE\Microsoft\Cryptography`), 0, syscall.KEY_READ|syscall.KEY_WOW64_64KEY, &h)
+	if err != nil {
+		return "", err
+	}
+	defer syscall.RegCloseKey(h)
+
+	const syscallRegBufLen = 74 // len(`{`) + len(`abcdefgh-1234-456789012-123345456671` * 2) + len(`}`) // 2 == bytes/UTF16
+	const uuidLen = 36
+
+	var regBuf [syscallRegBufLen]uint16
+	bufLen := uint32(syscallRegBufLen)
+	var valType uint32
+	err = syscall.RegQueryValueEx(h, syscall.StringToUTF16Ptr(`MachineGuid`), nil, &valType, (*byte)(unsafe.Pointer(&regBuf[0])), &bufLen)
+	if err != nil {
+		return "", err
+	}
+
+	hostID := syscall.UTF16ToString(regBuf[:])
+	hostIDLen := len(hostID)
+	if hostIDLen != uuidLen {
+		return "", fmt.Errorf("HostID incorrect: %q\n", hostID)
+	}
+
+	return hostID, nil
+}

--- a/vendor/github.com/rs/xid/id.go
+++ b/vendor/github.com/rs/xid/id.go
@@ -1,0 +1,365 @@
+// Package xid is a globally unique id generator suited for web scale
+//
+// Xid is using Mongo Object ID algorithm to generate globally unique ids:
+// https://docs.mongodb.org/manual/reference/object-id/
+//
+//   - 4-byte value representing the seconds since the Unix epoch,
+//   - 3-byte machine identifier,
+//   - 2-byte process id, and
+//   - 3-byte counter, starting with a random value.
+//
+// The binary representation of the id is compatible with Mongo 12 bytes Object IDs.
+// The string representation is using base32 hex (w/o padding) for better space efficiency
+// when stored in that form (20 bytes). The hex variant of base32 is used to retain the
+// sortable property of the id.
+//
+// Xid doesn't use base64 because case sensitivity and the 2 non alphanum chars may be an
+// issue when transported as a string between various systems. Base36 wasn't retained either
+// because 1/ it's not standard 2/ the resulting size is not predictable (not bit aligned)
+// and 3/ it would not remain sortable. To validate a base32 `xid`, expect a 20 chars long,
+// all lowercase sequence of `a` to `v` letters and `0` to `9` numbers (`[0-9a-v]{20}`).
+//
+// UUID is 16 bytes (128 bits), snowflake is 8 bytes (64 bits), xid stands in between
+// with 12 bytes with a more compact string representation ready for the web and no
+// required configuration or central generation server.
+//
+// Features:
+//
+//   - Size: 12 bytes (96 bits), smaller than UUID, larger than snowflake
+//   - Base32 hex encoded by default (16 bytes storage when transported as printable string)
+//   - Non configured, you don't need set a unique machine and/or data center id
+//   - K-ordered
+//   - Embedded time with 1 second precision
+//   - Unicity guaranteed for 16,777,216 (24 bits) unique ids per second and per host/process
+//
+// Best used with xlog's RequestIDHandler (https://godoc.org/github.com/rs/xlog#RequestIDHandler).
+//
+// References:
+//
+//   - http://www.slideshare.net/davegardnerisme/unique-id-generation-in-distributed-systems
+//   - https://en.wikipedia.org/wiki/Universally_unique_identifier
+//   - https://blog.twitter.com/2010/announcing-snowflake
+package xid
+
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/rand"
+	"database/sql/driver"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io/ioutil"
+	"os"
+	"sort"
+	"sync/atomic"
+	"time"
+)
+
+// Code inspired from mgo/bson ObjectId
+
+// ID represents a unique request id
+type ID [rawLen]byte
+
+const (
+	encodedLen = 20 // string encoded len
+	rawLen     = 12 // binary raw len
+
+	// encoding stores a custom version of the base32 encoding with lower case
+	// letters.
+	encoding = "0123456789abcdefghijklmnopqrstuv"
+)
+
+var (
+	// ErrInvalidID is returned when trying to unmarshal an invalid ID
+	ErrInvalidID = errors.New("xid: invalid ID")
+
+	// objectIDCounter is atomically incremented when generating a new ObjectId
+	// using NewObjectId() function. It's used as a counter part of an id.
+	// This id is initialized with a random value.
+	objectIDCounter = randInt()
+
+	// machineId stores machine id generated once and used in subsequent calls
+	// to NewObjectId function.
+	machineID = readMachineID()
+
+	// pid stores the current process id
+	pid = os.Getpid()
+
+	nilID ID
+
+	// dec is the decoding map for base32 encoding
+	dec [256]byte
+)
+
+func init() {
+	for i := 0; i < len(dec); i++ {
+		dec[i] = 0xFF
+	}
+	for i := 0; i < len(encoding); i++ {
+		dec[encoding[i]] = byte(i)
+	}
+
+	// If /proc/self/cpuset exists and is not /, we can assume that we are in a
+	// form of container and use the content of cpuset xor-ed with the PID in
+	// order get a reasonable machine global unique PID.
+	b, err := ioutil.ReadFile("/proc/self/cpuset")
+	if err == nil && len(b) > 1 {
+		pid ^= int(crc32.ChecksumIEEE(b))
+	}
+}
+
+// readMachineId generates machine id and puts it into the machineId global
+// variable. If this function fails to get the hostname, it will cause
+// a runtime error.
+func readMachineID() []byte {
+	id := make([]byte, 3)
+	hid, err := readPlatformMachineID()
+	if err != nil || len(hid) == 0 {
+		hid, err = os.Hostname()
+	}
+	if err == nil && len(hid) != 0 {
+		hw := md5.New()
+		hw.Write([]byte(hid))
+		copy(id, hw.Sum(nil))
+	} else {
+		// Fallback to rand number if machine id can't be gathered
+		if _, randErr := rand.Reader.Read(id); randErr != nil {
+			panic(fmt.Errorf("xid: cannot get hostname nor generate a random number: %v; %v", err, randErr))
+		}
+	}
+	return id
+}
+
+// randInt generates a random uint32
+func randInt() uint32 {
+	b := make([]byte, 3)
+	if _, err := rand.Reader.Read(b); err != nil {
+		panic(fmt.Errorf("xid: cannot generate random number: %v;", err))
+	}
+	return uint32(b[0])<<16 | uint32(b[1])<<8 | uint32(b[2])
+}
+
+// New generates a globally unique ID
+func New() ID {
+	return NewWithTime(time.Now())
+}
+
+// NewWithTime generates a globally unique ID with the passed in time
+func NewWithTime(t time.Time) ID {
+	var id ID
+	// Timestamp, 4 bytes, big endian
+	binary.BigEndian.PutUint32(id[:], uint32(t.Unix()))
+	// Machine, first 3 bytes of md5(hostname)
+	id[4] = machineID[0]
+	id[5] = machineID[1]
+	id[6] = machineID[2]
+	// Pid, 2 bytes, specs don't specify endianness, but we use big endian.
+	id[7] = byte(pid >> 8)
+	id[8] = byte(pid)
+	// Increment, 3 bytes, big endian
+	i := atomic.AddUint32(&objectIDCounter, 1)
+	id[9] = byte(i >> 16)
+	id[10] = byte(i >> 8)
+	id[11] = byte(i)
+	return id
+}
+
+// FromString reads an ID from its string representation
+func FromString(id string) (ID, error) {
+	i := &ID{}
+	err := i.UnmarshalText([]byte(id))
+	return *i, err
+}
+
+// String returns a base32 hex lowercased with no padding representation of the id (char set is 0-9, a-v).
+func (id ID) String() string {
+	text := make([]byte, encodedLen)
+	encode(text, id[:])
+	return string(text)
+}
+
+// MarshalText implements encoding/text TextMarshaler interface
+func (id ID) MarshalText() ([]byte, error) {
+	text := make([]byte, encodedLen)
+	encode(text, id[:])
+	return text, nil
+}
+
+// MarshalJSON implements encoding/json Marshaler interface
+func (id ID) MarshalJSON() ([]byte, error) {
+	if id.IsNil() {
+		return []byte("null"), nil
+	}
+	text, err := id.MarshalText()
+	return []byte(`"` + string(text) + `"`), err
+}
+
+// encode by unrolling the stdlib base32 algorithm + removing all safe checks
+func encode(dst, id []byte) {
+	dst[0] = encoding[id[0]>>3]
+	dst[1] = encoding[(id[1]>>6)&0x1F|(id[0]<<2)&0x1F]
+	dst[2] = encoding[(id[1]>>1)&0x1F]
+	dst[3] = encoding[(id[2]>>4)&0x1F|(id[1]<<4)&0x1F]
+	dst[4] = encoding[id[3]>>7|(id[2]<<1)&0x1F]
+	dst[5] = encoding[(id[3]>>2)&0x1F]
+	dst[6] = encoding[id[4]>>5|(id[3]<<3)&0x1F]
+	dst[7] = encoding[id[4]&0x1F]
+	dst[8] = encoding[id[5]>>3]
+	dst[9] = encoding[(id[6]>>6)&0x1F|(id[5]<<2)&0x1F]
+	dst[10] = encoding[(id[6]>>1)&0x1F]
+	dst[11] = encoding[(id[7]>>4)&0x1F|(id[6]<<4)&0x1F]
+	dst[12] = encoding[id[8]>>7|(id[7]<<1)&0x1F]
+	dst[13] = encoding[(id[8]>>2)&0x1F]
+	dst[14] = encoding[(id[9]>>5)|(id[8]<<3)&0x1F]
+	dst[15] = encoding[id[9]&0x1F]
+	dst[16] = encoding[id[10]>>3]
+	dst[17] = encoding[(id[11]>>6)&0x1F|(id[10]<<2)&0x1F]
+	dst[18] = encoding[(id[11]>>1)&0x1F]
+	dst[19] = encoding[(id[11]<<4)&0x1F]
+}
+
+// UnmarshalText implements encoding/text TextUnmarshaler interface
+func (id *ID) UnmarshalText(text []byte) error {
+	if len(text) != encodedLen {
+		return ErrInvalidID
+	}
+	for _, c := range text {
+		if dec[c] == 0xFF {
+			return ErrInvalidID
+		}
+	}
+	decode(id, text)
+	return nil
+}
+
+// UnmarshalJSON implements encoding/json Unmarshaler interface
+func (id *ID) UnmarshalJSON(b []byte) error {
+	s := string(b)
+	if s == "null" {
+		*id = nilID
+		return nil
+	}
+	return id.UnmarshalText(b[1 : len(b)-1])
+}
+
+// decode by unrolling the stdlib base32 algorithm + removing all safe checks
+func decode(id *ID, src []byte) {
+	id[0] = dec[src[0]]<<3 | dec[src[1]]>>2
+	id[1] = dec[src[1]]<<6 | dec[src[2]]<<1 | dec[src[3]]>>4
+	id[2] = dec[src[3]]<<4 | dec[src[4]]>>1
+	id[3] = dec[src[4]]<<7 | dec[src[5]]<<2 | dec[src[6]]>>3
+	id[4] = dec[src[6]]<<5 | dec[src[7]]
+	id[5] = dec[src[8]]<<3 | dec[src[9]]>>2
+	id[6] = dec[src[9]]<<6 | dec[src[10]]<<1 | dec[src[11]]>>4
+	id[7] = dec[src[11]]<<4 | dec[src[12]]>>1
+	id[8] = dec[src[12]]<<7 | dec[src[13]]<<2 | dec[src[14]]>>3
+	id[9] = dec[src[14]]<<5 | dec[src[15]]
+	id[10] = dec[src[16]]<<3 | dec[src[17]]>>2
+	id[11] = dec[src[17]]<<6 | dec[src[18]]<<1 | dec[src[19]]>>4
+}
+
+// Time returns the timestamp part of the id.
+// It's a runtime error to call this method with an invalid id.
+func (id ID) Time() time.Time {
+	// First 4 bytes of ObjectId is 32-bit big-endian seconds from epoch.
+	secs := int64(binary.BigEndian.Uint32(id[0:4]))
+	return time.Unix(secs, 0)
+}
+
+// Machine returns the 3-byte machine id part of the id.
+// It's a runtime error to call this method with an invalid id.
+func (id ID) Machine() []byte {
+	return id[4:7]
+}
+
+// Pid returns the process id part of the id.
+// It's a runtime error to call this method with an invalid id.
+func (id ID) Pid() uint16 {
+	return binary.BigEndian.Uint16(id[7:9])
+}
+
+// Counter returns the incrementing value part of the id.
+// It's a runtime error to call this method with an invalid id.
+func (id ID) Counter() int32 {
+	b := id[9:12]
+	// Counter is stored as big-endian 3-byte value
+	return int32(uint32(b[0])<<16 | uint32(b[1])<<8 | uint32(b[2]))
+}
+
+// Value implements the driver.Valuer interface.
+func (id ID) Value() (driver.Value, error) {
+	if id.IsNil() {
+		return nil, nil
+	}
+	b, err := id.MarshalText()
+	return string(b), err
+}
+
+// Scan implements the sql.Scanner interface.
+func (id *ID) Scan(value interface{}) (err error) {
+	switch val := value.(type) {
+	case string:
+		return id.UnmarshalText([]byte(val))
+	case []byte:
+		return id.UnmarshalText(val)
+	case nil:
+		*id = nilID
+		return nil
+	default:
+		return fmt.Errorf("xid: scanning unsupported type: %T", value)
+	}
+}
+
+// IsNil Returns true if this is a "nil" ID
+func (id ID) IsNil() bool {
+	return id == nilID
+}
+
+// NilID returns a zero value for `xid.ID`.
+func NilID() ID {
+	return nilID
+}
+
+// Bytes returns the byte array representation of `ID`
+func (id ID) Bytes() []byte {
+	return id[:]
+}
+
+// FromBytes convert the byte array representation of `ID` back to `ID`
+func FromBytes(b []byte) (ID, error) {
+	var id ID
+	if len(b) != rawLen {
+		return id, ErrInvalidID
+	}
+	copy(id[:], b)
+	return id, nil
+}
+
+// Compare returns an integer comparing two IDs. It behaves just like `bytes.Compare`.
+// The result will be 0 if two IDs are identical, -1 if current id is less than the other one,
+// and 1 if current id is greater than the other.
+func (id ID) Compare(other ID) int {
+	return bytes.Compare(id[:], other[:])
+}
+
+type sorter []ID
+
+func (s sorter) Len() int {
+	return len(s)
+}
+
+func (s sorter) Less(i, j int) bool {
+	return s[i].Compare(s[j]) < 0
+}
+
+func (s sorter) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Sort sorts an array of IDs inplace.
+// It works by wrapping `[]ID` and use `sort.Sort`.
+func Sort(ids []ID) {
+	sort.Sort(sorter(ids))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew/spew
 github.com/hashicorp/go-cleanhttp
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
+# github.com/rs/xid v1.2.1
+github.com/rs/xid
 # github.com/sirupsen/logrus v1.0.6
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/test


### PR DESCRIPTION
This PR contains a number of small improvements to Smokescreen's logging:
* Use a request scoped `logrus.Entry` attached to the request's context to log common fields. This logger is shared with `InstrumentedConn`s to ensure that field names are consistent.
* Added an `id` field to simplify pairing `CANONICAL-PROXY-DECISION` and `CANONICAL-PROXY-CN-CLOSE` events.
* Lifted `CONNECT` logging calls to the `OnConnect` handler to match how HTTP proxy requests are logged.
* Removed `trace_id` as a struct member, as it is now passed by the `logrus.Entry`.
* Removed the `idle` field logged during `CANONICAL-PROXY-CN-CLOSE` events as this field was unintuitive and not actually indicative of the connection being idle. It was replaced by the field `active_at_termination` which will only be emitted if Smokescreen is in the process of shutting down.
* Added a `last_activity` timestamp which is logged for every `CANONICAL-PROXY-CN-CLOSE`.

There were existing tests which hooked into logrus to check that the correct log fields are being emitted.

r? @hans-stripe 
cc @stripe/platform-security 