### PR TITLE
Adding the ability to define a custom reject response handler

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -71,11 +71,6 @@ type Config struct {
 
 	// Customer handler to allow clients to modify reject responses
 	RejectResponseHandler func(*http.Response)
-
-	// UnsafeAllowPrivateRanges inverts the default behavior, telling smokescreen to allow private IP
-	// ranges by default (exempting loopback and unicast ranges)
-	// This setting can be used to configure Smokescreen with a blocklist, rather than an allowlist
-	UnsafeAllowPrivateRanges bool
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -70,7 +70,12 @@ type Config struct {
 	ProxyDialTimeout func(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error)
 
 	// Customer handler to allow clients to modify reject responses
-	RejectResponseHandler func(message string, code int) (string, int)
+	RejectResponseHandler func(*http.Response)
+
+	// UnsafeAllowPrivateRanges inverts the default behavior, telling smokescreen to allow private IP
+	// ranges by default (exempting loopback and unicast ranges)
+	// This setting can be used to configure Smokescreen with a blocklist, rather than an allowlist
+	UnsafeAllowPrivateRanges bool
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -68,6 +68,9 @@ type Config struct {
 
 	// Custom Dial Timeout function to be called
 	ProxyDialTimeout func(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error)
+
+	// Customer handler to allow clients to modify reject responses
+	RejectResponseHandler func(message string, code int) (string, int)
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -327,6 +327,10 @@ func rejectResponse(pctx *goproxy.ProxyCtx, err error) *http.Response {
 		msg = fmt.Sprintf("%s\n\n%s\n", msg, sctx.cfg.AdditionalErrorMessageOnDeny)
 	}
 
+	if sctx.cfg.RejectResponseHandler != nil {
+		msg, code = sctx.cfg.RejectResponseHandler(msg, code)
+	}
+
 	resp := goproxy.NewResponse(pctx.Req, goproxy.ContentTypeText, code, msg+"\n")
 	resp.Status = status
 	resp.ProtoMajor = pctx.Req.ProtoMajor

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -152,7 +152,7 @@ func classifyAddr(config *Config, addr *net.TCPAddr) ipType {
 		return ipAllowUserConfigured
 	} else if addrIsInRuleRange(config.DenyRanges, addr) {
 		return ipDenyUserConfigured
-	} else if addrIsInRuleRange(PrivateRuleRanges, addr) {
+	} else if addrIsInRuleRange(PrivateRuleRanges, addr) && !config.UnsafeAllowPrivateRanges {
 		return ipDenyPrivateRange
 	} else {
 		return ipAllowDefault
@@ -327,15 +327,15 @@ func rejectResponse(pctx *goproxy.ProxyCtx, err error) *http.Response {
 		msg = fmt.Sprintf("%s\n\n%s\n", msg, sctx.cfg.AdditionalErrorMessageOnDeny)
 	}
 
-	if sctx.cfg.RejectResponseHandler != nil {
-		msg, code = sctx.cfg.RejectResponseHandler(msg, code)
-	}
 
 	resp := goproxy.NewResponse(pctx.Req, goproxy.ContentTypeText, code, msg+"\n")
 	resp.Status = status
 	resp.ProtoMajor = pctx.Req.ProtoMajor
 	resp.ProtoMinor = pctx.Req.ProtoMinor
 	resp.Header.Set(errorHeader, msg)
+	if sctx.cfg.RejectResponseHandler != nil {
+		sctx.cfg.RejectResponseHandler(resp)
+	}
 	return resp
 }
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -152,7 +152,7 @@ func classifyAddr(config *Config, addr *net.TCPAddr) ipType {
 		return ipAllowUserConfigured
 	} else if addrIsInRuleRange(config.DenyRanges, addr) {
 		return ipDenyUserConfigured
-	} else if addrIsInRuleRange(PrivateRuleRanges, addr) && !config.UnsafeAllowPrivateRanges {
+	} else if addrIsInRuleRange(PrivateRuleRanges, addr) {
 		return ipDenyPrivateRange
 	} else {
 		return ipAllowDefault


### PR DESCRIPTION
I think it would be nice to be able to customize reject responses. This tiny change adds a RejectResponseHandler to the config struct, allowing you to show custom error responses

It can be used like this:

```
func main() {
	conf, _ := cmd.NewConfiguration(nil, nil)

	conf.RejectResponseHandler = func(resp *http.Response) {
		if resp.StatusCode == http.StatusProxyAuthRequired || resp.StatusCode == http.StatusForbidden {
			resp.Header.Set("X-Custom-Header", "some customer header")
		}
	}
```