### PR TITLE
Go 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.17.x, 1.18.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Smokescreen uses a [custom fork](https://github.com/stripe/goproxy) of goproxy t
 
 Smokescreen is built and tested using the following Go releases. Generally, Smokescreen will only support the two most recent Go versions.
 
+- go1.18.x
 - go1.17.x
-- go1.16.x
 
 [mod]: https://github.com/golang/go/wiki/Modules
 


### PR DESCRIPTION
r? @jjiang-stripe 

This bumps the supported Go version to 1.18 and drops support for Go 1.16. I also fixed a test that was causing failures in https://github.com/stripe/smokescreen/pull/155.