### PR TITLE
Use Go-embedded binary version

### DIFF
--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/carlmjohnson/versioninfo"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/urfave/cli.v1"
 
@@ -28,7 +29,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 
 	app := cli.NewApp()
 	app.Name = "smokescreen"
-	app.Version = smokescreen.Version()
+	app.Version = versioninfo.Short()
 	app.Usage = "A simple HTTP proxy that prevents SSRF and can restrict destinations"
 	app.ArgsUsage = " " // blank but non-empty to suppress default "[arguments...]"
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/DataDog/datadog-go v4.5.1+incompatible
 	github.com/Microsoft/go-winio v0.4.17 // indirect
 	github.com/armon/go-proxyproto v0.0.0-20170620220930-48572f11356f
+	github.com/carlmjohnson/versioninfo v0.22.4
 	github.com/hashicorp/go-cleanhttp v0.0.0-20171218145408-d5fe4b57a186
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Microsoft/go-winio v0.4.17 h1:iT12IBVClFevaf8PuVyi3UmZOVh4OqnaLxDTW2O
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/armon/go-proxyproto v0.0.0-20170620220930-48572f11356f h1:5FTBPzFrJqeKm10UPWvw8qU8/CLrS0OAX87PyGkycIc=
 github.com/armon/go-proxyproto v0.0.0-20170620220930-48572f11356f/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=
+github.com/carlmjohnson/versioninfo v0.22.4 h1:AucUHDSKmk6j7Yx3dECGUxaowGHOAN0Zx5/EBtsXn4Y=
+github.com/carlmjohnson/versioninfo v0.22.4/go.mod h1:QT9mph3wcVfISUKd0i9sZfVrPviHuSF+cUtLjm2WSf8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/smokescreen/constants.go
+++ b/pkg/smokescreen/constants.go
@@ -4,16 +4,6 @@ import (
 	"regexp"
 )
 
-const versionSemantic = "0.0.3"
-
-// This can be set at build time:
-// go build -ldflags='-X github.com/stripe/smokescreen/pkg/smokescreen.VersionID=33955a3' .
-var VersionID = "unknown"
-
-func Version() string {
-	return versionSemantic + "-" + VersionID
-}
-
 const DefaultStatsdNamespace = "smokescreen."
 
 // Using a globally-shared Regexp can impact performace due to lock contention,

--- a/vendor/github.com/carlmjohnson/versioninfo/LICENSE
+++ b/vendor/github.com/carlmjohnson/versioninfo/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Carl Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/carlmjohnson/versioninfo/README.md
+++ b/vendor/github.com/carlmjohnson/versioninfo/README.md
@@ -1,0 +1,5 @@
+# versioninfo [![GoDoc](https://godoc.org/github.com/carlmjohnson/versioninfo?status.svg)](https://godoc.org/github.com/carlmjohnson/versioninfo) [![Go Report Card](https://goreportcard.com/badge/github.com/carlmjohnson/versioninfo)](https://goreportcard.com/report/github.com/carlmjohnson/versioninfo)
+
+Importable package that parses `debug.ReadBuildInfo()` for inclusion in your Go application.
+
+Requires Go 1.18+ for Git revision information, but compatible with prior versions of Go.

--- a/vendor/github.com/carlmjohnson/versioninfo/flag.go
+++ b/vendor/github.com/carlmjohnson/versioninfo/flag.go
@@ -1,0 +1,54 @@
+package versioninfo
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// AddFlag adds -v and -version flags to the FlagSet.
+// If triggered, the flags print version information and call os.Exit(0).
+// If FlagSet is nil, it adds the flags to flag.CommandLine.
+func AddFlag(f *flag.FlagSet) {
+	if f == nil {
+		f = flag.CommandLine
+	}
+	f.Var(boolFunc(printVersion), "v", "short alias for -version")
+	f.Var(boolFunc(printVersion), "version", "print version information and exit")
+}
+
+func printVersion(b bool) error {
+	if !b {
+		return nil
+	}
+	fmt.Println("Version:", Version)
+	fmt.Println("Revision:", Revision)
+	if Revision != "unknown" {
+		fmt.Println("Committed:", LastCommit.Format(time.RFC1123))
+		if DirtyBuild {
+			fmt.Println("Dirty Build")
+		}
+	}
+	os.Exit(0)
+	panic("unreachable")
+}
+
+type boolFunc func(bool) error
+
+func (f boolFunc) IsBoolFlag() bool {
+	return true
+}
+
+func (f boolFunc) String() string {
+	return ""
+}
+
+func (f boolFunc) Set(s string) error {
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return err
+	}
+	return f(b)
+}

