### PR TITLE
allow ipv4 only dns lookups

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -55,6 +55,9 @@ type Config struct {
 	Healthcheck                  http.Handler // User defined http.Handler for optional requests to a /healthcheck endpoint
 	ShuttingDown                 atomic.Value // Stores a boolean value indicating whether the proxy is actively shutting down
 
+	// Only resolve ipv4 addrs during DNS lookups
+	IPv4OnlyLookups bool
+
 	// A connection is idle if it has been inactive (no bytes in/out) for this many seconds.
 	IdleTimeout time.Duration
 

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -30,6 +30,7 @@ type yamlConfig struct {
 	SupportProxyProtocol bool     `yaml:"support_proxy_protocol"`
 	DenyMessageExtra     string   `yaml:"deny_message_extra"`
 	AllowMissingRole     bool     `yaml:"allow_missing_role"`
+	IPv4OnlyLookups      bool     `yaml:"ipv4_only_lookups"`
 
 	ConnectTimeout time.Duration  `yaml:"connect_timeout"`
 	IdleTimeout    time.Duration  `yaml:"idle_timeout"`
@@ -133,6 +134,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 
+	c.IPv4OnlyLookups = yc.IPv4OnlyLookups
 	c.AllowMissingRole = yc.AllowMissingRole
 	c.AdditionalErrorMessageOnDeny = yc.DenyMessageExtra
 	c.TimeConnect = yc.TimeConnect


### PR DESCRIPTION
This PR allows Smokescreen to be configured to only perform IPv4 lookups. `LookupIPAddr` looks up both v4 and v6 addresses, which doubles the total number of DNS queries to the configured resolver. Go 1.15 introduced a new function, [LookupIP](https://golang.org/pkg/net/#Resolver.LookupIP), which only performs v4 lookups. We will continue to default to the old behavior but allow clients to configure Smokescreen to only perform v4 lookups.

r? @mattm-stripe 
cc @stripe/platform-security 
