### PR TITLE
add dns and tcp timing information to logs

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -545,6 +545,9 @@ func logProxy(config *Config, pctx *goproxy.ProxyCtx) {
 
 	// start a new set of fields used only in this log message
 	fields = logrus.Fields{}
+
+	// If a lookup takes less than 1ms it will be rounded down to zero. This can separated from
+	// actual failures where the default zero value will also have the error field set.
 	fields["dns_lookup_time_ms"] = sctx.lookupTime.Milliseconds()
 
 	if pctx.Resp != nil {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -256,7 +256,7 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	connTime := time.Since(start)
 
 	fields := logrus.Fields{
-		"conn_establish_time": connTime.String(),
+		"conn_establish_time_ms": connTime.Milliseconds(),
 	}
 
 	if sctx.cfg.TimeConnect {
@@ -525,8 +525,6 @@ func logProxy(config *Config, pctx *goproxy.ProxyCtx) {
 
 	fields := logrus.Fields{}
 
-	fields["dns_lookup_time"] = sctx.lookupTime.String()
-
 	// attempt to retrieve information about the host originating the proxy request
 	if pctx.Req.TLS != nil && len(pctx.Req.TLS.PeerCertificates) > 0 {
 		fields["inbound_remote_x509_cn"] = pctx.Req.TLS.PeerCertificates[0].Subject.CommonName
@@ -547,6 +545,7 @@ func logProxy(config *Config, pctx *goproxy.ProxyCtx) {
 
 	// start a new set of fields used only in this log message
 	fields = logrus.Fields{}
+	fields["dns_lookup_time_ms"] = sctx.lookupTime.Milliseconds()
 
 	if pctx.Resp != nil {
 		fields["content_length"] = pctx.Resp.ContentLength


### PR DESCRIPTION
This PR adds TCP connection establishment and DNS lookup timing information to smokescreen's logs. This is being done to provide more granular connection information to help debug cases where a downstream service has a tight timeout window. Currently when a connection is timed out by the requestor it can be difficult to understand where time was spent in the connection initialization process.

`dns_lookup_time` will be logged with every CANONICAL-PROXY-DECISION log line. As we pre-resolve the requested host, we're able to attach this to the decision log. This field represents the time spent resolving the requested hostname.

`tcp_establish_time` is the amount of time spent establishing the TCP connection. Because of the asynchronous way `goproxy` invokes our custom `net.Transport` we can only add this field to the CANONICAL-PROXY-CN-CLOSE log line. `goproxy` requires us to decide whether to proxy the request prior to establishing the TCP connection. This means that we log the proxy decision before the TCP connection is established.

I've deployed this internally and verified the fields are being populated as expected.