### PR TITLE
Improve address normalization

### DIFF
--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -1,9 +1,5 @@
 package smokescreen
 
-import (
-	"regexp"
-)
-
 const versionSemantic = "0.0.3"
 
 // This can be set at build time:
@@ -15,15 +11,3 @@ func Version() string {
 }
 
 const DefaultStatsdNamespace = "smokescreen."
-
-// Using a globally-shared Regexp can impact performace due to lock contention,
-// but calling Copy() for each connection is much worse, and it looks like
-// handing out Regexps from a pool doesn't save us anything either, so we'll
-// just live with it.
-const hostExtractPattern = "^([^:]*)(:\\d+)?$"
-
-var hostExtractRE *regexp.Regexp
-
-func init() {
-	hostExtractRE = regexp.MustCompile(hostExtractPattern)
-}

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -1,6 +1,7 @@
 package smokescreen
 
 const versionSemantic = "0.0.3"
+const portMin, portMax = 0, 65535
 
 // This can be set at build time:
 // go build -ldflags='-X github.com/stripe/smokescreen/pkg/smokescreen.VersionID=33955a3' .

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -452,7 +452,7 @@ func normalizeHost(hostPort, scheme string, forceFQDN bool) (string, int, error)
 		if err != nil {
 			return "", noPort, fmt.Errorf("invalid port number %#v: %v", port, err)
 		}
-		if port < portMin && port > portMax {
+		if port < portMin || port > portMax {
 			return "", noPort, fmt.Errorf("invalid port number %#v: must be between %d and %d", port, portMin, portMax)
 		}
 	}

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -421,8 +421,11 @@ func hasPort(s string) bool {
 	return strings.LastIndex(s, "]") < strings.LastIndex(s, ":")
 }
 