--- a/vendor/github.com/carlmjohnson/versioninfo/go.mod
+++ b/vendor/github.com/carlmjohnson/versioninfo/go.mod
@@ -1,0 +1,3 @@
+module github.com/carlmjohnson/versioninfo
+
+go 1.16

--- a/vendor/github.com/carlmjohnson/versioninfo/legacy.go
+++ b/vendor/github.com/carlmjohnson/versioninfo/legacy.go
@@ -1,0 +1,13 @@
+//go:build go1.12
+
+package versioninfo
+
+import "runtime/debug"
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	Version = info.Main.Version
+}

--- a/vendor/github.com/carlmjohnson/versioninfo/modern.go
+++ b/vendor/github.com/carlmjohnson/versioninfo/modern.go
@@ -1,0 +1,25 @@
+//go:build go1.18
+
+package versioninfo
+
+import (
+	"runtime/debug"
+	"time"
+)
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	for _, kv := range info.Settings {
+		switch kv.Key {
+		case "vcs.revision":
+			Revision = kv.Value
+		case "vcs.time":
+			LastCommit, _ = time.Parse(time.RFC3339, kv.Value)
+		case "vcs.modified":
+			DirtyBuild = kv.Value == "true"
+		}
+	}
+}

--- a/vendor/github.com/carlmjohnson/versioninfo/short.go
+++ b/vendor/github.com/carlmjohnson/versioninfo/short.go
@@ -1,0 +1,26 @@
+package versioninfo
+
+import "strings"
+
+// Short provides a short string summarizing available version information.
+func Short() string {
+	parts := make([]string, 0, 3)
+	if Version != "unknown" && Version != "(devel)" {
+		parts = append(parts, Version)
+	}
+	if Revision != "unknown" && Revision != "" {
+		parts = append(parts, "rev")
+		commit := Revision
+		if len(commit) > 7 {
+			commit = commit[:7]
+		}
+		parts = append(parts, commit)
+		if DirtyBuild {
+			parts = append(parts, "dirty")
+		}
+	}
+	if len(parts) == 0 {
+		return "devel"
+	}
+	return strings.Join(parts, "-")
+}

--- a/vendor/github.com/carlmjohnson/versioninfo/variables.go
+++ b/vendor/github.com/carlmjohnson/versioninfo/variables.go
@@ -1,0 +1,16 @@
+// Package versioninfo uses runtime.ReadBuildInfo() to set global executable revision information if possible.
+package versioninfo
+
+import "time"
+
+var (
+	// Version will be the version tag if the binary is built with "go install url/tool@version".
+	// If the binary is built some other way, it will be "(devel)".
+	Version = "unknown"
+	// Revision is taken from the vcs.revision tag in Go 1.18+.
+	Revision = "unknown"
+	// LastCommit is taken from the vcs.time tag in Go 1.18+.
+	LastCommit time.Time
+	// DirtyBuild is taken from the vcs.modified tag in Go 1.18+.
+	DirtyBuild = true
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,6 +8,9 @@ github.com/Microsoft/go-winio/pkg/guid
 # github.com/armon/go-proxyproto v0.0.0-20170620220930-48572f11356f
 ## explicit
 github.com/armon/go-proxyproto
+# github.com/carlmjohnson/versioninfo v0.22.4
+## explicit
+github.com/carlmjohnson/versioninfo
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/hashicorp/go-cleanhttp v0.0.0-20171218145408-d5fe4b57a186


### PR DESCRIPTION
Go 1.18 embeds version control information in binaries: https://tip.golang.org/doc/go1.18#go-version

Deprecate hard coded constants in favour of the new mechanism at the cost of changing version format.