### PR TITLE
Make smokescreen clean of staticcheck and gosimple lints

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -101,9 +101,7 @@ func validateProxyResponse(t *testing.T, test *TestCase, resp *http.Response, er
 	}
 
 	var entries []*logrus.Entry
-	for _, entry := range logs {
-		entries = append(entries, entry)
-	}
+	entries = append(entries, logs...)
 
 	if len(entries) > 0 {
 		entry := findLogEntry(entries, smokescreen.CanonicalProxyDecision)

--- a/main.go
+++ b/main.go
@@ -36,11 +36,10 @@ func main() {
 			Entry: conf.Log.WithField("stdlog", "1"),
 		}
 
-		// Set the standard logger to use our logger's writter as output.
+		// Set the standard logger to use our logger's writer as output.
 		log.SetOutput(adapter)
 		log.SetFlags(0)
 		smokescreen.StartWithConfig(conf, nil)
-	} else {
-		// --help or --version was passed and handled by NewConfiguration, so do nothing
 	}
+	// Otherwise, --help or --version was passed and handled by NewConfiguration, so do nothing
 }

--- a/pkg/smokescreen/acl/v1/acl.go
+++ b/pkg/smokescreen/acl/v1/acl.go
@@ -185,10 +185,7 @@ func (acl *ACL) ValidateDomains(domains []string) error {
 			return fmt.Errorf("%v: domain glob must represent a full prefix (sub)domain", d)
 		}
 
-		domainToCheck := d
-		if strings.HasPrefix(domainToCheck, "*") {
-			domainToCheck = domainToCheck[1:]
-		}
+		domainToCheck := strings.TrimPrefix(d, "*")
 		if strings.Contains(domainToCheck, "*") {
 			return fmt.Errorf("%v: domain globs are only supported as prefix", d)
 		}

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -273,7 +273,7 @@ func (config *Config) SetupCrls(crlFiles []string) error {
 	}
 
 	// Verify that all CAs loaded have a CRL
-	for k, _ := range config.clientCasBySubjectKeyId {
+	for k := range config.clientCasBySubjectKeyId {
 		_, ok := config.CrlByAuthorityKeyId[k]
 		if !ok {
 			fmt.Printf("warn: no CRL loaded for Authority ID '%s'\n", hex.EncodeToString([]byte(k)))

--- a/pkg/smokescreen/conntrack/conn_tracker.go
+++ b/pkg/smokescreen/conntrack/conn_tracker.go
@@ -41,7 +41,7 @@ func (tr *Tracker) MaybeIdleIn(d time.Duration) time.Duration {
 
 		lastActivity := time.Unix(0, atomic.LoadInt64(c.LastActivity))
 		idleAt := lastActivity.Add(d)
-		idleIn := idleAt.Sub(time.Now())
+		idleIn := time.Until(idleAt)
 
 		if idleIn > longest {
 			longest = idleIn

--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -189,7 +189,7 @@ func (ic *InstrumentedConn) Stats() *InstrumentedConnStats {
 		Created:                  ic.Start,
 		BytesIn:                  *ic.BytesIn,
 		BytesOut:                 *ic.BytesOut,
-		SecondsSinceLastActivity: time.Now().Sub(time.Unix(0, *ic.LastActivity)).Seconds(),
+		SecondsSinceLastActivity: time.Since(time.Unix(0, *ic.LastActivity)).Seconds(),
 		ProxyType:                ic.proxyType,
 	}
 }

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -521,7 +521,7 @@ func logProxy(config *Config, pctx *goproxy.ProxyCtx) {
 	if pctx.Req.TLS != nil && len(pctx.Req.TLS.PeerCertificates) > 0 {
 		fields["src_host_common_name"] = pctx.Req.TLS.PeerCertificates[0].Subject.CommonName
 		var ouEntries = pctx.Req.TLS.PeerCertificates[0].Subject.OrganizationalUnit
-		if ouEntries != nil && len(ouEntries) > 0 {
+		if len(ouEntries) > 0 {
 			fields["src_host_organization_unit"] = ouEntries[0]
 		}
 	}

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -628,7 +628,6 @@ func StartWithConfig(config *Config, quit <-chan interface{}) {
 
 	config.ShuttingDown.Store(false)
 	runServer(config, &server, listener, quit)
-	return
 }
 
 func runServer(config *Config, server *http.Server, listener net.Listener, quit <-chan interface{}) {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -719,7 +719,7 @@ func runServer(config *Config, server *http.Server, listener net.Listener, quit 
 			for {
 				checkAgainIn := config.ConnTracker.MaybeIdleIn(idleTimeout)
 				if checkAgainIn > 0 {
-					if time.Now().Sub(beginTs) > config.ExitTimeout {
+					if time.Since(beginTs) > config.ExitTimeout {
 						config.Log.Print(fmt.Sprintf("Timed out at %v while waiting for all open connections to become idle.", config.ExitTimeout))
 						exit <- Timeout
 						break

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -681,6 +681,7 @@ func TestProxyHalfClosed(t *testing.T) {
 	r.NoError(err)
 
 	resp, err := client.Do(req)
+	r.NoError(err)
 	resp.Body.Close()
 	r.Equal(http.StatusOK, resp.StatusCode)
 

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -5,6 +5,7 @@ package smokescreen
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -315,18 +316,24 @@ func TestHealthcheck(t *testing.T) {
 
 	server := httptest.NewServer(handler)
 
+	errChan := make(chan error, 1)
 	go func() {
 		select {
 		case healthy := <-healthcheckCh:
-			a.Equal("OK", healthy)
+			if healthy != "OK" {
+				errChan <- fmt.Errorf("healthcheck not OK: %s", healthy)
+			}
 		case <-time.After(5 * time.Second):
-			t.Fatal("timed out waiting for client request")
+			errChan <- errors.New("timed out waiting for client request")
 		}
+		close(errChan)
 	}()
 
 	resp, err := http.Get(fmt.Sprintf("%s/healthcheck", server.URL))
 	r.NoError(err)
 	a.Equal(http.StatusOK, resp.StatusCode)
+
+	r.NoError(<-errChan)
 }
 
 var invalidHostCases = []struct {


### PR DESCRIPTION
This cleans up a bunch of issues as found by the staticcheck and gosimple linters, called via golangci-lint which I'd like to eventually incorporate as a CI check.

For the most part there shouldn't be any functional changes here.  Each commit should describe what it's doing.