### PR TITLE
Add flag for proxy protocol if using smokescreen as a reverse proxy

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -67,7 +67,7 @@ type Config struct {
 	TimeConnect bool
 
 	// Custom Dial Timeout function to be called
-	ProxyDialTimeout             func(network, address string, timeout time.Duration) (Conn, error)
+	ProxyDialTimeout             func(network, address string, timeout time.Duration) (net.Conn, error)
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -67,7 +67,7 @@ type Config struct {
 	TimeConnect bool
 
 	// Custom Dial Timeout function to be called
-	ProxyDialTimeout             func(network, address string, timeout time.Duration) (net.Conn, error)
+	ProxyDialTimeout func(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error)
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -65,6 +65,9 @@ type Config struct {
 
 	// Used for logging connection time
 	TimeConnect bool
+
+	// Used if smokescreen is used as a reverse proxy instead of a forward proxy
+	ReverseProxyProtocol bool
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -66,8 +66,8 @@ type Config struct {
 	// Used for logging connection time
 	TimeConnect bool
 
-	// Used if smokescreen is used as a reverse proxy instead of a forward proxy
-	ReverseProxyProtocol bool
+	// Custom Dial Timeout function to be called
+	ProxyDialTimeout             func(network, address string, timeout time.Duration) (Conn, error)
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -42,7 +42,6 @@ type yamlConfig struct {
 	TransportMaxIdleConnsPerHost int `yaml:"transport_max_idle_conns_per_host"`
 
 	TimeConnect bool `yaml:"time_connect"`
-	ReverseProxyProtocol bool `yaml:"reverse_proxy_protocol"`
 
 	Tls *yamlConfigTls
 	// Currently not configurable via YAML: RoleFromRequest, Log, DisabledAclPolicyActions
@@ -137,7 +136,6 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	c.AllowMissingRole = yc.AllowMissingRole
 	c.AdditionalErrorMessageOnDeny = yc.DenyMessageExtra
 	c.TimeConnect = yc.TimeConnect
-	c.ReverseProxyProtocol = yc.ReverseProxyProtocol
 
 	return nil
 }

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -42,6 +42,7 @@ type yamlConfig struct {
 	TransportMaxIdleConnsPerHost int `yaml:"transport_max_idle_conns_per_host"`
 
 	TimeConnect bool `yaml:"time_connect"`
+	ReverseProxyProtocol bool `yaml:"reverse_proxy_protocol"`
 
 	Tls *yamlConfigTls
 	// Currently not configurable via YAML: RoleFromRequest, Log, DisabledAclPolicyActions
@@ -136,6 +137,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	c.AllowMissingRole = yc.AllowMissingRole
 	c.AdditionalErrorMessageOnDeny = yc.DenyMessageExtra
 	c.TimeConnect = yc.TimeConnect
+	c.ReverseProxyProtocol = yc.ReverseProxyProtocol
 
 	return nil
 }

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -255,7 +255,11 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 		return nil, err
 	}
 	sctx.cfg.StatsdClient.Incr("cn.atpt.success.total", []string{}, 1)
-
+	
+	if sctx.cfg.ReverseProxyProtocol {
+		conn = proxyproto.NewConn(conn, sctx.cfg.ConnectTimeout)	
+	}
+	
 	// Only wrap CONNECT conns with an InstrumentedConn. Connections used for traditional HTTP proxy
 	// requests are pooled and reused by net.Transport.
 	if sctx.proxyType == connectProxy {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -244,14 +244,14 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	start := time.Now()
 
 	var conn net.Conn
-	var err  error
+	var err error
 
 	if sctx.cfg.ProxyDialTimeout == nil {
 		conn, err = net.DialTimeout(network, d.resolvedAddr.String(), sctx.cfg.ConnectTimeout)
 	} else {
-		conn, err = sctx.cfg.ProxyDialTimeout(network, d.resolvedAddr.String(), sctx.cfg.ConnectTimeout)
+		conn, err = sctx.cfg.ProxyDialTimeout(ctx, network, d.resolvedAddr.String(), sctx.cfg.ConnectTimeout)
 	}
-	
+
 	if sctx.cfg.TimeConnect {
 		domainTag := fmt.Sprintf("domain:%s", sctx.requestedHost)
 		sctx.cfg.StatsdClient.Timing("cn.atpt.connect.time", time.Since(start), []string{domainTag}, 1)
@@ -261,8 +261,8 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 		sctx.cfg.StatsdClient.Incr("cn.atpt.fail.total", []string{}, 1)
 		return nil, err
 	}
-	sctx.cfg.StatsdClient.Incr("cn.atpt.success.total", []string{}, 1)	
-	
+	sctx.cfg.StatsdClient.Incr("cn.atpt.success.total", []string{}, 1)
+
 	// Only wrap CONNECT conns with an InstrumentedConn. Connections used for traditional HTTP proxy
 	// requests are pooled and reused by net.Transport.
 	if sctx.proxyType == connectProxy {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -249,7 +249,7 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	if sctx.cfg.ProxyDialTimeout == nil {
 		conn, err = net.DialTimeout(network, d.resolvedAddr.String(), sctx.cfg.ConnectTimeout)
 	} else {
-		conn, err = sctx.cfg.ProxyDialTimeout(network, d.resolveAddr.String(), sctx.cfg.ConnectTimeout)
+		conn, err = sctx.cfg.ProxyDialTimeout(network, d.resolvedAddr.String(), sctx.cfg.ConnectTimeout)
 	}
 	
 	if sctx.cfg.TimeConnect {


### PR DESCRIPTION
Support proxy protocol for reverse proxy

#### Reviewers
r? @hans-stripe 
cc @stripe/platform-security  

#### Summary
Enable the proxy protocol based on a config flag when smokescreen is being used as a reverse proxy



