### PR TITLE
Use constants for logger field names

### DIFF
--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -11,7 +11,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const CanonicalProxyConnClose = "CANONICAL-PROXY-CN-CLOSE"
+const (
+	LogFieldBytesIn         = "bytes_in"
+	LogFieldBytesOut        = "bytes_out"
+	LogFieldEndTime         = "end_time"
+	LogFieldDuration        = "duration"
+	LogFieldError           = "error"
+	LogFieldLastActivity    = "last_activity"
+	CanonicalProxyConnClose = "CANONICAL-PROXY-CN-CLOSE"
+)
 
 type InstrumentedConn struct {
 	net.Conn
@@ -107,12 +115,12 @@ func (ic *InstrumentedConn) Close() error {
 	}
 
 	ic.logger.WithFields(logrus.Fields{
-		"bytes_in":      ic.BytesIn,
-		"bytes_out":     ic.BytesOut,
-		"end_time":      end.UTC(),
-		"duration":      duration,
-		"error":         errorMessage,
-		"last_activity": time.Unix(0, atomic.LoadInt64(ic.LastActivity)).UTC(),
+		LogFieldBytesIn:      ic.BytesIn,
+		LogFieldBytesOut:     ic.BytesOut,
+		LogFieldEndTime:      end.UTC(),
+		LogFieldDuration:     duration,
+		LogFieldError:        errorMessage,
+		LogFieldLastActivity: time.Unix(0, atomic.LoadInt64(ic.LastActivity)).UTC(),
 	}).Info(CanonicalProxyConnClose)
 
 	ic.tracker.Wg.Done()

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -55,6 +55,8 @@ const (
 	LogFieldAllow            = "allow"
 	LogFieldError            = "error"
 	CanonicalProxyDecision   = "CANONICAL-PROXY-DECISION"
+	LogFieldConnEstablishMS  = "conn_establish_time_ms"
+	LogFieldDNSLookupTime    = "dns_lookup_time_ms"
 )
 
 type ipType int
@@ -275,7 +277,7 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	connTime := time.Since(start)
 
 	fields := logrus.Fields{
-		"conn_establish_time_ms": connTime.Milliseconds(),
+		LogFieldConnEstablishMS: connTime.Milliseconds(),
 	}
 
 	if sctx.cfg.TimeConnect {
@@ -567,7 +569,7 @@ func logProxy(config *Config, pctx *goproxy.ProxyCtx) {
 
 	// If a lookup takes less than 1ms it will be rounded down to zero. This can separated from
 	// actual failures where the default zero value will also have the error field set.
-	fields["dns_lookup_time_ms"] = sctx.lookupTime.Milliseconds()
+	fields[LogFieldDNSLookupTime] = sctx.lookupTime.Milliseconds()
 
 	if pctx.Resp != nil {
 		fields[LogFieldContentLength] = pctx.Resp.ContentLength

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -36,7 +36,26 @@ const (
 	connectProxy = "connect"
 )
 
-const CanonicalProxyDecision = "CANONICAL-PROXY-DECISION"
+const (
+	LogFieldID               = "id"
+	LogFieldOutLocalAddr     = "outbound_local_addr"
+	LogFieldOutRemoteAddr    = "outbound_remote_addr"
+	LogFieldInRemoteAddr     = "inbound_remote_addr"
+	LogFieldProxyType        = "proxy_type"
+	LogFieldRequestedHost    = "requested_host"
+	LogFieldStartTime        = "start_time"
+	LogFieldTraceID          = "trace_id"
+	LogFieldInRemoteX509CN   = "inbound_remote_x509_cn"
+	LogFieldInRemoteX509OU   = "inbound_remote_x509_ou"
+	LogFieldRole             = "role"
+	LogFieldProject          = "project"
+	LogFieldContentLength    = "content_length"
+	LogFieldDecisionReason   = "decision_reason"
+	LogFieldEnforceWouldDeny = "enforce_would_deny"
+	LogFieldAllow            = "allow"
+	LogFieldError            = "error"
+	CanonicalProxyDecision   = "CANONICAL-PROXY-DECISION"
+)
 
 type ipType int
 
@@ -274,11 +293,11 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 		fields := logrus.Fields{}
 
 		if addr := conn.LocalAddr(); addr != nil {
-			fields["outbound_local_addr"] = addr.String()
+			fields[LogFieldOutLocalAddr] = addr.String()
 		}
 
 		if addr := conn.RemoteAddr(); addr != nil {
-			fields["outbound_remote_addr"] = addr.String()
+			fields[LogFieldOutRemoteAddr] = addr.String()
 		}
 
 	}
@@ -378,12 +397,12 @@ func newContext(cfg *Config, proxyType string, req *http.Request) *smokescreenCo
 	start := time.Now()
 
 	logger := cfg.Log.WithFields(logrus.Fields{
-		"id":                  xid.New().String(),
-		"inbound_remote_addr": req.RemoteAddr,
-		"proxy_type":          proxyType,
-		"requested_host":      req.Host,
-		"start_time":          start.UTC(),
-		"trace_id":            req.Header.Get(traceHeader),
+		LogFieldID:            xid.New().String(),
+		LogFieldInRemoteAddr:  req.RemoteAddr,
+		LogFieldProxyType:     proxyType,
+		LogFieldRequestedHost: req.Host,
+		LogFieldStartTime:     start.UTC(),
+		LogFieldTraceID:       req.Header.Get(traceHeader),
 	})
 
 	return &smokescreenContext{
@@ -527,17 +546,17 @@ func logProxy(config *Config, pctx *goproxy.ProxyCtx) {
 
 	// attempt to retrieve information about the host originating the proxy request
 	if pctx.Req.TLS != nil && len(pctx.Req.TLS.PeerCertificates) > 0 {
-		fields["inbound_remote_x509_cn"] = pctx.Req.TLS.PeerCertificates[0].Subject.CommonName
+		fields[LogFieldInRemoteX509CN] = pctx.Req.TLS.PeerCertificates[0].Subject.CommonName
 		var ouEntries = pctx.Req.TLS.PeerCertificates[0].Subject.OrganizationalUnit
 		if len(ouEntries) > 0 {
-			fields["inbound_remote_x509_ou"] = ouEntries[0]
+			fields[LogFieldInRemoteX509OU] = ouEntries[0]
 		}
 	}
 
 	decision := sctx.decision
 	if sctx.decision != nil {
-		fields["role"] = decision.role
-		fields["project"] = decision.project
+		fields[LogFieldRole] = decision.role
+		fields[LogFieldProject] = decision.project
 	}
 
 	// add the above fields to all future log messages sent using this smokescreen context's logger
@@ -551,18 +570,18 @@ func logProxy(config *Config, pctx *goproxy.ProxyCtx) {
 	fields["dns_lookup_time_ms"] = sctx.lookupTime.Milliseconds()
 
 	if pctx.Resp != nil {
-		fields["content_length"] = pctx.Resp.ContentLength
+		fields[LogFieldContentLength] = pctx.Resp.ContentLength
 	}
 
 	if sctx.decision != nil {
-		fields["decision_reason"] = decision.reason
-		fields["enforce_would_deny"] = decision.enforceWouldDeny
-		fields["allow"] = decision.allow
+		fields[LogFieldDecisionReason] = decision.reason
+		fields[LogFieldEnforceWouldDeny] = decision.enforceWouldDeny
+		fields[LogFieldAllow] = decision.allow
 	}
 
 	err := pctx.Error
 	if err != nil {
-		fields["error"] = err.Error()
+		fields[LogFieldError] = err.Error()
 	}
 
 	entry := sctx.logger.WithFields(fields)


### PR DESCRIPTION
This change introduces exported constants for logging field names. This enables the use of loggers with attached hooks, see [logrus.Hook](https://pkg.go.dev/github.com/sirupsen/logrus#Hook). While hooking is possible even now without constants, key names could change at any time and silently break implementations.