### PR TITLE
emit metrics for connection overhead latency

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -266,6 +266,11 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 		}
 	}
 
+	// This represents the elapsed time between the proxy request being received until
+	// we attempt to dial the remote host. This is intended to measure the latency
+	// cost incurred by Smokescreen.
+	sctx.cfg.MetricsClient.Timing("proxy_duration_ms", time.Since(sctx.start), 1)
+
 	var conn net.Conn
 	var err error
 


### PR DESCRIPTION
r? @cmoresco-stripe 

This PR will start emitting the `proxy_duration_ms` metric to measure the elapsed time spent in Smokescreen code. This is intended to latency cost incurred by Smokescreen.

It reuses the start time set on the initial context and uses the existing metrics client.