-// This is hacky but necessary in order to remove square brackets from non-IPv6 addresses
-// Otherwise, we'd be checking our ACL for "[stripe.com]" rather than "stripe.com"
+// normalizeHost returns host (as string) and port (as int) derived from  the
+// `hostPort` string. `hostPort` is a colon-separated (':') DNS name and port.
+//
+// Returns a normalized representation of host (Punycode for DNS names,
+// standardized IP address representation), as well as the port number.
 func normalizeHost(hostPort, scheme string) (string, int, error) {
 	host := hostPort
 	var err error

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -437,6 +437,9 @@ func normalizeHost(hostPort, scheme string, forceFQDN bool) (string, int, error)
 	// net.SplitHostPort() doesn't handle bare IPv6 addresses well so
 	// handle that case first.
 	if ip := net.ParseIP(hostPort); ip != nil && ip.To4() == nil {
+		// IP addresses might have different but equivalent representations
+		// (e.g., `2001:DB8::` and `2001:db8::` are the same address).
+		// Let's make sure we use a consistent representation from now on.
 		host = ip.String()
 	} else if hasPort(hostPort) {
 		// Extract host and port if both are provided.

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -465,9 +465,9 @@ func normalizeHost(hostPort, scheme string, forceFQDN bool) (string, int, error)
 	if ip := net.ParseIP(host); ip != nil {
 		host = ip.String()
 	} else {
-		// If it's not an IP address then it must be's a domain name.
-		// Convert it to Punycode it so that we deal only with with ASCII from now on
-		// and we find out if the domain name is malformed.
+		// If it's not an IP address then it must be a domain name.
+		// Convert it to Punycode it so that we deal only with with ASCII from now on.
+		// This way we can find out whether the domain name is malformed.
 		host, err = idna.Lookup.ToASCII(host)
 		if err != nil {
 			return "", noPort, fmt.Errorf("invalid domain '%v': %v", host, err)

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -886,12 +886,12 @@ func getRole(config *Config, req *http.Request) (string, error) {
 
 func checkIfRequestShouldBeProxied(config *Config, req *http.Request, host string, port int) (*aclDecision, time.Duration, error) {
 	decision := checkACLsForRequest(config, req, host, port)
-	socketAddress := net.JoinHostPort(host, strconv.Itoa(port))
 
 	var lookupTime time.Duration
 	if decision.allow {
 		start := time.Now()
-		resolved, reason, err := safeResolve(config, "tcp", socketAddress)
+		hostPort := net.JoinHostPort(host, strconv.Itoa(port))
+		resolved, reason, err := safeResolve(config, "tcp", hostPort)
 		lookupTime = time.Since(start)
 		if err != nil {
 			if _, ok := err.(denyError); !ok {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -463,6 +463,9 @@ func normalizeHost(hostPort, scheme string, forceFQDN bool) (string, int, error)
 	}
 
 	if ip := net.ParseIP(host); ip != nil {
+		// IP addresses might have different but equivalent representations
+		// (e.g., `2001:DB8::` and `2001:db8::` are the same address).
+		// Let's make sure we use a consistent representation from now on.
 		host = ip.String()
 	} else {
 		// If it's not an IP address then it must be a domain name.

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -458,7 +458,7 @@ func normalizeHost(hostPort, scheme string, forceFQDN bool) (string, int, error)
 		// Port was not provided so try to determine it based on scheme.
 		port, err = net.LookupPort("tcp", scheme)
 		if err != nil {
-			return "", noPort, fmt.Errorf("unable to determine port: %v", err)
+			return "", noPort, fmt.Errorf("unable to determine port for %v", scheme)
 		}
 	}
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -427,9 +427,9 @@ func hasPort(s string) bool {
 // Returns a normalized representation of host (Punycode for DNS names,
 // standardized IP address representation), as well as the port number.
 func normalizeHost(hostPort, scheme string) (string, int, error) {
-	const portMin, portMax = 0, 65535
 	var err error
-	host, port := hostPort, -1
+	const noPort = -1
+	host, port := hostPort, noPort
 
 	// net.SplitHostPort() doesn't handle bare IPv6 addresses well so
 	// handle that case first.
@@ -440,22 +440,22 @@ func normalizeHost(hostPort, scheme string) (string, int, error) {
 		var portString string
 		host, portString, err = net.SplitHostPort(hostPort)
 		if err != nil {
-			return "", -1, fmt.Errorf("unable to parse host: %v", err)
+			return "", noPort, fmt.Errorf("unable to parse host: %v", err)
 		}
 		port, err = strconv.Atoi(portString)
 		if err != nil {
-			return "", -1, fmt.Errorf("invalid port number %#v: %v", port, err)
+			return "", noPort, fmt.Errorf("invalid port number %#v: %v", port, err)
 		}
 		if port < portMin && port > portMax {
-			return "", -1, fmt.Errorf("invalid port number %#v: must be between %d and %d", port, portMin, portMax)
+			return "", noPort, fmt.Errorf("invalid port number %#v: must be between %d and %d", port, portMin, portMax)
 		}
 	}
 
-	if port == -1 {
+	if port == noPort {
 		// Port was not provided so try to determine it based on scheme.
 		port, err = net.LookupPort("tcp", scheme)
 		if err != nil {
-			return "", -1, fmt.Errorf("unable to determine port: %v", err)
+			return "", noPort, fmt.Errorf("unable to determine port: %v", err)
 		}
 	}
 
@@ -467,7 +467,7 @@ func normalizeHost(hostPort, scheme string) (string, int, error) {
 		// and we find out if the domain name is malformed.
 		host, err = idna.Lookup.ToASCII(host)
 		if err != nil {
-			return "", -1, fmt.Errorf("invalid domain '%v': %v", host, err)
+			return "", noPort, fmt.Errorf("invalid domain '%v': %v", host, err)
 		}
 	}
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -667,7 +667,7 @@ func handleConnect(config *Config, pctx *goproxy.ProxyCtx) (string, error) {
 	}
 	sctx.decision, sctx.lookupTime, pctx.Error = checkIfRequestShouldBeProxied(config, pctx.Req, remoteHost, remotePort)
 	if pctx.Error != nil {
-		return "", pctx.Error
+		return "", denyError{pctx.Error}
 	}
 	if !sctx.decision.allow {
 		return "", denyError{errors.New(sctx.decision.reason)}

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -421,7 +421,7 @@ func TestInvalidHost(t *testing.T) {
 
 			resp, err := client.Get(fmt.Sprintf("%s://notarealhost.test", testCase.scheme))
 			if testCase.expectErr {
-				r.Contains(err.Error(), "Bad gateway")
+				r.Contains(err.Error(), "Request rejected by proxy")
 			} else {
 				r.NoError(err)
 				r.Equal(http.StatusBadGateway, resp.StatusCode)

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -459,7 +459,7 @@ func TestHostNormalization(t *testing.T) {
 		{"https", "2001:DB8::1337", "2001:db8::1337", 443, false, ""},
 		{"https", "[2001:DB8::1337]:443", "2001:db8::1337", 443, false, ""},
 		{"https", "[2001:db8::1337]:443", "2001:db8::1337", 443, false, ""},
-		{"unknown", "[[2001:DB8::1337]]", "", -1, false, "unable to determine port: lookup tcp/unknown: nodename nor servname provided, or not known"},
+		{"unknown", "[[2001:DB8::1337]]", "", -1, false, "unable to determine port for unknown"},
 		{"https", "🔐.example.com:123", "xn--jv8h.example.com", 123, false, ""},
 		{"smtp", "✉️.example.com.", "xn--4bi.example.com.", 25, false, ""},
 		{"https", "🔐.example.com:123", "xn--jv8h.example.com.", 123, true, ""},

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -459,6 +459,8 @@ func TestHostNormalization(t *testing.T) {
 		{"https", "2001:DB8::1337", "2001:db8::1337", 443, false, ""},
 		{"https", "[2001:DB8::1337]:443", "2001:db8::1337", 443, false, ""},
 		{"https", "[2001:db8::1337]:443", "2001:db8::1337", 443, false, ""},
+		{"https", "[2001:DB8::1337]:-1", "2001:db8::1337", -1, false, "invalid port number -1: must be between 0 and 65535"},
+		{"https", "[2001:db8::1337]:111111", "2001:db8::1337", -1, false, "invalid port number 111111: must be between 0 and 65535"},
 		{"unknown", "[[2001:DB8::1337]]", "", -1, false, "unable to determine port for unknown"},
 		{"https", "🔐.example.com:123", "xn--jv8h.example.com", 123, false, ""},
 		{"smtp", "✉️.example.com.", "xn--4bi.example.com.", 25, false, ""},

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -449,11 +449,11 @@ var hostSquareBracketsCases = []struct {
 	hostname  string
 	msg       string
 }{
-	{"http", "http", "[stripe.com]", "unable to parse destination host"},
+	{"http", "http", "[stripe.com]", "invalid domain '[stripe.com]': idna: disallowed rune U+005B"},
 	{"https", "connect", "[stripe.com]", "host matched rule in global deny list"},
-	{"http", "http", "[[stripe.com]]", "unable to parse destination host"},
+	{"http", "http", "[[stripe.com]]", "invalid domain '[[stripe.com]]': idna: disallowed rune U+005B"},
 	{"https", "connect", "[[stripe.com]]", "host matched rule in global deny list"},
-	{"http", "http", "[[[stripe.com]]]", "unable to parse destination host"},
+	{"http", "http", "[[[stripe.com]]]", "invalid domain '[[[stripe.com]]]': idna: disallowed rune U+005B"},
 	{"https", "connect", "[2001:Db8::]:443", "Destination host cannot be determined"},
 	// These somewhat confusing error messages originate from net.SplitHostPort().
 	{"https", "connect", "[[[stripe.com]]]", "unable to parse host: address [[stripe.com]]:443: missing port in address"},
@@ -462,7 +462,7 @@ var hostSquareBracketsCases = []struct {
 
 func TestHostSquareBrackets(t *testing.T) {
 	for _, testCase := range hostSquareBracketsCases {
-		t.Run(testCase.scheme, func(t *testing.T) {
+		t.Run(testCase.scheme+"://"+testCase.hostname, func(t *testing.T) {
 			r := require.New(t)
 
 			cfg, err := testConfig("test-open-srv")

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -454,6 +454,7 @@ var hostSquareBracketsCases = []struct {
 	{"http", "http", "[[stripe.com]]", "unable to parse destination host"},
 	{"https", "connect", "[[stripe.com]]", "host matched rule in global deny list"},
 	{"http", "http", "[[[stripe.com]]]", "unable to parse destination host"},
+	{"https", "connect", "[2001:Db8::]:443", "Destination host cannot be determined"},
 	// These somewhat confusing error messages originate from net.SplitHostPort().
 	{"https", "connect", "[[[stripe.com]]]", "unable to parse host: address [[stripe.com]]:443: missing port in address"},
 	{"http", "http", "[[stripe.com]]:80", "unable to parse host: address [[stripe.com]]:80: missing port in address"},

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -1,3 +1,4 @@
+//go:build !nounit
 // +build !nounit
 
 package smokescreen
@@ -453,8 +454,9 @@ var hostSquareBracketsCases = []struct {
 	{"http", "http", "[[stripe.com]]", "unable to parse destination host"},
 	{"https", "connect", "[[stripe.com]]", "host matched rule in global deny list"},
 	{"http", "http", "[[[stripe.com]]]", "unable to parse destination host"},
-	{"https", "connect", "[[[stripe.com]]]", "Destination host cannot be determined"},
-	{"http", "http", "[[stripe.com]]:80", "Destination host cannot be determined"},
+	// These somewhat confusing error messages originate from net.SplitHostPort().
+	{"https", "connect", "[[[stripe.com]]]", "unable to parse host: address [[stripe.com]]:443: missing port in address"},
+	{"http", "http", "[[stripe.com]]:80", "unable to parse host: address [[stripe.com]]:80: missing port in address"},
 }
 
 func TestHostSquareBrackets(t *testing.T) {


### PR DESCRIPTION
- Use the same address for connecting to destination and for ACL checks
- Support IPv6 addresses
- Remove regexp-based domain validation
- Enforce a standardized form of IP addresses and DNS names
- Add tests for `normalizeHost()`