### PR TITLE
Use new TrackerInterface in the smokescreen config

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -51,7 +51,7 @@ type Config struct {
 	StatsSocketDir               string
 	StatsSocketFileMode          os.FileMode
 	StatsServer                  *StatsServer // StatsServer
-	ConnTracker                  *conntrack.Tracker
+	ConnTracker                  conntrack.TrackerInterface
 	Healthcheck                  http.Handler // User defined http.Handler for optional requests to a /healthcheck endpoint
 	ShuttingDown                 atomic.Value // Stores a boolean value indicating whether the proxy is actively shutting down
 

--- a/pkg/smokescreen/conntrack/conn_tracker.go
+++ b/pkg/smokescreen/conntrack/conn_tracker.go
@@ -20,6 +20,7 @@ type TrackerInterface interface {
 	NewInstrumentedConn(net.Conn, *logrus.Entry, string, string, string) *InstrumentedConn
 	NewInstrumentedConnWithTimeout(net.Conn, time.Duration, *logrus.Entry, string, string, string) *InstrumentedConn
 	Wg() *sync.WaitGroup
+	Range(f func(key any, value any) bool)
 }
 
 type Tracker struct {

--- a/pkg/smokescreen/conntrack/conn_tracker.go
+++ b/pkg/smokescreen/conntrack/conn_tracker.go
@@ -20,7 +20,7 @@ type TrackerInterface interface {
 	NewInstrumentedConn(net.Conn, *logrus.Entry, string, string, string) *InstrumentedConn
 	NewInstrumentedConnWithTimeout(net.Conn, time.Duration, *logrus.Entry, string, string, string) *InstrumentedConn
 	Wg() *sync.WaitGroup
-	Range(f func(key any, value any) bool)
+	Range(f func(interface{}, interface{}) bool)
 }
 
 type Tracker struct {


### PR DESCRIPTION
Adds the TrackerInterface to the smokescreen config (and also adds the Range() method, which is from the promoted sync.Map field and which I forgot in my prior PR)