### PR TITLE
Log amount of time net.DialTimeout takes to establish the connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ If a domain matches both the `global_allow_list` and the `global_deny_list`, the
  - Andreas Fuchs
  - Andrew Dunham
  - Andrew Metcalf
+ - Aniket Joshi
  - Carl Jackson
+ - Craig Shannon
  - Evan Broder
  - Marc-André Tremblay
  - Ryan Koppenhaver

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -62,6 +62,9 @@ type Config struct {
 	// These are *only* used for traditional HTTP proxy requests
 	TransportMaxIdleConns        int
 	TransportMaxIdleConnsPerHost int
+
+	// Used for logging connection time
+	TimeConnect bool
 }
 
 type missingRoleError struct {


### PR DESCRIPTION
This logs the host url with the amount of time the DialTimeout function takes to establish a connection to that url. 

r? @cds2-stripe  
cc @stripe/platform-security 
