### PR TITLE
bump goproxy to 3f1dfba6d1a4747c78fee7069e2f28fd6b703917

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -1,3 +1,4 @@
+//go:build !nointegration
 // +build !nointegration
 
 package cmd
@@ -368,8 +369,8 @@ func TestSmokescreenIntegration(t *testing.T) {
 					if expectAllow {
 						testCase.ExpectStatus = http.StatusOK
 						if overTLS && !authorizedHost {
-							// The Stripe API returns a 403 to a bare HTTP GET request
-							testCase.ExpectStatus = http.StatusUnauthorized
+							// The Stripe API returns a 404 to a bare HTTP GET request
+							testCase.ExpectStatus = http.StatusNotFound
 						}
 					} else {
 						testCase.ExpectStatus = http.StatusProxyAuthRequired

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.3.0
-	github.com/stripe/goproxy v0.0.0-20201214151142-bb691dcfe7e9
+	github.com/stripe/goproxy v0.0.0-20220308202309-3f1dfba6d1a4
 	golang.org/x/net v0.0.0-20200528225125-3c3fba18258b // indirect
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/urfave/cli.v1 v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stripe/goproxy v0.0.0-20201214151142-bb691dcfe7e9 h1:4BvarxVTLjeiXfHrl3JxfjXTSjXi1AU034EcGvzFOos=
 github.com/stripe/goproxy v0.0.0-20201214151142-bb691dcfe7e9/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20220308202309-3f1dfba6d1a4 h1:6lqpRCXAhigpiMu6aZYTHryDmLrhIND0H4iUKEntN1M=
+github.com/stripe/goproxy v0.0.0-20220308202309-3f1dfba6d1a4/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=

--- a/vendor/github.com/stripe/goproxy/https.go
+++ b/vendor/github.com/stripe/goproxy/https.go
@@ -420,7 +420,7 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 			}
 			defer resp.Body.Close()
 			if resp.StatusCode != 200 {
-				resp, err := ioutil.ReadAll(resp.Body)
+				resp, err := ioutil.ReadAll(io.LimitReader(resp.Body, 500))
 				if err != nil {
 					return nil, err
 				}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -26,7 +26,7 @@ github.com/sirupsen/logrus/hooks/test
 ## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/stripe/goproxy v0.0.0-20201214151142-bb691dcfe7e9
+# github.com/stripe/goproxy v0.0.0-20220308202309-3f1dfba6d1a4
 ## explicit
 github.com/stripe/goproxy
 # golang.org/x/net v0.0.0-20200528225125-3c3fba18258b


### PR DESCRIPTION
This bumps the version of `stripe/goproxy` to the latest master. Specifically it brings in two commits:
* [Limit response size from upstream proxies](https://github.com/stripe/goproxy/pull/20)
* [Add KeepAcceptEncoding option to keep the Accept-Encoding header intact ](https://github.com/stripe/goproxy/pull/19)

I also fixed an integration test that changed since the last PR. You can verify the new behavior is correct manually with:
```
curl -I https://api.stripe.com
HTTP/2 404
```

r? @jjiang-stripe 