### PR TITLE
Upgrade tested Go versions for 1.16 Go release.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.15.x, 1.16.x]
         platform: [ubuntu-16.04, ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Smokescreen uses a [custom fork](https://github.com/stripe/goproxy) of goproxy t
 
 Smokescreen is built and tested using the following Go releases. Generally, Smokescreen will only support the two most recent Go versions.
 
-- go1.14.x
 - go1.15.x
+- go1.16.x
 
 [mod]: https://github.com/golang/go/wiki/Modules
 


### PR DESCRIPTION
[Go 1.16 was released 2021/02/16](https://golang.org/doc/devel/release.html).