### PR TITLE
Use tags to track successful/failed connection attempt metrics

### DIFF
--- a/pkg/smokescreen/metrics.go
+++ b/pkg/smokescreen/metrics.go
@@ -20,8 +20,6 @@ var metrics = []string{
 	"acl.role_not_determined",
 	"acl.unknown_error",
 	"cn.atpt.connect.time",
-	"cn.atpt.fail.total",
-	"cn.atpt.success.total",
 	"cn.atpt.total",
 	"resolver.allow.default",
 	"resolver.allow.user_configured",

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -263,8 +263,6 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 		}
 	}
 
-	sctx.cfg.MetricsClient.Incr("cn.atpt.total", 1)
-
 	var conn net.Conn
 	var err error
 
@@ -286,10 +284,10 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	}
 
 	if err != nil {
-		sctx.cfg.MetricsClient.Incr("cn.atpt.fail.total", 1)
+		sctx.cfg.MetricsClient.IncrWithTags("cn.atpt.total", []string{"success:false"}, 1)
 		return nil, err
 	}
-	sctx.cfg.MetricsClient.Incr("cn.atpt.success.total", 1)
+	sctx.cfg.MetricsClient.IncrWithTags("cn.atpt.total", []string{"success:true"}, 1)
 
 	if conn != nil {
 		fields := logrus.Fields{}


### PR DESCRIPTION
r? @cds2-stripe 

Defining these as two separate metrics means it's difficult to get an accurate success rate because metrics occasionally get reported into separate windows. By using tags instead, we can properly measure success/failure rates. This PR does exactly that! 

I deployed this internally and verified that metrics continue to be reported as expected, with the appropriate tag value.