### PR TITLE
only emit active_at_termination if the conn is not idle

### DIFF
--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -96,7 +96,7 @@ func (ic *InstrumentedConn) Close() error {
 
 	// Track when we terminate active connections during a shutdown
 	if ic.tracker.ShuttingDown.Load() == true {
-		if ic.Idle() {
+		if !ic.Idle() {
 			ic.logger = ic.logger.WithField("active_at_termination", true)
 			ic.tracker.statsc.Incr("cn.active_at_termination", tags, 1)
 		}


### PR DESCRIPTION
Fixes an incorrect boolean check. The metric should only be emitted if an active connection is being closed at shut down.

r? @ransford-stripe 
cc @stripe/platform-security 