### PR TITLE
Improve hostname glob comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ If a domain matches both the `global_allow_list` and the `global_deny_list`, the
 - Andrew Dunham
 - Andrew Metcalf
 - Aniket Joshi
+- Ben Ransford
 - Carl Jackson
 - Craig Shannon
 - Evan Broder

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 )
 
-const versionSemantic = "0.0.2"
+const versionSemantic = "0.0.3"
 
 // This can be set at build time:
 // go build -ldflags='-X github.com/stripe/smokescreen/pkg/smokescreen.VersionID=33955a3' .


### PR DESCRIPTION
Several improvements to hostname versus ACL comparisons.

- canonicalize hostname and glob to lowercase before comparison
- ignore legal trailing dot in comparison
- reject globs matching all hostnames (folded #145 into this branch)
- improve error message on glob validation errors
- add comments clarifying intentions
- add unit tests

One slightly breaking change that I am happy to remove if it's not palatable: I renamed `ValidateDomains` to `ValidateDomainGlobs` in the interest of accuracy.