### PR TITLE
goproxy: close after copy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,4 @@ jobs:
         # Run integration tests hermetically to avoid nondeterministic races on environment variables
         go test -race -v -timeout 2m -failfast ./cmd/... -run TestSmokescreenIntegration
         go test -race -v -timeout 2m -failfast ./cmd/... -run TestInvalidUpstreamProxyConfiguration
+        go test -race -v -timeout 2m -failfast ./cmd/... -run TestClientHalfCloseConnection

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/sirupsen/logrus v1.0.6
 	github.com/stretchr/testify v1.3.0
 	github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b
-	github.com/stripe/goproxy v0.0.0-20200427190316-05fc299d1e72
-	golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 // indirect
+	github.com/stripe/goproxy v0.0.0-20200529180715-360e2f2e4be2
+	golang.org/x/net v0.0.0-20200528225125-3c3fba18258b // indirect
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,10 @@ github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b h1:RjOPjQht0WXH5
 github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b/go.mod h1:hkb6IH5oGd1qYMSCC8kjJCLwbCY8yFn/fABFwClTXTA=
 github.com/stripe/goproxy v0.0.0-20200427190316-05fc299d1e72 h1:3DTs/WnMXgNtgdSGBGNq77az7y3cQ+Zqj4GYrJYt/8M=
 github.com/stripe/goproxy v0.0.0-20200427190316-05fc299d1e72/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20200528221707-872a67f36810 h1:WiEeLe73b5Diguyv9Uol+VND79QsgKMtpO0fGNS7ihY=
+github.com/stripe/goproxy v0.0.0-20200528221707-872a67f36810/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20200529180715-360e2f2e4be2 h1:2rNYlzFfEk9MkvwIQHtC5p/SHv7uIk2rGuXTYSKww4Q=
+github.com/stripe/goproxy v0.0.0-20200529180715-360e2f2e4be2/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -42,6 +46,10 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 h1:Jcxah/M+oLZ/R4/z5RzfPzGbPXnVDPkEDtf2JnuxN+U=
 golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2 h1:eDrdRpKgkcCqKZQwyZRyeFZgfqt37SL7Kv3tok06cKE=
+golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200528225125-3c3fba18258b h1:IYiJPiJfzktmDAO1HQiwjMjwjlYKHAL7KzeD544RJPs=
+golang.org/x/net v0.0.0-20200528225125-3c3fba18258b/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -121,7 +121,7 @@ func (ic *InstrumentedConn) Close() error {
 		"end_time":      end.UTC(),
 		"duration":      duration,
 		"error":         errorMessage,
-		"last_activity": time.Unix(0, *ic.LastActivity).UTC(),
+		"last_activity": time.Unix(0, atomic.LoadInt64(ic.LastActivity)).UTC(),
 		"dst_ip":        dstIP,
 		"dst_port":      dstPort,
 	}).Info(CanonicalProxyConnClose)

--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -102,14 +102,9 @@ func (ic *InstrumentedConn) Close() error {
 		}
 	}
 
-	var timeout bool
 	var errorMessage string
 	if ic.ConnError != nil {
 		errorMessage = ic.ConnError.Error()
-		if e, ok := ic.ConnError.(net.Error); ok && e.Timeout() {
-			timeout = true
-			ic.tracker.statsc.Incr("cn.timeout", tags, 1)
-		}
 	}
 
 	var dstIP, dstPortStr string
