### PR TITLE
Add code coverage to our test workflow w/ goveralls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Setup env
       run: |
-        echo ::set-env name=GOFLAGS::-mod=vendor
+        echo "{GOFLAGS}={-mod=vendor}" >> $GITHUB_ENV
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Vet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,16 @@ jobs:
     - name: Test
       run: |
         go mod verify
-        go test -race -v -timeout 2m -failfast ./... -tags=nointegration
+        go test -race -v -timeout 2m -failfast -covermode atomic -coverprofile=.covprofile ./... -tags=nointegration
         # Run integration tests hermetically to avoid nondeterministic races on environment variables
         go test -race -v -timeout 2m -failfast ./cmd/... -run TestSmokescreenIntegration
         go test -race -v -timeout 2m -failfast ./cmd/... -run TestInvalidUpstreamProxyConfiguration
         go test -race -v -timeout 2m -failfast ./cmd/... -run TestClientHalfCloseConnection
+    - name: Install goveralls
+      env:
+        GO111MODULE: off
+      run: go get github.com/mattn/goveralls
+    - name: Send coverage
+      env:
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: goveralls -coverprofile=.covprofile -service=github


### PR DESCRIPTION
r? @cds2-stripe 
cc @stripe/platform-security 

This PR adds `goveralls` to our test workflow so we can generate code coverage reports. `goveralls` is the Go integration for coveralls.io, which I think just converts Go's coverage output to the input that coveralls likes. We already use coveralls for [several Stripe repos](https://coveralls.io/github/stripe/). I copied the config from https://github.com/mattn/goveralls#github-actions and the build appears at https://coveralls.io/github/stripe/smokescreen.

I also noticed some deprecation warnings for our usage of set-env (https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) and fixed those according to https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

I'm not sure if this will trigger PR comments since I'm not directly using coveralls' github action, but let's see!