### PR TITLE
Allow private ranges default option

### DIFF
--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -122,6 +122,10 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			Value: "700",
 			Usage: "Set the filemode to `FILE_MODE` on the statistics socket",
 		},
+		cli.BoolFlag{
+			Name:  "unsafe-allow-private-ranges",
+			Usage: "Allow private ip ranges by default",
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -234,6 +238,10 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			if err := conf.SetupCrls(c.StringSlice("tls-crl-file")); err != nil {
 				return err
 			}
+		}
+
+		if c.IsSet("unsafe-allow-private-ranges") {
+			conf.UnsafeAllowPrivateRanges = c.Bool("unsafe-allow-private-ranges")
 		}
 
 		// FIXME: mixing and matching parts of TLS config between cli and file

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -71,6 +71,11 @@ type Config struct {
 
 	// Customer handler to allow clients to modify reject responses
 	RejectResponseHandler func(*http.Response)
+
+	// UnsafeAllowPrivateRanges inverts the default behavior, telling smokescreen to allow private IP
+	// ranges by default (exempting loopback and unicast ranges)
+	// This setting can be used to configure Smokescreen with a blocklist, rather than an allowlist
+	UnsafeAllowPrivateRanges bool
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -45,6 +45,8 @@ type yamlConfig struct {
 
 	Tls *yamlConfigTls
 	// Currently not configurable via YAML: RoleFromRequest, Log, DisabledAclPolicyActions
+
+	UnsafeAllowPrivateRanges bool	`yaml:"unsafe_allow_private_ranges"`
 }
 
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -136,6 +138,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	c.AllowMissingRole = yc.AllowMissingRole
 	c.AdditionalErrorMessageOnDeny = yc.DenyMessageExtra
 	c.TimeConnect = yc.TimeConnect
+	c.UnsafeAllowPrivateRanges = yc.UnsafeAllowPrivateRanges
 
 	return nil
 }

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -152,7 +152,7 @@ func classifyAddr(config *Config, addr *net.TCPAddr) ipType {
 		return ipAllowUserConfigured
 	} else if addrIsInRuleRange(config.DenyRanges, addr) {
 		return ipDenyUserConfigured
-	} else if addrIsInRuleRange(PrivateRuleRanges, addr) {
+	} else if addrIsInRuleRange(PrivateRuleRanges, addr) && !config.UnsafeAllowPrivateRanges {
 		return ipDenyPrivateRange
 	} else {
 		return ipAllowDefault

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -111,9 +111,6 @@ func TestUnsafeAllowPrivateRanges (t *testing.T) {
 
 	conf := NewConfig()
 	a.NoError(conf.SetDenyRanges([]string {"192.168.0.0/24", "10.0.0.0/8"}))
-	a.NoError(conf.SetDenyAddresses([]string {"192.168"
-	a.NoError(conf.SetAllowRanges(allowRanges))
-	a.NoError(conf.SetAllowAddresses(allowAddresses))
 	conf.ConnectTimeout = 10 * time.Second
 	conf.ExitTimeout = 10 * time.Second
 	conf.AdditionalErrorMessageOnDeny = "Proxy denied"
@@ -122,24 +119,20 @@ func TestUnsafeAllowPrivateRanges (t *testing.T) {
 
 	testIPs := []testCase{
 		testCase{"8.8.8.8", 1, ipAllowDefault},
-		testCase{"8.8.9.8", 1, ipAllowUserConfigured},
 
 		// Specific blocked networks
-		testCase{"10.0.0.1", 1, ipDenyPrivateRange},
-		testCase{"10.0.0.1", 321, ipAllowUserConfigured},
-		testCase{"10.0.1.1", 1, ipAllowUserConfigured},
-		testCase{"172.16.0.1", 1, ipDenyPrivateRange},
-		testCase{"172.16.1.1", 1, ipAllowUserConfigured},
-		testCase{"192.168.0.1", 1, ipDenyPrivateRange},
-		testCase{"192.168.1.1", 1, ipAllowUserConfigured},
-		testCase{"8.8.8.8", 321, ipDenyUserConfigured},
-		testCase{"1.1.1.1", 1, ipDenyUserConfigured},
+		testCase{"10.0.0.1", 1, ipDenyUserConfigured},
+		testCase{"10.0.0.1", 321, ipDenyUserConfigured},
+		testCase{"10.0.1.1", 1, ipDenyUserConfigured},
+		testCase{"172.16.0.1", 1, ipAllowDefault},
+		testCase{"172.16.1.1", 1, ipAllowDefault},
+		testCase{"192.168.0.1", 1, ipDenyUserConfigured},
+		testCase{"192.168.1.1", 1, ipAllowDefault},
 
 		// localhost
 		testCase{"127.0.0.1", 1, ipDenyNotGlobalUnicast},
 		testCase{"127.255.255.255", 1, ipDenyNotGlobalUnicast},
 		testCase{"::1", 1, ipDenyNotGlobalUnicast},
-		testCase{"127.0.1.1", 1, ipAllowUserConfigured},
 
 		// ec2 metadata endpoint
 		testCase{"169.254.169.254", 1, ipDenyNotGlobalUnicast},


### PR DESCRIPTION
👋 Hi! We are planning on using smokescreen, but need the option to configure smokescreen in a "blocklist" mode, where private IP ranges are allowed by default, unless they are explicitly blocked. 

For example, we need to allow access to all of `172.16.0.0/12`, but block `172.17.0.0/16`. This is not currently possible with smokescreen, since the [allow-list applies before the block-list](https://github.com/stripe/smokescreen/blob/master/pkg/smokescreen/smokescreen.go#L151-L154). `./smokescreen --allow-range 172.16.0.0/12 --deny-range 172.17.0.0/16` will not block the range `172.17.0.0/16`.

The simplest solution is to configure smokescreen in "blocklist mode", . This change introduces the option to pass an `--unsafe-allow-private-ranges` flag which instructs smokescreen to allow private ranges by default, but still respect the `--deny-range` option. (_Note: this only inverts behavior for RFC 1918 ranges. Stuff like 169.254.269.254 will still be blocked by default. I'm open to changing that if you prefer!_)

I'm not totally sure if this is something you want to include in smokescreen. This is definitely the easiest option for us, but I can understand the argument that this behavior would be better in a smokescreen fork. Alternatively, we could do some CIDR math to compute exactly which ranges should be allowed/denied. That's potentially doable, but would get a bit complicated for us (for reasons that are hard to explain :) )