### PR TITLE
Report more detail on connection failures

### DIFF
--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -264,7 +264,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 
 		// Setup the connection tracker if there is not yet one in the config
 		if conf.ConnTracker == nil {
-			conf.ConnTracker = conntrack.NewTracker(conf.IdleTimeout, conf.MetricsClient.StatsdClient, conf.Log, conf.ShuttingDown, nil)
+			conf.ConnTracker = conntrack.NewTracker(conf.IdleTimeout, conf.MetricsClient.StatsdClient(), conf.Log, conf.ShuttingDown, nil)
 		}
 		configToReturn = conf
 		return nil

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	Resolver                     *net.Resolver
 	ConnectTimeout               time.Duration
 	ExitTimeout                  time.Duration
-	MetricsClient                *MetricsClient
+	MetricsClient                MetricsClientInterface
 	EgressACL                    acl.Decider
 	SupportProxyProtocol         bool
 	TlsConfig                    *tls.Config

--- a/pkg/smokescreen/metrics.go
+++ b/pkg/smokescreen/metrics.go
@@ -26,8 +26,8 @@ var metrics = []string{
 
 	// Connection statistics (cn.atpt == connection attempt)
 	"cn.atpt.total",        // Total connection attempts, tagged by success
-	"cn.atpt.connect.time", // Connect time in ms, tagged by domain
 	"cn.atpt.connect.err",  // Connection failures, tagged by failure type
+	"cn.atpt.connect.time", // Connect time in ms, tagged by domain
 
 	// DNS resolution statistics
 	"resolver.allow.default",

--- a/pkg/smokescreen/metrics.go
+++ b/pkg/smokescreen/metrics.go
@@ -13,14 +13,20 @@ import (
 // a persistent tag with the metric. This list must be updated with new metric names
 // if the metric should support persistent tagging.
 var metrics = []string{
+	// ACL decision statistics
 	"acl.allow",
 	"acl.decide_error",
 	"acl.deny",
 	"acl.report",
 	"acl.role_not_determined",
 	"acl.unknown_error",
-	"cn.atpt.connect.time",
-	"cn.atpt.total",
+
+	// Connection statistics (cn.atpt == connection attempt)
+	"cn.atpt.total",        // Total connection attempts, tagged by success
+	"cn.atpt.connect.time", // Connect time in ms, tagged by domain
+	"cn.atpt.connect.err",  // Connection failures, tagged by failure type
+
+	// DNS resolution statistics
 	"resolver.allow.default",
 	"resolver.allow.user_configured",
 	"resolver.attempts_total",

--- a/pkg/smokescreen/metrics_test.go
+++ b/pkg/smokescreen/metrics_test.go
@@ -62,6 +62,53 @@ func TestMetricsClient(t *testing.T) {
 	})
 }
 
+func TestMockMetricsClient(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("Incr", func(t *testing.T) {
+		m := NewMockMetricsClient()
+		m.Incr("foobar", 1)
+		c, err := m.GetCount("foobar")
+		r.NoError(err)
+		r.Equal(c, uint64(1))
+	})
+
+	t.Run("IncrWithTags", func(t *testing.T) {
+		m := NewMockMetricsClient()
+		tags := []string{"foo", "bar"}
+		m.IncrWithTags("foobar", tags, 1)
+		c, err := m.GetCount("foobar", tags...)
+		r.NoError(err)
+		r.Equal(c, uint64(1))
+	})
+
+	t.Run("IncrWithTags", func(t *testing.T) {
+		m := NewMockMetricsClient()
+		tags := []string{"foo", "bar"}
+		m.IncrWithTags("foobar", tags, 1)
+		c, err := m.GetCount("foobar", tags...)
+		r.NoError(err)
+		r.Equal(c, uint64(1))
+	})
+
+	t.Run("Timing", func(t *testing.T) {
+		m := NewMockMetricsClient()
+		m.Timing("foobar", time.Second, 1)
+		c, err := m.GetCount("foobar")
+		r.NoError(err)
+		r.Equal(c, uint64(1))
+	})
+
+	t.Run("TimingWithTags", func(t *testing.T) {
+		m := NewMockMetricsClient()
+		tags := []string{"foo", "bar"}
+		m.TimingWithTags("foobar", time.Second, 1, tags)
+		c, err := m.GetCount("foobar", tags...)
+		r.NoError(err)
+		r.Equal(c, uint64(1))
+	})
+}
+
 // MockMetricsClient is a MetricsClient that counts metric updates.
 type MockMetricsClient struct {
 	MetricsClient

--- a/pkg/smokescreen/metrics_test.go
+++ b/pkg/smokescreen/metrics_test.go
@@ -1,7 +1,11 @@
 package smokescreen
 
 import (
+	"fmt"
+	"sort"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -56,3 +60,83 @@ func TestMetricsClient(t *testing.T) {
 		r.Error(err)
 	})
 }
+
+type MockMetricsClient struct {
+	MetricsClient
+
+	counts map[string]uint64
+	mu     sync.Mutex
+}
+
+func NewMockMetricsClient() *MockMetricsClient {
+	return &MockMetricsClient{
+		*NewNoOpMetricsClient(),
+		make(map[string]uint64),
+		sync.Mutex{},
+	}
+}
+
+func (m *MockMetricsClient) GetCount(metric string, tags ...string) (uint64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	mName := metric
+	sort.Strings(tags)
+	if len(tags) > 0 {
+		mName = fmt.Sprintf("%s %v", mName, tags)
+	}
+	i, ok := m.counts[mName]
+	if !ok {
+		return 0, fmt.Errorf("unknown metric")
+	}
+
+	return i, nil
+}
+
+func (m *MockMetricsClient) Incr(metric string, rate float64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if i, ok := m.counts[metric]; ok {
+		m.counts[metric] = i + 1
+	}
+
+	return m.MetricsClient.Incr(metric, rate)
+}
+
+func (m *MockMetricsClient) IncrWithTags(metric string, tags []string, rate float64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sort.Strings(tags)
+	mName := fmt.Sprintf("%s %v", metric, tags)
+	if i, ok := m.counts[mName]; ok {
+		m.counts[metric] = i + 1
+	}
+
+	return m.MetricsClient.IncrWithTags(metric, tags, rate)
+}
+
+func (m *MockMetricsClient) Timing(metric string, d time.Duration, rate float64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if i, ok := m.counts[metric]; ok {
+		m.counts[metric] = i + 1
+	}
+
+	return m.MetricsClient.Timing(metric, d, rate)
+}
+
+func (m *MockMetricsClient) TimingWithTags(metric string, d time.Duration, rate float64, tags []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sort.Strings(tags)
+	mName := fmt.Sprintf("%s %v", metric, tags)
+	if i, ok := m.counts[mName]; ok {
+		m.counts[metric] = i + 1
+	}
+
+	return m.MetricsClient.TimingWithTags(metric, d, rate, tags)
+}
+
+var _ MetricsClientInterface = &MockMetricsClient{}

--- a/pkg/smokescreen/metrics_test.go
+++ b/pkg/smokescreen/metrics_test.go
@@ -62,6 +62,7 @@ func TestMetricsClient(t *testing.T) {
 	})
 }
 
