### PR TITLE
Create a Tracker interface so it can be mocked for testing

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -560,7 +560,7 @@ func TestClientHalfCloseConnection(t *testing.T) {
 	// logged a connection close event
 	tcpConn.CloseWrite()
 
-	conf.ConnTracker.Wg.Wait()
+	conf.ConnTracker.Wg().Wait()
 
 	entries := logHook.AllEntries()
 	entry := findLogEntry(entries, "CANONICAL-PROXY-CN-CLOSE")

--- a/pkg/smokescreen/conntrack/conn_tracker.go
+++ b/pkg/smokescreen/conntrack/conn_tracker.go
@@ -19,7 +19,6 @@ type TrackerInterface interface {
 	MaybeIdleIn(time.Duration) time.Duration
 	NewInstrumentedConn(net.Conn, *logrus.Entry, string, string, string) *InstrumentedConn
 	NewInstrumentedConnWithTimeout(net.Conn, time.Duration, *logrus.Entry, string, string, string) *InstrumentedConn
-
 	Wg() *sync.WaitGroup
 }
 

--- a/pkg/smokescreen/conntrack/conn_tracker.go
+++ b/pkg/smokescreen/conntrack/conn_tracker.go
@@ -168,3 +168,5 @@ func (tr *Tracker) MaybeIdleIn(d time.Duration) time.Duration {
 func (tr *Tracker) Wg() *sync.WaitGroup {
 	return tr.wg
 }
+
+var _ TrackerInterface = &Tracker{}

--- a/pkg/smokescreen/conntrack/conn_tracker.go
+++ b/pkg/smokescreen/conntrack/conn_tracker.go
@@ -13,10 +13,20 @@ import (
 	"golang.org/x/net/publicsuffix"
 )
 
+type TrackerInterface interface {
+	ReportConnectionSuccessRate() *ConnSuccessRateStats
+	RecordAttempt(string, bool)
+	MaybeIdleIn(time.Duration) time.Duration
+	NewInstrumentedConn(net.Conn, *logrus.Entry, string, string, string) *InstrumentedConn
+	NewInstrumentedConnWithTimeout(net.Conn, time.Duration, *logrus.Entry, string, string, string) *InstrumentedConn
+
+	Wg() *sync.WaitGroup
+}
+
 type Tracker struct {
 	*sync.Map
 	ShuttingDown atomic.Value
-	Wg           *sync.WaitGroup
+	wg           *sync.WaitGroup
 	statsc       statsd.ClientInterface
 
 	SuccessRateTracker *ConnSuccessRateTracker
@@ -90,7 +100,7 @@ func NewTracker(idle time.Duration, statsc statsd.ClientInterface, logger *logru
 	return &Tracker{
 		Map:                &sync.Map{},
 		ShuttingDown:       sd,
-		Wg:                 &sync.WaitGroup{},
+		wg:                 &sync.WaitGroup{},
 		IdleTimeout:        idle,
 		statsc:             statsc,
 		SuccessRateTracker: successRateTracker,
@@ -154,4 +164,8 @@ func (tr *Tracker) MaybeIdleIn(d time.Duration) time.Duration {
 		return true
 	})
 	return longest
+}
+
+func (tr *Tracker) Wg() *sync.WaitGroup {
+	return tr.wg
 }

--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -70,7 +70,7 @@ func (t *Tracker) NewInstrumentedConn(conn net.Conn, logger *logrus.Entry, role,
 	}
 
 	ic.tracker.Store(ic, nil)
-	ic.tracker.Wg.Add(1)
+	ic.tracker.Wg().Add(1)
 
 	return ic
 }
@@ -130,7 +130,7 @@ func (ic *InstrumentedConn) Close() error {
 		LogFieldOutboundAddr: outboundAddr,
 	}).Info(CanonicalProxyConnClose)
 
-	ic.tracker.Wg.Done()
+	ic.tracker.Wg().Done()
 	ic.CloseError = ic.Conn.Close()
 	return ic.CloseError
 }

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -858,7 +858,7 @@ func runServer(config *Config, server *http.Server, listener net.Listener, quit 
 		// This subroutine blocks until all connections close.
 		go func() {
 			config.Log.Print("Waiting for all connections to close...")
-			config.ConnTracker.Wg.Wait()
+			config.ConnTracker.Wg().Wait()
 			config.Log.Print("All connections are closed. Continuing with shutdown...")
 			exit <- Closed
 		}()

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -785,7 +785,7 @@ func TestProxyTimeouts(t *testing.T) {
 		r.Error(err)
 		r.Contains(err.Error(), "EOF")
 
-		cfg.ConnTracker.Wg.Wait()
+		cfg.ConnTracker.Wg().Wait()
 
 		// The metrics client records success:true because of the way Goproxy surfaces CONNECT
 		// timeouts to Smokescreen; same reasons we test for EOF above.
@@ -964,7 +964,7 @@ func TestProxyHalfClosed(t *testing.T) {
 	resp.Body.Close()
 	r.Equal(http.StatusOK, resp.StatusCode)
 
-	cfg.ConnTracker.Wg.Wait()
+	cfg.ConnTracker.Wg().Wait()
 
 	tmc, ok := cfg.MetricsClient.(*MockMetricsClient)
 	r.True(ok)


### PR DESCRIPTION
Adds `conntrack.TrackerInterface` that replaces `*contrack.Tracker` in the smokescreen Config. This allows it to be mocked out in unit tests.