### PR TITLE
Fix hostname parsing for hosts with square brackets

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -457,7 +457,7 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 		pctx.RoundTripper = rtFn
 
 		// Build an address parsable by net.ResolveTCPAddr
-		remoteHost := req.Host
+		remoteHost := req.URL.Hostname()
 		if strings.LastIndex(remoteHost, ":") <= strings.LastIndex(remoteHost, "]") {
 			switch req.URL.Scheme {
 			case "http":
@@ -600,7 +600,7 @@ func handleConnect(config *Config, pctx *goproxy.ProxyCtx) error {
 	sctx := pctx.UserData.(*smokescreenContext)
 
 	// Check if requesting role is allowed to talk to remote
-	sctx.decision, sctx.lookupTime, pctx.Error = checkIfRequestShouldBeProxied(config, pctx.Req, pctx.Req.Host)
+	sctx.decision, sctx.lookupTime, pctx.Error = checkIfRequestShouldBeProxied(config, pctx.Req, pctx.Req.URL.Hostname())
 	if pctx.Error != nil {
 		return pctx.Error
 	}

--- a/pkg/smokescreen/testdata/acl.yaml
+++ b/pkg/smokescreen/testdata/acl.yaml
@@ -1,14 +1,20 @@
 ---
-    version: v1
-    services:
-      - name: test-trusted-srv
-        project: security
-        action: enforce
-        allowed_domains:
-          - notarealhost.test
-          - httpbin.org
-      - name: test-local-srv
-        project: security
-        action: open
-        allowed_domains:
-          - 127.0.0.1
+version: v1
+services:
+  - name: test-trusted-srv
+    project: security
+    action: enforce
+    allowed_domains:
+      - notarealhost.test
+      - httpbin.org
+  - name: test-local-srv
+    project: security
+    action: open
+    allowed_domains:
+      - 127.0.0.1
+  - name: test-open-srv
+    project: security
+    action: open
+
+global_deny_list:
+  - stripe.com


### PR DESCRIPTION
r? @cds2-stripe

This fixes up our handling for hostnames that contain square brackets, like `[stripe.com]`. We check against our ACL using `[stripe.com]` instead of `stripe.com` and then make a DNS query + request for `stripe.com`, which is confusing and inconsistent (the request ends up being malformed, but it's still bizarre). I've done a bit of hackery to get from `[stripe.com]` -> `stripe.com:80` as cleanly as possible without breaking things for IPv6 addresses. I've stared at this code possibly a little _too_ long so it's quite likely I've overengineered a solution here and I'm very open to alternatives 😅

I added a unit test to confirm the behaviour, and will deploy this internally to verify existing use cases still work as intended.