### PR TITLE
Accept a flag which parses the role from an HTTP header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ Smokescreen will warn you if you load a CA certificate with no associated CRL an
 Smokescreen can be provided with an ACL to determine which remote
 hosts a service is allowed to interact with.  By default, Smokescreen
 will identify clients by the "common name" in the TLS certificate they
-present, if any.  The client identification function can also be
-easily replaced; more on this in the usage section.
+present, if any. If `--trust-role-from-header` is supplied, it instead
+trusts the role provided in the specified CONNECT HTTP header. The
+client identification function can also be easily replaced; more on
+this in the usage section.
 
 ## Dependencies
 

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"time"
 
+	"net/http"
+
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/urfave/cli.v1"
 
@@ -104,6 +106,10 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 		cli.StringSliceFlag{
 			Name:  "tls-crl-file",
 			Usage: "Verify validity of client certificates against Certificate Revocation List from `FILE`",
+		},
+		cli.StringFlag{
+			Name:  "trust-role-from-header",
+			Usage: "Trust the provided header name to contain the client's role.\nNote that this is unsafe against clients with the ability to construct arbitrary HTTP requests!",
 		},
 		cli.StringFlag{
 			Name:  "additional-error-message-on-deny",
@@ -259,6 +265,10 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 				c.StringSlice("tls-client-ca-file")); err != nil {
 				return err
 			}
+		}
+
+		if c.IsSet("trust-role-from-header") {
+			conf.TrustRoleFromHeader = http.CanonicalHeaderKey(c.String("trust-role-from-header"))
 		}
 
 		// Setup the connection tracker

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	SupportProxyProtocol         bool
 	TlsConfig                    *tls.Config
 	CrlByAuthorityKeyId          map[string]*pkix.CertificateList
+	TrustRoleFromHeader          string
 	RoleFromRequest              func(subject *http.Request) (string, error)
 	clientCasBySubjectKeyId      map[string]*x509.Certificate
 	AdditionalErrorMessageOnDeny string

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -145,7 +145,6 @@ func (t ipType) statsdString() string {
 }
 
 const errorHeader = "X-Smokescreen-Error"
-const roleHeader = "X-Smokescreen-Role"
 const traceHeader = "X-Smokescreen-Trace-ID"
 
 func addrIsInRuleRange(ranges []RuleRange, addr *net.TCPAddr) bool {
@@ -479,7 +478,9 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 
 		// Delete Smokescreen specific headers before goproxy forwards the request
 		defer func() {
-			req.Header.Del(roleHeader)
+			if config.TrustRoleFromHeader != "" {
+				req.Header.Del(config.TrustRoleFromHeader)
+			}
 			req.Header.Del(traceHeader)
 		}()
 


### PR DESCRIPTION
a94c48a4f4ee removed this default behaviour; add it back, though
protected by a flag.

---

This came up in #141, and we'd find it useful behaviour to have available.

"import `smokescreen` and override `conf.RoleFromRequest`" is a fine response to this, but I think it's a useful low-stakes way to configure roles, and provide out-of-the-box.