### PR TITLE
Fix up Smokescreen build version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-pkg/smokescreen/constants.go ident

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 )
 
-const versionSemantic = "0.0.1"
+const versionSemantic = "0.0.2"
 // This can be set at build time:
 // go build -ldflags='-X github.com/stripe/smokescreen/pkg/smokescreen.VersionID=33955a3' .
 var VersionID = "unknown"

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -6,9 +6,11 @@ import (
 )
 
 const versionSemantic = "0.0.1"
-const versionHash = "$Id$" // See `git help attributes`
+// This can be set at build time:
+// go build -ldflags='-X github.com/stripe/smokescreen/pkg/smokescreen.VersionID=33955a3' .
+var VersionID = "unknown"
 func Version() string {
-	return versionSemantic + "-" + versionHash[5:13]
+	return versionSemantic + "-" + VersionID
 }
 
 const DefaultStatsdNamespace = "smokescreen."


### PR DESCRIPTION
Inspired by #121, this PR removes the not-working-as-intended `$Id$` from the version number and instead replaces it with a variable that can be easily set in the Golang build toolchain. We're also exporting the variable so it can be set from outside of Smokescreen (i.e. in our internal wrapper which imports this package).

I've also bumped the version to `0.0.2` since it's been a while.

r? @cds2-stripe 
cc @stripe/security-infra @alexmv 