### PR TITLE
Improve smokescreen log messages

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -207,6 +207,10 @@ type authKeyId struct {
 }
 
 func NewConfig() *Config {
+	log.SetFormatter(&log.JSONFormatter{
+		TimestampFormat: time.RFC3339Nano,
+	})
+
 	return &Config{
 		CrlByAuthorityKeyId:     make(map[string]*pkix.CertificateList),
 		clientCasBySubjectKeyId: make(map[string]*x509.Certificate),

--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -107,23 +106,13 @@ func (ic *InstrumentedConn) Close() error {
 		errorMessage = ic.ConnError.Error()
 	}
 
-	var dstIP, dstPortStr string
-	var dstPort int
-	if remoteAddr := ic.Conn.RemoteAddr(); remoteAddr != nil {
-		dstIP, dstPortStr, _ = net.SplitHostPort(remoteAddr.String())
-		dstPort, _ = strconv.Atoi(dstPortStr)
-	}
-
 	ic.logger.WithFields(logrus.Fields{
 		"bytes_in":      ic.BytesIn,
 		"bytes_out":     ic.BytesOut,
-		"role":          ic.Role,
 		"end_time":      end.UTC(),
 		"duration":      duration,
 		"error":         errorMessage,
 		"last_activity": time.Unix(0, atomic.LoadInt64(ic.LastActivity)).UTC(),
-		"dst_ip":        dstIP,
-		"dst_port":      dstPort,
 	}).Info(CanonicalProxyConnClose)
 
 	ic.tracker.Wg.Done()

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -6,9 +6,11 @@ import (
 )
 
 const versionSemantic = "0.0.2"
+
 // This can be set at build time:
 // go build -ldflags='-X github.com/stripe/smokescreen/pkg/smokescreen.VersionID=33955a3' .
 var VersionID = "unknown"
+
 func Version() string {
 	return versionSemantic + "-" + VersionID
 }

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -372,11 +372,11 @@ func newContext(cfg *Config, proxyType string, req *http.Request) *smokescreenCo
 
 	logger := cfg.Log.WithFields(logrus.Fields{
 		"id":                  xid.New().String(),
+		"inbound_remote_addr": req.RemoteAddr,
 		"proxy_type":          proxyType,
 		"requested_host":      req.Host,
 		"start_time":          start.UTC(),
 		"trace_id":            req.Header.Get(traceHeader),
-		"inbound_remote_addr": req.RemoteAddr,
 	})
 
 	return &smokescreenContext{

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -263,6 +263,23 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	}
 	sctx.cfg.StatsdClient.Incr("cn.atpt.success.total", []string{}, 1)
 
+	if conn != nil {
+		fields := logrus.Fields{}
+
+		if addr := conn.LocalAddr(); addr != nil {
+			fields["outbound_local_addr"] = addr.String()
+		}
+
+		if addr := conn.RemoteAddr(); addr != nil {
+			fields["outbound_remote_addr"] = addr.String()
+		}
+
+		if len(fields) > 0 {
+			// add the above fields to all future log messages sent using this smokescreen context's logger
+			sctx.logger = sctx.logger.WithFields(fields)
+		}
+	}
+
 	// Only wrap CONNECT conns with an InstrumentedConn. Connections used for traditional HTTP proxy
 	// requests are pooled and reused by net.Transport.
 	if sctx.proxyType == connectProxy {
@@ -272,6 +289,7 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	} else {
 		conn = NewTimeoutConn(conn, sctx.cfg.IdleTimeout)
 	}
+
 	return conn, nil
 }
 
@@ -351,13 +369,14 @@ func configureTransport(tr *http.Transport, cfg *Config) {
 
 func newContext(cfg *Config, proxyType string, req *http.Request) *smokescreenContext {
 	start := time.Now()
+
 	logger := cfg.Log.WithFields(logrus.Fields{
-		"id":             xid.New().String(),
-		"proxy_type":     proxyType,
-		"requested_host": req.Host,
-		"source_addr":    req.RemoteAddr,
-		"start_time":     start.UTC(),
-		"trace_id":       req.Header.Get(traceHeader),
+		"id":                  xid.New().String(),
+		"proxy_type":          proxyType,
+		"requested_host":      req.Host,
+		"start_time":          start.UTC(),
+		"trace_id":            req.Header.Get(traceHeader),
+		"inbound_remote_addr": req.RemoteAddr,
 	})
 
 	return &smokescreenContext{
@@ -497,32 +516,14 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 func logProxy(config *Config, pctx *goproxy.ProxyCtx) {
 	sctx := pctx.UserData.(*smokescreenContext)
 
-	var contentLength int64
-	if pctx.Resp != nil {
-		contentLength = pctx.Resp.ContentLength
-	}
-
-	fromHost, fromPort, _ := net.SplitHostPort(pctx.Req.RemoteAddr)
-
-	fields := logrus.Fields{
-		"src_host":       fromHost,
-		"src_port":       fromPort,
-		"content_length": contentLength,
-	}
-
-	if sctx.decision.resolvedAddr != nil {
-		fields["dst_ip"] = sctx.decision.resolvedAddr.IP.String()
-		fields["dst_port"] = sctx.decision.resolvedAddr.Port
-	}
+	fields := logrus.Fields{}
 
 	// attempt to retrieve information about the host originating the proxy request
-	fields["src_host_common_name"] = "unknown"
-	fields["src_host_organization_unit"] = "unknown"
 	if pctx.Req.TLS != nil && len(pctx.Req.TLS.PeerCertificates) > 0 {
-		fields["src_host_common_name"] = pctx.Req.TLS.PeerCertificates[0].Subject.CommonName
+		fields["inbound_remote_x509_cn"] = pctx.Req.TLS.PeerCertificates[0].Subject.CommonName
 		var ouEntries = pctx.Req.TLS.PeerCertificates[0].Subject.OrganizationalUnit
 		if len(ouEntries) > 0 {
-			fields["src_host_organization_unit"] = ouEntries[0]
+			fields["inbound_remote_x509_ou"] = ouEntries[0]
 		}
 	}
 
@@ -530,6 +531,19 @@ func logProxy(config *Config, pctx *goproxy.ProxyCtx) {
 	if sctx.decision != nil {
 		fields["role"] = decision.role
 		fields["project"] = decision.project
+	}
+
+	// add the above fields to all future log messages sent using this smokescreen context's logger
+	sctx.logger = sctx.logger.WithFields(fields)
+
+	// start a new set of fields used only in this log message
+	fields = logrus.Fields{}
+
+	if pctx.Resp != nil {
+		fields["content_length"] = pctx.Resp.ContentLength
+	}
+
+	if sctx.decision != nil {
 		fields["decision_reason"] = decision.reason
 		fields["enforce_would_deny"] = decision.enforceWouldDeny
 		fields["allow"] = decision.allow

--- a/pkg/smokescreen/stats_server.go
+++ b/pkg/smokescreen/stats_server.go
@@ -32,14 +32,14 @@ func (s *StatsServer) Serve() {
 	ln, err := net.Listen("unix", s.socketPath)
 
 	if err != nil {
-		s.config.Log.Fatal("Could not start the reporting server.", err)
+		s.config.Log.Fatal("Could not start the reporting server: ", err)
 	}
 	os.Chmod(s.socketPath, s.config.StatsSocketFileMode)
 
 	s.ln = ln
 	err = http.Serve(s.ln, s.mux)
 	if err != nil {
-		s.config.Log.Fatal("Could not start the reporting server.", err)
+		s.config.Log.Fatal("Could not start the reporting server: ", err)
 	}
 }
 


### PR DESCRIPTION
r? @cds2-stripe 
cc @stripe/platform-security 

This PR makes changes related to how we log events in smokescreen:

- It sets logrus's default timestamp format (for its `time` field) to include nanoseconds, in order to match other fields that are timestamps.
- It changes `src` and `dst` to `inbound` and `outbound` in field names, as appropriate.  The fields that contain IP addresses/ports will be consistently named `(inbound|outbound)_(local|remote)_addr`, which hopefully makes it clearer what's being referred to.
- It renames the CN/OU fields from `src_host_common_name` and `src_host_organization_unit` to `inbound_remote_x509_cn` and `inbound_remote_x509_ou`, to further remove `src` in field names.
- It updates the smokescreen context's logger with certain fields as soon as it learns the information for those fields.  The biggest thing here is that it'll thread `role`, `project`, and X.509 CN/OU fields through to later log messages instead of only including them in the decision message.

### Known deficiencies

- My goal was to make error messages for TCP connections that failed (timed out, connection refused, etc.) include the failed connections' `outbound_local_addr`, to aid in debugging network issues.  Unfortunately, Go's `net` package doesn't make it easy to obtain the local IP address and port number from a failed TCP connection, and I can't figure out any way to do it short of reimplementing a big chunk of the `net` package.
- Some errors emitted by goproxy do not use the logger in the smokescreen context, so they'll still be missing all kinds of useful information.  This PR doesn't attempt to improve our story here.  (If I had the time to fix it, I think I'd instead spend it on getting rid of goproxy entirely.)