### PR TITLE
Remove misleading `$Id$` embedded into version string

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-pkg/smokescreen/constants.go ident

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -6,9 +6,8 @@ import (
 )
 
 const versionSemantic = "0.0.1"
-const versionHash = "$Id$" // See `git help attributes`
 func Version() string {
-	return versionSemantic + "-" + versionHash[5:13]
+	return versionSemantic
 }
 
 const DefaultStatsdNamespace = "smokescreen."


### PR DESCRIPTION
The `$Id$` which can be auto-expanded in files via the `ident`
attribute does not function the same as the old CVS `$Id$` keyword.
In CVS, the keyword expansion was updated on every commit, to contain
the current commit id.  In git, it is expanded with the identifier of
the _blob it is found in_.  That is, previous to this commit, the
`$Id$` (and hence the reported "version hash") was
f220e479c5d8d85c7b753e95dc5fe0b67bbfbd38 -- and had been since the
file was changed last, in f386360edaa6000deaeffc3a05bed97e79b9b953.

Remove the misleading hash, and attendant git attributes file.  It
will frequently mislead callers that the version has not changed
when, in reality, it has.

Git itself does not have a way to embed "the current commit hash" into
a file in a way that is updated whenever the commit changes.  Nor does
Go natively have a way to embed it into the binary at build time,
though this may change in the future[1].

As alluded to in that ticket, most projects elect to pass in the
build-time commit information via something like:
```
GIT_COMMIT=$(git rev-parse HEAD)
go build -ldflags "-X main.gitCommit=$(GIT_COMMIT)"
```

However, smokescreen does not currently have any build system external
to `go build` which could embed the above logic.  Rather than choose a
build system and introduce a new dependency, remove the misleading
hash entirely.

[1] https://github.com/golang/go/issues/37475 and also
    https://github.com/golang/go/issues/29228