### PR TITLE
report more detail on Dial errors

### DIFF
--- a/pkg/smokescreen/metrics.go
+++ b/pkg/smokescreen/metrics.go
@@ -13,14 +13,20 @@ import (
 // a persistent tag with the metric. This list must be updated with new metric names
 // if the metric should support persistent tagging.
 var metrics = []string{
+	// ACL decision statistics
 	"acl.allow",
 	"acl.decide_error",
 	"acl.deny",
 	"acl.report",
 	"acl.role_not_determined",
 	"acl.unknown_error",
-	"cn.atpt.connect.time",
-	"cn.atpt.total",
+
+	// Connection statistics (cn.atpt == connection attempt)
+	"cn.atpt.total",        // Total connection attempts, tagged by success
+	"cn.atpt.connect.time", // Connect time in ms, tagged by domain
+	"cn.atpt.connect.err",  // Connection failures, tagged by failure type
+
+	// DNS resolution statistics
 	"resolver.allow.default",
 	"resolver.allow.user_configured",
 	"resolver.attempts_total",

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -287,6 +287,7 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 
 	if err != nil {
 		sctx.cfg.MetricsClient.IncrWithTags("cn.atpt.total", []string{"success:false"}, 1)
+		reportConnError(sctx.cfg.MetricsClient, err)
 		return nil, err
 	}
 	sctx.cfg.MetricsClient.IncrWithTags("cn.atpt.total", []string{"success:true"}, 1)
@@ -316,6 +317,32 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	}
 
 	return conn, nil
+}
+
+// reportConnError emits a detailed metric about a connection error, with a tag corresponding to
+// the failure type. If err is not a net.Error, does nothing.
+func reportConnError(mc *MetricsClient, err error) {
+	e, ok := err.(net.Error)
+	if !ok {
+		return
+	}
+
+	const m = "cn.atpt.connect.err"
+	var etag string
+	switch {
+	case e.Timeout():
+		etag = "type:timeout"
+	case errors.Is(e, syscall.ECONNREFUSED):
+		etag = "type:refused"
+	case errors.Is(e, syscall.ECONNRESET):
+		etag = "type:reset"
+	case errors.Is(e, syscall.ECONNABORTED):
+		etag = "type:aborted"
+	default:
+		etag = "type:unknown"
+	}
+
+	mc.IncrWithTags("cn.atpt.connect.err", []string{etag}, 1)
 }
 
 // HTTPErrorHandler allows returning a custom error response when smokescreen


### PR DESCRIPTION
This PR teaches Smokescreen to report more detailed information about connection errors under a new metric `cn.atpt.connect.err`, tagged by `type:<something>`. It unconditionally reports this metric whenever `cn.atpt.total` is incremented with `success:false` because of a `net.Error`, i.e., when an outbound connection fails for network-y reasons.

This is the first of (at least) two PRs in this vein. A followup branch gives tests the ability to make assertions around metric emission. Then we'll add tests for connection failures and assert that the metrics added in this branch were correctly emitted.

It's fine to hold off on approving/merging this until the followup PRs have added tests for the new behavior.