### PR TITLE
Move metrics utilities into a package

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stripe/smokescreen/pkg/smokescreen"
 	acl "github.com/stripe/smokescreen/pkg/smokescreen/acl/v1"
+	"github.com/stripe/smokescreen/pkg/smokescreen/metrics"
 )
 
 var ProxyTargetHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -606,7 +607,7 @@ func startSmokescreen(t *testing.T, useTLS bool, logHook logrus.Hook) (*smokescr
 		conf.RoleFromRequest = testRFRHeader
 	}
 
-	conf.MetricsClient = smokescreen.NewNoOpMetricsClient()
+	conf.MetricsClient = metrics.NewNoOpMetricsClient()
 
 	conf.ConnectTimeout = time.Second
 

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -264,7 +264,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 
 		// Setup the connection tracker if there is not yet one in the config
 		if conf.ConnTracker == nil {
-			conf.ConnTracker = conntrack.NewTracker(conf.IdleTimeout, conf.MetricsClient.StatsdClient(), conf.Log, conf.ShuttingDown, nil)
+			conf.ConnTracker = conntrack.NewTracker(conf.IdleTimeout, conf.MetricsClient, conf.Log, conf.ShuttingDown, nil)
 		}
 		configToReturn = conf
 		return nil

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -21,6 +21,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	acl "github.com/stripe/smokescreen/pkg/smokescreen/acl/v1"
 	"github.com/stripe/smokescreen/pkg/smokescreen/conntrack"
