### PR TITLE
Permit underscores in requested domain names

### DIFF
--- a/pkg/smokescreen/hostport/hostport_test.go
+++ b/pkg/smokescreen/hostport/hostport_test.go
@@ -71,7 +71,7 @@ func TestNewWithScheme(t *testing.T) {
 		{"http", "example.com", "example.com", 80, false, ""},
 		{"http", "127.0.0.1", "127.0.0.1", 80, false, ""},
 		{"https", "127.0.0.1:123", "127.0.0.1", 123, false, ""},
-		{"https", "[2001:DB8::1337]", "", 443, false, "invalid domain \"[2001:DB8::1337]\": idna: disallowed rune U+005B"},
+		{"https", "[2001:DB8::1337]", "[2001:db8::1337]", 443, false, "invalid domain \"[2001:DB8::1337]\": disallowed rune U+005B"},
 		{"https", "2001:DB8::1337", "2001:db8::1337", 443, false, ""},
 		{"https", "[2001:DB8::1337]:443", "2001:db8::1337", 443, false, ""},
 		{"https", "[2001:db8::1337]:443", "2001:db8::1337", 443, false, ""},
@@ -82,6 +82,7 @@ func TestNewWithScheme(t *testing.T) {
 		{"smtp", "✉️.example.com.", "xn--4bi.example.com.", 25, false, ""},
 		{"https", "🔐.example.com:123", "xn--jv8h.example.com.", 123, true, ""},
 		{"https", "🔐.example.com:007", "xn--jv8h.example.com.", 7, true, ""},
+		{"https", "foo_bar.example.com:007", "foo_bar.example.com.", 7, true, ""},
 		{"https", "FOO-BAR.example.com", "foo-bar.example.com.", 443, true, ""},
 		{"smtp", "✉️.example.com", "xn--4bi.example.com.", 25, true, ""},
 	}

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -449,11 +449,11 @@ var hostSquareBracketsCases = []struct {
 	hostname  string
 	msg       string
 }{
-	{"http", "http", "[stripe.com]", "invalid domain \"[stripe.com]\": idna: disallowed rune U+005B"},
+	{"http", "http", "[stripe.com]", "invalid domain \"[stripe.com]\": disallowed rune U+005B"},
 	{"https", "connect", "[stripe.com]", "host matched rule in global deny list"},
-	{"http", "http", "[[stripe.com]]", "invalid domain \"[[stripe.com]]\": idna: disallowed rune U+005B"},
+	{"http", "http", "[[stripe.com]]", "invalid domain \"[[stripe.com]]\": disallowed rune U+005B"},
 	{"https", "connect", "[[stripe.com]]", "host matched rule in global deny list"},
-	{"http", "http", "[[[stripe.com]]]", "invalid domain \"[[[stripe.com]]]\": idna: disallowed rune U+005B"},
+	{"http", "http", "[[[stripe.com]]]", "invalid domain \"[[[stripe.com]]]\": disallowed rune U+005B"},
 	{"https", "connect", "[2001:Db8::]:443", "Destination host cannot be determined"},
 	// These somewhat confusing error messages originate from net.SplitHostPort().
 	{"https", "connect", "[[[stripe.com]]]", "address [[stripe.com]]:443: missing port in address"},


### PR DESCRIPTION
The practice shows that the use of underscores in domain names is unfortunately way too common to be ignored.