### PR TITLE
Fix logging of project in CANONICAL-PROXY-DECISION

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -824,6 +824,8 @@ func checkACLsForRequest(config *Config, req *http.Request, outboundHost string)
 	destination := submatch[1]
 
 	aclDecision, err := config.EgressACL.Decide(role, destination)
+	decision.project = aclDecision.Project
+	decision.reason = aclDecision.Reason
 	if err != nil {
 		config.Log.WithFields(logrus.Fields{
 			"error": err,
@@ -831,7 +833,6 @@ func checkACLsForRequest(config *Config, req *http.Request, outboundHost string)
 		}).Warn("EgressAcl.Decide returned an error.")
 
 		config.StatsdClient.Incr("acl.decide_error", []string{}, 1)
-		decision.reason = aclDecision.Reason
 		return decision
 	}
 
@@ -841,7 +842,6 @@ func checkACLsForRequest(config *Config, req *http.Request, outboundHost string)
 		fmt.Sprintf("project:%s", aclDecision.Project),
 	}
 
-	decision.reason = aclDecision.Reason
 	switch aclDecision.Result {
 	case acl.Deny:
 		decision.enforceWouldDeny = true


### PR DESCRIPTION
r? @cds2-stripe 
cc @stripe/platform-security 

Carry the `aclDecision.Project` through to the `decision.project` so the project can get logged as part of the `CANONICAL-PROXY-DECISION` log lines.

An example `CANONICAL-PROXY-DECISION` logged by the test suite, before and after this change:

```
(scroll right) → → →                                                                                                                                                                                                                 ↓↓↓↓↓↓↓↓
before: INFO[0000] CANONICAL-PROXY-DECISION                      allow=true content_length=137 decision_reason="host matched allowed domain in rule" dst_ip=3.221.81.55 dst_port=80 enforce_would_deny=false id=bt6lilbd0cvgjkbhbbhg project= proxy_type=http requested_host=httpbin.org role=test-trusted-srv source_addr="127.0.0.1:56511" src_host=127.0.0.1 src_host_common_name=unknown src_host_organization_unit=unknown src_port=56511 start_time="2020-08-31 20:11:01.90101 +0000 UTC" trace_id=
 after: INFO[0000] CANONICAL-PROXY-DECISION                      allow=true content_length=137 decision_reason="host matched allowed domain in rule" dst_ip=3.221.81.55 dst_port=80 enforce_would_deny=false id=bt6lhvrd0cvvrvslsr4g project=security proxy_type=http requested_host=httpbin.org role=test-trusted-srv source_addr="127.0.0.1:56426" src_host=127.0.0.1 src_host_common_name=unknown src_host_organization_unit=unknown src_port=56426 start_time="2020-08-31 20:09:35.49886 +0000 UTC" trace_id=
(scroll right) → → →                                                                                                                                                                                                                 ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑
```