### PR TITLE
Bumping goproxy version to include support for upstream proxies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/sirupsen/logrus v1.0.6
 	github.com/stretchr/testify v1.3.0
 	github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b
-	github.com/stripe/goproxy v0.0.0-20200902225839-ac962cdd7165
+	github.com/stripe/goproxy v0.0.0-20201214151142-bb691dcfe7e9
 	golang.org/x/net v0.0.0-20200528225125-3c3fba18258b // indirect
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b h1:RjOPjQht0WXH5
 github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b/go.mod h1:hkb6IH5oGd1qYMSCC8kjJCLwbCY8yFn/fABFwClTXTA=
 github.com/stripe/goproxy v0.0.0-20200902225839-ac962cdd7165 h1:FLZlkRr7DAQxqfdApNSokzbd0S0K6C5b3/URYRm61Ss=
 github.com/stripe/goproxy v0.0.0-20200902225839-ac962cdd7165/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20201214151142-bb691dcfe7e9 h1:4BvarxVTLjeiXfHrl3JxfjXTSjXi1AU034EcGvzFOos=
+github.com/stripe/goproxy v0.0.0-20201214151142-bb691dcfe7e9/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/vendor/github.com/stripe/goproxy/https.go
+++ b/vendor/github.com/stripe/goproxy/https.go
@@ -494,7 +494,7 @@ func (proxy *ProxyHttpServer) connectDialProxyWithContext(ctx *ProxyCtx, proxyHo
 		return nil, err
 	}
 
-	c, err := proxy.connectDialContext(ctx, "tcp", proxyHost)
+	c, err := proxy.connectDialContext(ctx, "tcp", proxyURL.Host)
 	if err != nil {
 		return nil, err
 	}
@@ -558,5 +558,5 @@ func httpsProxyFromEnv(reqURL *url.URL) (string, error) {
 		service = proxyURL.Scheme
 	}
 
-	return fmt.Sprintf("%s:%s", proxyURL.Hostname(), service), nil
+	return fmt.Sprintf("%s://%s:%s", proxyURL.Scheme, proxyURL.Hostname(), service), nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,7 +18,7 @@ github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/stripe/go-einhorn v0.0.0-20160225014757-79db5cd84b4b
 github.com/stripe/go-einhorn/einhorn
-# github.com/stripe/goproxy v0.0.0-20200902225839-ac962cdd7165
+# github.com/stripe/goproxy v0.0.0-20201214151142-bb691dcfe7e9
 github.com/stripe/goproxy
 # golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 golang.org/x/crypto/ssh/terminal


### PR DESCRIPTION
Bumping the goproxy version, which will include these changes: https://github.com/stripe/goproxy/pull/18, resolving #131 