+// MockMetricsClient is a MetricsClient that counts metric updates.
 type MockMetricsClient struct {
 	MetricsClient
 
@@ -69,6 +70,8 @@ type MockMetricsClient struct {
 	mu     sync.Mutex
 }
 
+// NewMockMetricsClient returns a new MockMetricsClient that wraps a NoOpMetricsClient
+// with counters to track metric updates.
 func NewMockMetricsClient() *MockMetricsClient {
 	return &MockMetricsClient{
 		*NewNoOpMetricsClient(),

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -493,7 +493,7 @@ func NormalizeHostPort(hostPort string, forceFQDN bool) (host string, port int, 
 // If no port is specified, the `scheme` string is used to find the default
 // port (https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.3).
 //
-// If `forceFQDN“ is true, returned normalized domain name will be an FQDN.
+// If forceFQDN is true, returned normalized domain name will be an FQDN.
 func NormalizeHostWithOptionalPort(hostPort, scheme string, forceFQDN bool) (string, int, error) {
 	var err error
 	const noPort = -1

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -777,7 +777,7 @@ func StartWithConfig(config *Config, quit <-chan interface{}) {
 
 	// Setup connection tracking if not already set in config
 	if config.ConnTracker == nil {
-		config.ConnTracker = conntrack.NewTracker(config.IdleTimeout, config.MetricsClient.StatsdClient, config.Log, config.ShuttingDown, nil)
+		config.ConnTracker = conntrack.NewTracker(config.IdleTimeout, config.MetricsClient.StatsdClient(), config.Log, config.ShuttingDown, nil)
 	}
 
 	server := http.Server{
@@ -792,7 +792,7 @@ func StartWithConfig(config *Config, quit <-chan interface{}) {
 		server.IdleTimeout = config.IdleTimeout
 	}
 
-	config.MetricsClient.started.Store(true)
+	config.MetricsClient.SetStarted()
 	config.ShuttingDown.Store(false)
 	runServer(config, &server, listener, quit)
 }

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -490,7 +490,7 @@ func NormalizeHostPort(hostPort string, forceFQDN bool) (host string, port int, 
 // normalized with `normalizeHost` and `normalizePort`.
 //
 // `hostPort` is a bare host or a colon-separated (':') host name and port.
-// If no port is specified, the `scheme“ string is used to find the default
+// If no port is specified, the `scheme` string is used to find the default
 // port (https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.3).
 //
 // If `forceFQDN“ is true, returned normalized domain name will be an FQDN.

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -321,32 +321,6 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	return conn, nil
 }
 
-// reportConnError emits a detailed metric about a connection error, with a tag corresponding to
-// the failure type. If err is not a net.Error, does nothing.
-func reportConnError(mc *MetricsClient, err error) {
-	e, ok := err.(net.Error)
-	if !ok {
-		return
-	}
-
-	const m = "cn.atpt.connect.err"
-	var etag string
-	switch {
-	case e.Timeout():
-		etag = "type:timeout"
-	case errors.Is(e, syscall.ECONNREFUSED):
-		etag = "type:refused"
-	case errors.Is(e, syscall.ECONNRESET):
-		etag = "type:reset"
-	case errors.Is(e, syscall.ECONNABORTED):
-		etag = "type:aborted"
-	default:
-		etag = "type:unknown"
-	}
-
-	mc.IncrWithTags("cn.atpt.connect.err", []string{etag}, 1)
-}
-
 // HTTPErrorHandler allows returning a custom error response when smokescreen
 // fails to connect to the proxy target.
 func HTTPErrorHandler(w io.WriteCloser, pctx *goproxy.ProxyCtx, err error) {

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -966,6 +966,12 @@ func TestProxyHalfClosed(t *testing.T) {
 
 	cfg.ConnTracker.Wg.Wait()
 
+	tmc, ok := cfg.MetricsClient.(*MockMetricsClient)
+	r.True(ok)
+	i, err := tmc.GetCount("cn.atpt.total", "success:true")
+	r.NoError(err)
+	r.Equal(i, uint64(1))
+
 	entry := findCanonicalProxyClose(logHook.AllEntries())
 	r.NotNil(entry)
 }

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -862,7 +862,7 @@ func TestProxyTimeouts(t *testing.T) {
 }
 
 // TestProxyConnectFailure tests that the proxy correctly handles non-timeout connection failures.
-// In general, the proxy should respond with "Bad Gateway" and record failure statistics
+// In general, the proxy should respond with "Bad gateway" and record failure statistics
 // reflecting the cause of the failure.
 func TestProxyConnectFailure(t *testing.T) {
 	r := require.New(t)


### PR DESCRIPTION
Makes Smokescreen report more detail about connection failures under the `cn.atpt.connect.err` metric, tagged by failure type (`timeout`, `refused`, `reset`, `aborted`).

Tests:
- Adds a  bare-bones `MockMetricsClient` that wraps a `NoOpMetricsClient` with counters so that tests can assert that metrics were or weren't updated.
- Uses the new counting facility to augment existing tests to assert that certain metrics are emitted.
- Adds a test for destination refusing connections.
- Doesn't add tests for ECONNRESET and ECONNABORTED, to avoid adding low-level socket shenanigans to tests and refactoring the guts of all the test harnesses.

A few other small changes:
- Refactors metrics client attachment to `smokescreen.Config`: change into an interface instead of an explicit `*MetricsClient` pointer to allow substitution of a `MockMetricsClient`. Why didn't I simply extend `MetricsClient` to do what I wanted? Because I wanted tests to be able to assert counts of metrics with specific tags, so I needed to store a counter with every metric update, but I didn't want high-cardinality metrics like `cn.atpt.connect.time` (tagged by domain) to eat memory in production for a counting facility we needed only at testing time. Changing to an interface involved hiding `StatsdClient` behind a getter function.
- Adds some descriptive comments.