### PR TITLE
Add target host to timeout and connection failure metrics

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -250,7 +250,10 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	}
 
 	if err != nil {
-		sctx.cfg.StatsdClient.Incr("cn.atpt.fail.total", []string{}, 1)
+		sctx.cfg.StatsdClient.Incr("cn.atpt.fail.total", []string{sctx.requestedHost}, 1)
+		if e, ok := err.(net.Error); ok && e.Timeout() {
+			sctx.cfg.StatsdClient.Incr("cn.atpt.fail.timeout", []string{sctx.requestedHost}, 1)
+		}
 		return nil, err
 	}
 	sctx.cfg.StatsdClient.Incr("cn.atpt.success.total", []string{}, 1)


### PR DESCRIPTION
This logs the target url whenever the host fails to connect and adds additional logging to emit a metric whenever the failure is a timeout.

r? @cds2-stripe 
cc @stripe/platform-security 