### PR TITLE
Add coverage % badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Smokescreen ![Test](https://github.com/stripe/smokescreen/workflows/Test/badge.svg?branch=master&event=push) [![Coverage Status](https://coveralls.io/repos/github/stripe/smokescreen/badge.svg?branch=master)](https://coveralls.io/github/stripe/smokescreen?branch=master)
+# Smokescreen [![Test](https://github.com/stripe/smokescreen/workflows/Test/badge.svg?branch=master&event=push)](https://github.com/stripe/smokescreen/actions?query=workflow%3ATest+branch%3Amaster) [![Coverage Status](https://coveralls.io/repos/github/stripe/smokescreen/badge.svg?branch=master)](https://coveralls.io/github/stripe/smokescreen?branch=master)
 
 Smokescreen is a HTTP CONNECT proxy. It proxies most traffic from Stripe to the
 external world (e.g., webhooks).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Smokescreen ![Test](https://github.com/stripe/smokescreen/workflows/Test/badge.svg?branch=master&event=push)
+# Smokescreen ![Test](https://github.com/stripe/smokescreen/workflows/Test/badge.svg?branch=master&event=push) [![Coverage Status](https://coveralls.io/repos/github/stripe/smokescreen/badge.svg?branch=master)](https://coveralls.io/github/stripe/smokescreen?branch=master)
 
 Smokescreen is a HTTP CONNECT proxy. It proxies most traffic from Stripe to the
 external world (e.g., webhooks).


### PR DESCRIPTION
This PR adds the coveralls code coverage badge to our README. Holding off on assigning/merging this PR until we hit 70%+ coverage.

I also linked the test badge to the test workflow page for master so clicking it is more useful.