### PR TITLE
Update tested Go versions to 1.14 and 1.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x]
+        go-version: [1.14.x, 1.15.x]
         platform: [ubuntu-16.04, ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Smokescreen uses a [custom fork](https://github.com/stripe/goproxy) of goproxy t
 
 Smokescreen is built and tested using the following Go releases. Generally, Smokescreen will only support the two most recent Go versions.
 
-- go1.13.x
 - go1.14.x
+- go1.15.x
 
 [mod]: https://github.com/golang/go/wiki/Modules
 


### PR DESCRIPTION
We should be testing on the two most recent Go versions