### PR TITLE
CI matrix maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x]
         platform: [ubuntu-16.04, ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.16.x, 1.17.x]
-        platform: [ubuntu-16.04, ubuntu-latest]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x]
+        go-version: [1.16.x, 1.17.x]
         platform: [ubuntu-16.04, ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Smokescreen uses a [custom fork](https://github.com/stripe/goproxy) of goproxy t
 
 Smokescreen is built and tested using the following Go releases. Generally, Smokescreen will only support the two most recent Go versions.
 
-- go1.15.x
+- go1.17.x
 - go1.16.x
 
 [mod]: https://github.com/golang/go/wiki/Modules


### PR DESCRIPTION
- Add Go 1.17.x, drop 1.15.x per readme
- Remove Ubuntu 16.04 (now [EOL](https://ubuntu.com/16-04))