+	"github.com/stripe/smokescreen/pkg/smokescreen/metrics"
 )
 
 type RuleRange struct {
@@ -37,7 +38,7 @@ type Config struct {
 	Resolver                     *net.Resolver
 	ConnectTimeout               time.Duration
 	ExitTimeout                  time.Duration
-	MetricsClient                MetricsClientInterface
+	MetricsClient                metrics.MetricsClientInterface
 	EgressACL                    acl.Decider
 	SupportProxyProtocol         bool
 	TlsConfig                    *tls.Config
@@ -229,7 +230,7 @@ func NewConfig() *Config {
 		ExitTimeout:             500 * time.Minute,
 		StatsSocketFileMode:     os.FileMode(0700),
 		ShuttingDown:            atomic.Value{},
-		MetricsClient:           NewNoOpMetricsClient(),
+		MetricsClient:           metrics.NewNoOpMetricsClient(),
 		Network:                 "ip",
 	}
 }
@@ -301,11 +302,11 @@ func (config *Config) SetupCrls(crlFiles []string) error {
 func (config *Config) SetupStatsdWithNamespace(addr, namespace string) error {
 	if addr == "" {
 		fmt.Println("warn: no statsd addr provided, using noop client")
-		config.MetricsClient = NewNoOpMetricsClient()
+		config.MetricsClient = metrics.NewNoOpMetricsClient()
 		return nil
 	}
 
-	mc, err := NewMetricsClient(addr, namespace)
+	mc, err := metrics.NewMetricsClient(addr, namespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/smokescreen/conntrack/conn_tracker.go
+++ b/pkg/smokescreen/conntrack/conn_tracker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 	cache "github.com/patrickmn/go-cache"
 	"github.com/sirupsen/logrus"
+	"github.com/stripe/smokescreen/pkg/smokescreen/metrics"
 	"golang.org/x/net/publicsuffix"
 )
 
@@ -27,7 +28,7 @@ type Tracker struct {
 	*sync.Map
 	ShuttingDown atomic.Value
 	wg           *sync.WaitGroup
-	statsc       statsd.ClientInterface
+	statsc       metrics.MetricsClientInterface
 
 	SuccessRateTracker *ConnSuccessRateTracker
 
@@ -96,7 +97,7 @@ func StartNewConnSuccessRateTracker(calculationInterval time.Duration, calculati
 	return newSuccessTracker
 }
 
-func NewTracker(idle time.Duration, statsc statsd.ClientInterface, logger *logrus.Logger, sd atomic.Value, successRateTracker *ConnSuccessRateTracker) *Tracker {
+func NewTracker(idle time.Duration, statsc metrics.MetricsClientInterface, logger *logrus.Logger, sd atomic.Value, successRateTracker *ConnSuccessRateTracker) *Tracker {
 	return &Tracker{
 		Map:                &sync.Map{},
 		ShuttingDown:       sd,

--- a/pkg/smokescreen/conntrack/conn_tracker.go
+++ b/pkg/smokescreen/conntrack/conn_tracker.go
@@ -7,7 +7,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
 	cache "github.com/patrickmn/go-cache"
 	"github.com/sirupsen/logrus"
 	"github.com/stripe/smokescreen/pkg/smokescreen/metrics"
@@ -64,7 +63,7 @@ type ConnSuccessRateStats struct {
 // - calculationInterval is how often statistics will be recomputed.
 // - calculationWindow is the period that statistics will be calculated over.
 // - cleanupInterval is how often expired items (e.g., items older than the calculationWindow) will be deleted from memory.
-func StartNewConnSuccessRateTracker(calculationInterval time.Duration, calculationWindow time.Duration, cleanupInterval time.Duration, statsc statsd.ClientInterface) *ConnSuccessRateTracker {
+func StartNewConnSuccessRateTracker(calculationInterval time.Duration, calculationWindow time.Duration, cleanupInterval time.Duration, statsc metrics.MetricsClientInterface) *ConnSuccessRateTracker {
 	newSuccessTracker := &ConnSuccessRateTracker{
 		ConnAttempts: cache.New(calculationWindow, time.Second*cleanupInterval),
 	}
@@ -87,8 +86,8 @@ func StartNewConnSuccessRateTracker(calculationInterval time.Duration, calculati
 				successRate = (float64(succeeded) / float64(total)) * 100
 			}
 			newSuccessTracker.ConnSuccessRateStats.Store(ConnSuccessRateStats{CalculatedAt: time.Now(), ConnSuccessRate: successRate, TotalConns: total})
-			statsc.Gauge("cn.atpt.distinct_domains", float64(total), []string{}, 1)
-			statsc.Gauge("cn.atpt.distinct_domains_success_rate", successRate, []string{}, 1)
+			statsc.Gauge("cn.atpt.distinct_domains", float64(total), 1)
+			statsc.Gauge("cn.atpt.distinct_domains_success_rate", successRate, 1)
 
 			time.Sleep(calculationInterval)
 		}

--- a/pkg/smokescreen/conntrack/conn_tracker_test.go
+++ b/pkg/smokescreen/conntrack/conn_tracker_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stripe/smokescreen/pkg/smokescreen/metrics"
 )
 
 var testLogger = logrus.New()
@@ -50,7 +51,7 @@ func NewTestTracker(idle time.Duration) *Tracker {
 	sd := atomic.Value{}
 	sd.Store(false)
 
-	return NewTracker(idle, &statsd.NoOpClient{}, logrus.New(), sd, nil)
+	return NewTracker(idle, metrics.NewNoOpMetricsClient(), logrus.New(), sd, nil)
 }
 
 // TestConnSuccessRateTracker tests that a ConnTracker with a ConnSuccessRateTracker correctly
@@ -85,7 +86,7 @@ func TestConnSuccessRateTracker(t *testing.T) {
 			sd := atomic.Value{}
 			sd.Store(false)
 			mockMetricsClient := &mockClientInterface{}
-			tracker := NewTracker(time.Second, &statsd.NoOpClient{}, logrus.New(), sd, StartNewConnSuccessRateTracker(500*time.Millisecond, 2*time.Second, 10*time.Second, mockMetricsClient))
+			tracker := NewTracker(time.Second, metrics.NewNoOpMetricsClient(), logrus.New(), sd, StartNewConnSuccessRateTracker(500*time.Millisecond, 2*time.Second, 10*time.Second, mockMetricsClient))
 
 			for _, record := range tc.additions {
 				tracker.RecordAttempt(record.host, record.success)

--- a/pkg/smokescreen/conntrack/conn_tracker_test.go
+++ b/pkg/smokescreen/conntrack/conn_tracker_test.go
@@ -84,7 +84,12 @@ func TestConnSuccessRateTracker(t *testing.T) {
 			sd := atomic.Value{}
 			sd.Store(false)
 			mockMetricsClient := metrics.NewMockMetricsClient()
-			tracker := NewTracker(time.Second, metrics.NewNoOpMetricsClient(), logrus.New(), sd, StartNewConnSuccessRateTracker(500*time.Millisecond, 2*time.Second, 10*time.Second, mockMetricsClient))
+			tracker := NewTracker(
+				time.Second,
+				metrics.NewNoOpMetricsClient(), // We aren't testing metrics for the Tracker here, only for the embedded ConnSuccessRateTracker
+				logrus.New(),
+				sd,
+				StartNewConnSuccessRateTracker(500*time.Millisecond, 2*time.Second, 10*time.Second, mockMetricsClient))
 
 			for _, record := range tc.additions {
 				tracker.RecordAttempt(record.host, record.success)

--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -97,16 +97,16 @@ func (ic *InstrumentedConn) Close() error {
 		fmt.Sprintf("role:%s", ic.Role),
 	}
 
-	ic.tracker.statsc.Incr("cn.close", tags, 1)
-	ic.tracker.statsc.Histogram("cn.duration", duration, tags, 1)
-	ic.tracker.statsc.Histogram("cn.bytes_in", float64(atomic.LoadUint64(ic.BytesIn)), tags, 1)
-	ic.tracker.statsc.Histogram("cn.bytes_out", float64(atomic.LoadUint64(ic.BytesOut)), tags, 1)
+	ic.tracker.statsc.IncrWithTags("cn.close", tags, 1)
+	ic.tracker.statsc.HistogramWithTags("cn.duration", duration, tags, 1)
+	ic.tracker.statsc.HistogramWithTags("cn.bytes_in", float64(atomic.LoadUint64(ic.BytesIn)), tags, 1)
+	ic.tracker.statsc.HistogramWithTags("cn.bytes_out", float64(atomic.LoadUint64(ic.BytesOut)), tags, 1)
 
 	// Track when we terminate active connections during a shutdown
 	if ic.tracker.ShuttingDown.Load() == true {
 		if !ic.Idle() {
 			ic.logger = ic.logger.WithField("active_at_termination", true)
-			ic.tracker.statsc.Incr("cn.active_at_termination", tags, 1)
+			ic.tracker.statsc.IncrWithTags("cn.active_at_termination", tags, 1)
 		}
 	}
 

--- a/pkg/smokescreen/metrics/metrics.go
+++ b/pkg/smokescreen/metrics/metrics.go
@@ -56,6 +56,7 @@ type MetricsClientInterface interface {
 	AddMetricTags(string, []string) error
 	Incr(string, float64) error
 	IncrWithTags(string, []string, float64) error
+	Gauge(string, float64, float64) error
 	Histogram(string, float64, float64) error
 	HistogramWithTags(string, float64, []string, float64) error
 	Timing(string, time.Duration, float64) error
@@ -133,6 +134,11 @@ func (mc *MetricsClient) IncrWithTags(metric string, tags []string, rate float64
 	mTags := mc.GetMetricTags(metric)
 	tags = append(tags, mTags...)
 	return mc.statsdClient.Incr(metric, tags, rate)
+}
+
+func (mc *MetricsClient) Gauge(metric string, value float64, rate float64) error {
+	mTags := mc.GetMetricTags(metric)
+	return mc.statsdClient.Gauge(metric, value, mTags, rate)
 }
 
 func (mc *MetricsClient) Histogram(metric string, value float64, rate float64) error {

--- a/pkg/smokescreen/metrics/metrics.go
+++ b/pkg/smokescreen/metrics/metrics.go
@@ -104,6 +104,11 @@ func NewNoOpMetricsClient() *MetricsClient {
 // AddMetricTags associates the provided tags slice with a given metric. The metric must be present
 // in the metrics slice.
 //
+// Once a metric has tags added via AddMetricTags, those tags will *always* be attached whenever
+// that metric is emitted.
+// For example, calling `AddMetricTags(foo, [bar])` will cause the `bar` tag to be added to
+// *every* metric `foo` that is emitted for the lifetime of the MetricsClient.
+//
 // This function is not thread safe, and adding persitent tags should only be done while initializing
 // the configuration and prior to running smokescreen.
 func (mc *MetricsClient) AddMetricTags(metric string, mTags []string) error {

--- a/pkg/smokescreen/metrics/metrics_test.go
+++ b/pkg/smokescreen/metrics/metrics_test.go
@@ -1,0 +1,118 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricsTags(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("add custom tags", func(t *testing.T) {
+		metric := "acl.allow"
+		mc := NewNoOpMetricsClient()
+
+		err := mc.AddMetricTags(metric, []string{"globalize"})
+		r.NoError(err)
+
+		tags := mc.GetMetricTags(metric)
+		r.Len(tags, 1)
+		r.Equal(tags[0], "globalize")
+
+		err = mc.AddMetricTags(metric, []string{"ignore"})
+		r.NoError(err)
+
+		tags = mc.GetMetricTags(metric)
+		r.Len(tags, 2)
+	})
+
+	t.Run("add invalid tags", func(t *testing.T) {
+		metric := "acl.does.not.exist"
+		mc := NewNoOpMetricsClient()
+
+		err := mc.AddMetricTags(metric, []string{"globalize"})
+		r.Error(err)
+	})
+}
+
+func TestMetricsClient(t *testing.T) {
+	r := require.New(t)
+
+	// Passing NewMetricsClient a missing statsd address should always fail
+	t.Run("nil statsd addr", func(t *testing.T) {
+		mc, err := NewMetricsClient("", "test_namespace")
+		r.Error(err)
+		r.Nil(mc)
+	})
+
+	// MetricsClient is not thread safe. Adding a tag after smokescreen has started
+	// should always return an error.
+	t.Run("adding metrics after started", func(t *testing.T) {
+		mc := NewNoOpMetricsClient()
+		mc.started.Store(true)
+
+		err := mc.AddMetricTags("acl.allow", []string{"globalize"})
+		r.Error(err)
+	})
+}
+
+func TestMockMetricsClient(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("Incr", func(t *testing.T) {
+		m := NewMockMetricsClient()
+		m.Incr("foobar", 1)
+		c, err := m.GetCount("foobar")
+		r.NoError(err)
+		r.Equal(c, uint64(1))
+	})
+
+	t.Run("Multiple Incr", func(t *testing.T) {
+		m := NewMockMetricsClient()
+		m.Incr("foobar", 1)
+		m.Incr("foobar", 1)
+		m.Incr("foobar", 1)
+		c, err := m.GetCount("foobar")
+		r.NoError(err)
+		r.Equal(c, uint64(3))
+
+		m.Incr("foobar", 123)
+		c, err = m.GetCount("foobar")
+		r.NoError(err)
+		r.Equal(c, uint64(4))
+	})
+
+	t.Run("IncrWithTags", func(t *testing.T) {
+		m := NewMockMetricsClient()
+		tags := []string{"foo", "bar"}
+		m.IncrWithTags("foobar", tags, 1)
+		c, err := m.GetCount("foobar", tags...)
+		r.NoError(err)
+		r.Equal(c, uint64(1))
+		c, err = m.GetCount("foobar")
+		r.NoError(err)
+		r.Equal(c, uint64(1))
+	})
+
+	t.Run("Timing", func(t *testing.T) {
+		m := NewMockMetricsClient()
+		m.Timing("foobar", time.Second, 1)
+		c, err := m.GetCount("foobar")
+		r.NoError(err)
+		r.Equal(c, uint64(1))
+	})
+
+	t.Run("TimingWithTags", func(t *testing.T) {
+		m := NewMockMetricsClient()
+		tags := []string{"foo", "bar"}
+		m.TimingWithTags("foobar", time.Second, 1, tags)
+		c, err := m.GetCount("foobar", tags...)
+		r.NoError(err)
+		r.Equal(c, uint64(1))
+		c, err = m.GetCount("foobar")
+		r.NoError(err)
+		r.Equal(c, uint64(1))
+	})
+}

--- a/pkg/smokescreen/metrics/metrics_test.go
+++ b/pkg/smokescreen/metrics/metrics_test.go
@@ -96,6 +96,36 @@ func TestMockMetricsClient(t *testing.T) {
 		r.Equal(c, uint64(1))
 	})
 
+	t.Run("Histogram", func(t *testing.T) {
+		m := NewMockMetricsClient()
+		m.Histogram("foobar", 2.0, 1)
+		m.Histogram("foobar", 3.0, 1)
+		c, err := m.GetCount("foobar")
+		r.NoError(err)
+		r.Equal(c, uint64(2))
+		v, err := m.GetValues("foobar")
+		r.NoError(err)
+		r.Equal([]float64{2.0, 3.0}, v)
+	})
+
+	t.Run("HistogramWithTags", func(t *testing.T) {
+		m := NewMockMetricsClient()
+		tags := []string{"foo", "bar"}
+		m.HistogramWithTags("foobar", 2.0, tags, 1)
+		c, err := m.GetCount("foobar", tags...)
+		r.NoError(err)
+		r.Equal(c, uint64(1))
+		c, err = m.GetCount("foobar")
+		r.NoError(err)
+		r.Equal(c, uint64(1))
+		v, err := m.GetValues("foobar")
+		r.NoError(err)
+		r.Equal([]float64{2.0}, v)
+		v, err = m.GetValues("foobar", tags...)
+		r.NoError(err)
+		r.Equal([]float64{2.0}, v)
+	})
+
 	t.Run("Timing", func(t *testing.T) {
 		m := NewMockMetricsClient()
 		m.Timing("foobar", time.Second, 1)

--- a/pkg/smokescreen/metrics/metrics_test.go
+++ b/pkg/smokescreen/metrics/metrics_test.go
@@ -96,6 +96,18 @@ func TestMockMetricsClient(t *testing.T) {
 		r.Equal(c, uint64(1))
 	})
 
+	t.Run("Gauge", func(t *testing.T) {
+		m := NewMockMetricsClient()
+		m.Gauge("foobar", 2.0, 1)
+		m.Gauge("foobar", 3.0, 1)
+		c, err := m.GetCount("foobar")
+		r.NoError(err)
+		r.Equal(c, uint64(2))
+		v, err := m.GetValues("foobar")
+		r.NoError(err)
+		r.Equal([]float64{2.0, 3.0}, v)
+	})
+
 	t.Run("Histogram", func(t *testing.T) {
 		m := NewMockMetricsClient()
 		m.Histogram("foobar", 2.0, 1)

--- a/pkg/smokescreen/metrics/metrics_test.go
+++ b/pkg/smokescreen/metrics/metrics_test.go
@@ -28,7 +28,7 @@ func TestMetricsTags(t *testing.T) {
 		r.Len(tags, 2)
 	})
 
-	t.Run("add invalid tags", func(t *testing.T) {
+	t.Run("add tags to a nonexistent metric", func(t *testing.T) {
 		metric := "acl.does.not.exist"
 		mc := NewNoOpMetricsClient()
 

--- a/pkg/smokescreen/metrics/mocks.go
+++ b/pkg/smokescreen/metrics/mocks.go
@@ -123,6 +123,14 @@ func (m *MockMetricsClient) IncrWithTags(metric string, tags []string, rate floa
 	return m.MetricsClient.IncrWithTags(metric, tags, rate)
 }
 
+func (m *MockMetricsClient) Gauge(metric string, value float64, rate float64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.countOneWithValue(metric, value)
+
+	return m.MetricsClient.Incr(metric, rate)
+}
+
 func (m *MockMetricsClient) Histogram(metric string, value float64, rate float64) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/smokescreen/metrics/mocks.go
+++ b/pkg/smokescreen/metrics/mocks.go
@@ -1,125 +1,12 @@
-package smokescreen
+package metrics
 
 import (
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
-	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 )
-
-func TestMetricsTags(t *testing.T) {
-	r := require.New(t)
-
-	t.Run("add custom tags", func(t *testing.T) {
-		metric := "acl.allow"
-		mc := NewNoOpMetricsClient()
-
-		err := mc.AddMetricTags(metric, []string{"globalize"})
-		r.NoError(err)
-
-		tags := mc.GetMetricTags(metric)
-		r.Len(tags, 1)
-		r.Equal(tags[0], "globalize")
-
-		err = mc.AddMetricTags(metric, []string{"ignore"})
-		r.NoError(err)
-
-		tags = mc.GetMetricTags(metric)
-		r.Len(tags, 2)
-	})
-
-	t.Run("add invalid tags", func(t *testing.T) {
-		metric := "acl.does.not.exist"
-		mc := NewNoOpMetricsClient()
-
-		err := mc.AddMetricTags(metric, []string{"globalize"})
-		r.Error(err)
-	})
-}
-
-func TestMetricsClient(t *testing.T) {
-	r := require.New(t)
-
-	// Passing NewMetricsClient a missing statsd address should always fail
-	t.Run("nil statsd addr", func(t *testing.T) {
-		mc, err := NewMetricsClient("", "test_namespace")
-		r.Error(err)
-		r.Nil(mc)
-	})
-
-	// MetricsClient is not thread safe. Adding a tag after smokescreen has started
-	// should always return an error.
-	t.Run("adding metrics after started", func(t *testing.T) {
-		mc := NewNoOpMetricsClient()
-		mc.started.Store(true)
-
-		err := mc.AddMetricTags("acl.allow", []string{"globalize"})
-		r.Error(err)
-	})
-}
-
-func TestMockMetricsClient(t *testing.T) {
-	r := require.New(t)
-
-	t.Run("Incr", func(t *testing.T) {
-		m := NewMockMetricsClient()
-		m.Incr("foobar", 1)
-		c, err := m.GetCount("foobar")
-		r.NoError(err)
-		r.Equal(c, uint64(1))
-	})
-
-	t.Run("Multiple Incr", func(t *testing.T) {
-		m := NewMockMetricsClient()
-		m.Incr("foobar", 1)
-		m.Incr("foobar", 1)
-		m.Incr("foobar", 1)
-		c, err := m.GetCount("foobar")
-		r.NoError(err)
-		r.Equal(c, uint64(3))
-
-		m.Incr("foobar", 123)
-		c, err = m.GetCount("foobar")
-		r.NoError(err)
-		r.Equal(c, uint64(4))
-	})
-
-	t.Run("IncrWithTags", func(t *testing.T) {
-		m := NewMockMetricsClient()
-		tags := []string{"foo", "bar"}
-		m.IncrWithTags("foobar", tags, 1)
-		c, err := m.GetCount("foobar", tags...)
-		r.NoError(err)
-		r.Equal(c, uint64(1))
-		c, err = m.GetCount("foobar")
-		r.NoError(err)
-		r.Equal(c, uint64(1))
-	})
-
-	t.Run("Timing", func(t *testing.T) {
-		m := NewMockMetricsClient()
-		m.Timing("foobar", time.Second, 1)
-		c, err := m.GetCount("foobar")
-		r.NoError(err)
-		r.Equal(c, uint64(1))
-	})
-
-	t.Run("TimingWithTags", func(t *testing.T) {
-		m := NewMockMetricsClient()
-		tags := []string{"foo", "bar"}
-		m.TimingWithTags("foobar", time.Second, 1, tags)
-		c, err := m.GetCount("foobar", tags...)
-		r.NoError(err)
-		r.Equal(c, uint64(1))
-		c, err = m.GetCount("foobar")
-		r.NoError(err)
-		r.Equal(c, uint64(1))
-	})
-}
 
 // MockMetricsClient is a MetricsClient that counts metric updates.
 type MockMetricsClient struct {

--- a/pkg/smokescreen/metrics/mocks.go
+++ b/pkg/smokescreen/metrics/mocks.go
@@ -13,6 +13,7 @@ type MockMetricsClient struct {
 	MetricsClient
 
 	counts map[string]uint64
+	values map[string][]float64
 	mu     sync.Mutex
 }
 
@@ -22,6 +23,7 @@ func NewMockMetricsClient() *MockMetricsClient {
 	return &MockMetricsClient{
 		*NewNoOpMetricsClient(),
 		make(map[string]uint64),
+		make(map[string][]float64),
 		sync.Mutex{},
 	}
 }
@@ -34,6 +36,18 @@ func (m *MockMetricsClient) countOne(metric string) {
 	} else {
 		m.counts[metric] = 1
 	}
+}
+
+// countOneWithValue increments a metric count by 1 for metrics that emit a value, starting the count at 1 if the metric has
+// not yet been counted. Call with m.mu.Lock held.
+func (m *MockMetricsClient) countOneWithValue(metric string, value float64) {
+	if i, ok := m.counts[metric]; ok {
+		m.counts[metric] = i + 1
+	} else {
+		m.counts[metric] = 1
+
+	}
+	m.values[metric] = append(m.values[metric], value)
 }
 
 // GetCount returns the number of times metric has been updated since the MockMetricsClient was
@@ -61,6 +75,31 @@ func (m *MockMetricsClient) GetCount(metric string, tags ...string) (uint64, err
 	return i, nil
 }
 
+// GetValues returns the values stored for a metric metric has been updated since the MockMetricsClient was
+// created. To support GetValues being called with or without tags for a given metric, tagged metrics
+// are counted twice: once for the untagged metric ("foo") and once for the metric with its tags
+// sorted("foo [a b c]").
+func (m *MockMetricsClient) GetValues(metric string, tags ...string) ([]float64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	mName := metric
+	sort.Strings(tags)
+	if len(tags) > 0 {
+		mName = fmt.Sprintf("%s %v", mName, tags)
+	}
+	i, ok := m.values[mName]
+	if !ok {
+		keys := make([]string, len(m.counts))
+		for k, _ := range m.values {
+			keys = append(keys, k)
+		}
+		return nil, fmt.Errorf("unknown metric %s (know %s)", mName, strings.Join(keys, ","))
+	}
+
+	return i, nil
+}
+
 func (m *MockMetricsClient) Incr(metric string, rate float64) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -80,6 +119,29 @@ func (m *MockMetricsClient) IncrWithTags(metric string, tags []string, rate floa
 	sort.Strings(tags)
 	mName := fmt.Sprintf("%s %v", metric, tags)
 	m.countOne(mName)
+
+	return m.MetricsClient.IncrWithTags(metric, tags, rate)
+}
+
+func (m *MockMetricsClient) Histogram(metric string, value float64, rate float64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.countOneWithValue(metric, value)
+
+	return m.MetricsClient.Incr(metric, rate)
+}
+
+func (m *MockMetricsClient) HistogramWithTags(metric string, value float64, tags []string, rate float64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Count the metric name without tags
+	m.countOneWithValue(metric, value)
+
+	// Count the metric name with its tags sorted
+	sort.Strings(tags)
+	mName := fmt.Sprintf("%s %v", metric, tags)
+	m.countOneWithValue(mName, value)
 
 	return m.MetricsClient.IncrWithTags(metric, tags, rate)
 }

--- a/pkg/smokescreen/metrics/mocks.go
+++ b/pkg/smokescreen/metrics/mocks.go
@@ -76,8 +76,8 @@ func (m *MockMetricsClient) GetCount(metric string, tags ...string) (uint64, err
 }
 
 // GetValues returns the values stored for a metric metric has been updated since the MockMetricsClient was
-// created. To support GetValues being called with or without tags for a given metric, tagged metrics
-// are counted twice: once for the untagged metric ("foo") and once for the metric with its tags
+// created. To support GetValues being called with or without tags for a given metric, the values for tagged
+// metrics are recorded twice: once for the untagged metric ("foo") and once for the metric with its tags
 // sorted("foo [a b c]").
 func (m *MockMetricsClient) GetValues(metric string, tags ...string) ([]float64, error) {
 	m.mu.Lock()

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stripe/smokescreen/internal/einhorn"
 	acl "github.com/stripe/smokescreen/pkg/smokescreen/acl/v1"
 	"github.com/stripe/smokescreen/pkg/smokescreen/conntrack"
+	"github.com/stripe/smokescreen/pkg/smokescreen/metrics"
 	"golang.org/x/net/idna"
 )
 
@@ -288,7 +289,7 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	if err != nil {
 		sctx.cfg.MetricsClient.IncrWithTags("cn.atpt.total", []string{"success:false"}, 1)
 		sctx.cfg.ConnTracker.RecordAttempt(sctx.requestedHost, false)
-		reportConnError(sctx.cfg.MetricsClient, err)
+		metrics.ReportConnError(sctx.cfg.MetricsClient, err)
 		return nil, err
 	}
 	sctx.cfg.MetricsClient.IncrWithTags("cn.atpt.total", []string{"success:true"}, 1)
@@ -777,7 +778,7 @@ func StartWithConfig(config *Config, quit <-chan interface{}) {
 
 	// Setup connection tracking if not already set in config
 	if config.ConnTracker == nil {
-		config.ConnTracker = conntrack.NewTracker(config.IdleTimeout, config.MetricsClient.StatsdClient(), config.Log, config.ShuttingDown, nil)
+		config.ConnTracker = conntrack.NewTracker(config.IdleTimeout, config.MetricsClient, config.Log, config.ShuttingDown, nil)
 	}
 
 	server := http.Server{

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -18,12 +18,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/sirupsen/logrus"
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/smokescreen/pkg/smokescreen/conntrack"
+	"github.com/stripe/smokescreen/pkg/smokescreen/metrics"
 )
 
 var allowRanges = []string{
@@ -248,7 +248,7 @@ func TestConsistentHostHeader(t *testing.T) {
 
 	// Custom proxy config for the "remote" httptest.NewServer
 	conf := NewConfig()
-	conf.ConnTracker = conntrack.NewTracker(conf.IdleTimeout, &statsd.NoOpClient{}, conf.Log, atomic.Value{}, nil)
+	conf.ConnTracker = conntrack.NewTracker(conf.IdleTimeout, metrics.NewNoOpMetricsClient(), conf.Log, atomic.Value{}, nil)
 	err := conf.SetAllowAddresses([]string{"127.0.0.1"})
 	r.NoError(err)
 
@@ -289,7 +289,7 @@ func TestClearsTraceIDHeader(t *testing.T) {
 	var logHook logrustest.Hook
 	conf := NewConfig()
 	conf.Log.AddHook(&logHook)
-	conf.ConnTracker = conntrack.NewTracker(conf.IdleTimeout, &statsd.NoOpClient{}, conf.Log, atomic.Value{}, nil)
+	conf.ConnTracker = conntrack.NewTracker(conf.IdleTimeout, metrics.NewNoOpMetricsClient(), conf.Log, atomic.Value{}, nil)
 	err := conf.SetAllowAddresses([]string{"127.0.0.1"})
 	r.NoError(err)
 
@@ -789,7 +789,7 @@ func TestProxyTimeouts(t *testing.T) {
 
 		// The metrics client records success:true because of the way Goproxy surfaces CONNECT
 		// timeouts to Smokescreen; same reasons we test for EOF above.
-		tmc, ok := cfg.MetricsClient.(*MockMetricsClient)
+		tmc, ok := cfg.MetricsClient.(*metrics.MockMetricsClient)
 		r.True(ok)
 		i, err := tmc.GetCount("cn.atpt.total", "success:true")
 		r.NoError(err)
@@ -825,7 +825,7 @@ func TestProxyTimeouts(t *testing.T) {
 		r.Error(err)
 		r.Contains(err.Error(), "Gateway timeout")
 
-		tmc, ok := cfg.MetricsClient.(*MockMetricsClient)
+		tmc, ok := cfg.MetricsClient.(*metrics.MockMetricsClient)
 		r.True(ok)
 		i, err := tmc.GetCount("cn.atpt.total", "success:false")
 		r.NoError(err)
@@ -900,7 +900,7 @@ func TestProxyConnectFailure(t *testing.T) {
 		r.Error(err)
 		r.Contains(err.Error(), "Bad gateway")
 
-		tmc, ok := cfg.MetricsClient.(*MockMetricsClient)
+		tmc, ok := cfg.MetricsClient.(*metrics.MockMetricsClient)
 		r.True(ok)
 		i, err := tmc.GetCount("cn.atpt.total", "success:false")
 		r.NoError(err)
@@ -966,7 +966,7 @@ func TestProxyHalfClosed(t *testing.T) {
 
 	cfg.ConnTracker.Wg().Wait()
 
-	tmc, ok := cfg.MetricsClient.(*MockMetricsClient)
+	tmc, ok := cfg.MetricsClient.(*metrics.MockMetricsClient)
 	r.True(ok)
 	i, err := tmc.GetCount("cn.atpt.total", "success:true")
 	r.NoError(err)
@@ -1016,7 +1016,7 @@ func TestCustomDialTimeout(t *testing.T) {
 		r.Contains(err.Error(), "Gateway timeout")
 		r.Equal(custom, true)
 
-		tmc, ok := cfg.MetricsClient.(*MockMetricsClient)
+		tmc, ok := cfg.MetricsClient.(*metrics.MockMetricsClient)
 		r.True(ok)
 		i, err := tmc.GetCount("cn.atpt.total", "success:false")
 		r.NoError(err)
@@ -1058,7 +1058,7 @@ func TestCustomDialTimeout(t *testing.T) {
 
 		r.Equal(custom, true)
 
-		tmc, ok := cfg.MetricsClient.(*MockMetricsClient)
+		tmc, ok := cfg.MetricsClient.(*metrics.MockMetricsClient)
 		r.True(ok)
 		i, err := tmc.GetCount("cn.atpt.total", "success:false")
 		r.NoError(err)
@@ -1146,8 +1146,8 @@ func testConfig(role string) (*Config, error) {
 		return role, nil
 	}
 
-	mc := NewMockMetricsClient()
-	conf.ConnTracker = conntrack.NewTracker(conf.IdleTimeout, mc.StatsdClient(), conf.Log, atomic.Value{}, nil)
+	mc := metrics.NewMockMetricsClient()
+	conf.ConnTracker = conntrack.NewTracker(conf.IdleTimeout, mc, conf.Log, atomic.Value{}, nil)
 	conf.MetricsClient = mc
 	return conf, nil
 }


### PR DESCRIPTION
Moves `metrics.go` and `metrics_test.go` into a `metrics` package to allow these utilities to be used by the `conntrack` package. Updates the conntrack package to use this new metrics package.