@@ -125,7 +120,6 @@ func (ic *InstrumentedConn) Close() error {
 		"role":          ic.Role,
 		"end_time":      end.UTC(),
 		"duration":      duration,
-		"timed_out":     timeout,
 		"error":         errorMessage,
 		"last_activity": time.Unix(0, *ic.LastActivity).UTC(),
 		"dst_ip":        dstIP,

--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -91,8 +91,8 @@ func (ic *InstrumentedConn) Close() error {
 
 	ic.tracker.statsc.Incr("cn.close", tags, 1)
 	ic.tracker.statsc.Histogram("cn.duration", duration, tags, 1)
-	ic.tracker.statsc.Histogram("cn.bytes_in", float64(*ic.BytesIn), tags, 1)
-	ic.tracker.statsc.Histogram("cn.bytes_out", float64(*ic.BytesOut), tags, 1)
+	ic.tracker.statsc.Histogram("cn.bytes_in", float64(atomic.LoadUint64(ic.BytesIn)), tags, 1)
+	ic.tracker.statsc.Histogram("cn.bytes_out", float64(atomic.LoadUint64(ic.BytesOut)), tags, 1)
 
 	// Track when we terminate active connections during a shutdown
 	if ic.tracker.ShuttingDown.Load() == true {

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -568,8 +568,8 @@ func TestProxyTimeouts(t *testing.T) {
 		entry := findCanonicalProxyClose(logHook.AllEntries())
 		r.NotNil(entry)
 
-		r.Equal(true, entry.Data["timed_out"])
-		r.Contains(entry.Data["error"], "i/o timeout")
+		// Error should be set when a connection times out
+		r.NotEqual(entry.Data["error"], "")
 	})
 
 	t.Run("CONNECT proxy dial timeouts", func(t *testing.T) {

--- a/vendor/github.com/stripe/goproxy/https.go
+++ b/vendor/github.com/stripe/goproxy/https.go
@@ -15,7 +15,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 
 	"golang.org/x/net/http/httpproxy"
@@ -148,31 +147,31 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 			go copyAndClose(ctx, targetTCP, proxyClientTCP)
 			go copyAndClose(ctx, proxyClientTCP, targetTCP)
 		} else {
+			// There is a race with the runtime here. In the case where the
+			// connection to the target site times out, we cannot control which
+			// io.Copy loop will receive the timeout signal first. This means
+			// that in some cases the error passed to the ConnErrorHandler will
+			// be the timeout error, and in other cases it will be an error raised
+			// by the use of a closed network connection.
+			//
+			// 2020/05/28 23:42:17 [001] WARN: Error copying to client: read tcp 127.0.0.1:33742->127.0.0.1:34763: i/o timeout
+			// 2020/05/28 23:42:17 [001] WARN: Error copying to client: read tcp 127.0.0.1:45145->127.0.0.1:60494: use of closed network connection
+			//
+			// It's also not possible to synchronize these connection closures due to
+			// TCP connections which are half-closed. When this happens, only the one
+			// side of the connection breaks out of its io.Copy loop. The other side
+			// of the connection remains open until it either times out or is reset by
+			// the client.
 			go func() {
-				var err error
-				var wg sync.WaitGroup
-				wg.Add(2)
-				// Only capture an error from one of the calls to copyOrWarn.
-				// copyOrWarn() is called twice with the same net.Conn pair with
-				// the src and dst parameters inverted. When the connection is
-				// terminated prematurely the net.Error type is the same, but
-				// the directionality of the Error() message changes.
-				go func() {
-					err = copyOrWarn(ctx, targetSiteCon, proxyClient)
-					wg.Done()
-				}()
-				go func() {
-					copyOrWarn(ctx, proxyClient, targetSiteCon)
-					wg.Done()
-				}()
-				wg.Wait()
-
+				err := copyOrWarn(ctx, targetSiteCon, proxyClient)
 				if err != nil && ctx.ConnErrorHandler != nil {
 					ctx.ConnErrorHandler(err)
 				}
-
-				proxyClient.Close()
 				targetSiteCon.Close()
+			}()
+			go func() {
+				copyOrWarn(ctx, proxyClient, targetSiteCon)
+				proxyClient.Close()
 			}()
 		}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,11 +18,11 @@ github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b
 github.com/stripe/go-einhorn/einhorn
-# github.com/stripe/goproxy v0.0.0-20200427190316-05fc299d1e72
+# github.com/stripe/goproxy v0.0.0-20200529180715-360e2f2e4be2
 github.com/stripe/goproxy
 # golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 golang.org/x/crypto/ssh/terminal
-# golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0
+# golang.org/x/net v0.0.0-20200528225125-3c3fba18258b
 golang.org/x/net/http/httpproxy
 golang.org/x/net/idna
 # golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd


### PR DESCRIPTION
This brings in https://github.com/stripe/goproxy/pull/15 from `stripe/goproxy`. The PR reverts the way we handle connection closures to how it was being handled previously.

Additionally, this PR:
* Adds a regression tests to ensure Smokescreen doesn't leak connections when a TCP connection is half-closed.
* Fixes a data race found by Go's race detector.
* Removes the `timed_out` field on `CANONICAL-PROXY-CN-CLOSE` log events. See the comment on the goproxy PR, but we're no longer able to rely on this field being accurate due to a race with the runtime. I believe it's better to not surface this field if it cannot reliably report on whether a connection was timed out. It should still be possible to infer if a connection was timed out by comparing the `last_activity` field to the configured inactivity timeout.

r? @hans-stripe 
cc @stripe/platform-security 