### PR TITLE
Strip all square brackets

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -415,7 +415,7 @@ func newContext(cfg *Config, proxyType string, req *http.Request) *smokescreenCo
 }
 
 func stripSquareBrackets(host string) string {
-	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+	for strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
 		host = host[1 : len(host)-1]
 	}
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -898,6 +898,10 @@ func checkACLsForRequest(config *Config, req *http.Request, outboundHost string)
 	decision.role = role
 
 	submatch := hostExtractRE.FindStringSubmatch(outboundHost)
+	if len(submatch) < 2 {
+		decision.reason = "Destination host cannot be determined"
+		return decision
+	}
 	destination := submatch[1]
 
 	aclDecision, err := config.EgressACL.Decide(role, destination)

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -414,21 +414,19 @@ func newContext(cfg *Config, proxyType string, req *http.Request) *smokescreenCo
 	}
 }
 
-func stripSquareBrackets(host string) string {
-	for strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
-		host = host[1 : len(host)-1]
-	}
-
-	return host
-}
-
 // This is hacky but necessary in order to remove square brackets from non-IPv6 addresses
 // Otherwise, we'd be checking our ACL for "[stripe.com]" rather than "stripe.com"
 func normalizeHost(host, scheme string) (string, error) {
 	hostname, port, err := net.SplitHostPort(host)
 	if err != nil {
 		if strings.Contains(err.Error(), "missing port in address") {
-			hostname = stripSquareBrackets(host)
+			// net.SplitHostPort should remove square brackets on a valid IPv6 address, so if there
+			// are still square brackets, the hostname is malformed and we should just return an error
+			if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+				return "", denyError{fmt.Errorf("unable to parse destination host")}
+			}
+
+			hostname = host
 			switch scheme {
 			case "http":
 				port = "80"


### PR DESCRIPTION
r? @cds2-stripe 

As a follow up to https://github.com/stripe/smokescreen/pull/158, if you supply a hostname with _two_ sets of square brackets (e.g. [[example.com]]), it ends up only stripping one set ([example.com]) and we end up falling into the old code path that allowed the request. Converting to a loop _should_ fix things. I also added a bit of error handling in the ACL matching code that would panic if you passed something like `[[example.com]]:80` because `net.SplitHostPort` would fail, and we'd end up passing `[[[example.com]]:80]:80`. Given that the hostname is malformed anyway, I figured it wasn't worth trying to parse it into something manageable, and we should just deny and return an error.

I've added several tests to confirm the behaviour. I also ran this and tested an example set up to confirm this now works.