### PR TITLE
Disallow wildcard ACL entries that match all hostnames

### DIFF
--- a/pkg/smokescreen/acl/v1/acl.go
+++ b/pkg/smokescreen/acl/v1/acl.go
@@ -181,6 +181,10 @@ func (acl *ACL) ValidateDomains(domains []string) error {
 			return fmt.Errorf("glob cannot be empty")
 		}
 
+		if d == "*" || d == "*." {
+			return fmt.Errorf("glob cannot match all hostnames")
+		}
+
 		if !strings.HasPrefix(d, "*.") && strings.HasPrefix(d, "*") {
 			return fmt.Errorf("%v: domain glob must represent a full prefix (sub)domain", d)
 		}

--- a/pkg/smokescreen/acl/v1/acl_test.go
+++ b/pkg/smokescreen/acl/v1/acl_test.go
@@ -223,17 +223,23 @@ func TestACLMalformedPolicyDisable(t *testing.T) {
 func TestACLAddInvalidDomain(t *testing.T) {
 	a := assert.New(t)
 
+	testDomains := []string{
+		"*.*.stripe.com", // multiple stars in glob
+		"*",              // glob matches everything
+		"*.",             // glob matches everything
+	}
+
 	acl := &ACL{
-		Rules: make(map[string]Rule),
+		Rules: make(map[string]Rule, len(testDomains)),
 	}
 
-	r := Rule{
-		Project:     "security",
-		Policy:      Open,
-		DomainGlobs: []string{"*.*.stripe.com"},
+	for _, td := range testDomains {
+		a.Error(acl.Add("acl", Rule{
+			Project:     "security",
+			Policy:      Open,
+			DomainGlobs: []string{td},
+		}), "did not reject invalid domain %q", td)
 	}
-
-	a.Error(acl.Add("acl", r))
 }
 
 func TestACLAddExistingRule(t *testing.T) {


### PR DESCRIPTION
r? @cds2-stripe 
cc @stripe/platform-security 

Explicitly disallow adding ACL entries with a domain of `*` or `*.` and update the tests to ensure these are rejected.  (`*` is already rejected by the tests, but `*.` isn't.)

Example test failure (after commenting out a check in `acl.go`):

```
--- FAIL: TestACLAddInvalidDomain (0.00s)
    acl_test.go:237: 
        	Error Trace:	acl_test.go:237
        	Error:      	An error is expected but got nil.
        	Test:       	TestACLAddInvalidDomain
        	Messages:   	did not reject invalid domain "*."
```