### PR TITLE
add logging for failed net.Dials

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -241,6 +241,10 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	sctx.cfg.StatsdClient.Incr("cn.atpt.total", []string{}, 1)
 	conn, err := net.DialTimeout(network, d.resolvedAddr.String(), sctx.cfg.ConnectTimeout)
 	if err != nil {
+		sctx.logger.WithFields(logrus.Fields{
+			"error":   err.Error(),
+			"address": d.resolvedAddr.String(),
+		}).Error("failed to dial proxy target")
 		sctx.cfg.StatsdClient.Incr("cn.atpt.fail.total", []string{}, 1)
 		return nil, err
 	}

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -528,6 +528,9 @@ func TestProxyTimeouts(t *testing.T) {
 		r.Error(err)
 		r.Contains(err.Error(), "EOF")
 
+		// Wait for all InstrumentedConns to close
+		cfg.ConnTracker.Wg.Wait()
+
 		entry := findCanonicalProxyClose(logHook.AllEntries())
 		r.NotNil(entry)
 


### PR DESCRIPTION
While working on runbooks for some of our detectors I realized we didn't have good logs which are generated when we fail to establish a connection to the proxy target. We increment the `smokescreen.cn.atpt.fail.total` metric, and the go runtime will emit and error, but that's about it. For traditional HTTP proxy requests, we also catch and log this as a generic error in the `OnResponse()` function.

Even with the error handling improvements queued up in https://github.com/stripe/smokescreen/pull/100/, we are only returning the failure to the client and not logging any useful debugging information.

This makes it possible to tie `net.Dial` failures to individual requests.

r? @rwg-stripe 
cc @stripe/platform-security 

