### PR TITLE
Add VerifyRequestHandler config option

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -79,6 +79,10 @@ type Config struct {
 	// ranges by default (exempting loopback and unicast ranges)
 	// This setting can be used to configure Smokescreen with a blocklist, rather than an allowlist
 	UnsafeAllowPrivateRanges bool
+
+	// Customer handler for verifying requests, users can pass in custom methods to verify requests based
+	// on headers etc.
+	VerifyRequestHandler func(*http.Request) error
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -82,6 +82,7 @@ type Config struct {
 
 	// Custom handler for users to allow running code per requests, users can pass in custom methods to verify requests based
 	// on headers, code for metrics etc.
+	// If the handler returns an error, smokescreen will deny the request.
 	CustomRequestHandler func(*http.Request) error
 }
 

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -80,9 +80,9 @@ type Config struct {
 	// This setting can be used to configure Smokescreen with a blocklist, rather than an allowlist
 	UnsafeAllowPrivateRanges bool
 
-	// Customer handler for verifying requests, users can pass in custom methods to verify requests based
-	// on headers etc.
-	VerifyRequestHandler func(*http.Request) error
+	// Custom handler for users to allow running code per requests, users can pass in custom methods to verify requests based
+	// on headers, code for metrics etc.
+	CustomRequestHandler func(*http.Request) error
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -475,9 +475,9 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 
 		sctx.logger.WithField("url", req.RequestURI).Debug("received HTTP proxy request")
 
-		// verify the request based on the handler, if it exists
-		if config.VerifyRequestHandler != nil {
-			err = config.VerifyRequestHandler(pctx.Req)
+		// Call the custom request handler if it exists
+		if config.CustomRequestHandler != nil {
+			err = config.CustomRequestHandler(pctx.Req)
 			if err != nil {
 				pctx.Error = denyError{err}
 				return req, rejectResponse(pctx, pctx.Error)
@@ -619,9 +619,9 @@ func handleConnect(config *Config, pctx *goproxy.ProxyCtx) (string, error) {
 		return "", pctx.Error
 	}
 
-	// verify the request based on the handler, if it exists
-	if config.VerifyRequestHandler != nil {
-		err = config.VerifyRequestHandler(pctx.Req)
+	// Call the custom request handler if it exists
+	if config.CustomRequestHandler != nil {
+		err = config.CustomRequestHandler(pctx.Req)
 		if err != nil {
 			pctx.Error = denyError{err}
 			return "", pctx.Error

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -477,7 +477,7 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 
 		// Call the custom request handler if it exists
 		if config.CustomRequestHandler != nil {
-			err = config.CustomRequestHandler(pctx.Req)
+			err = config.CustomRequestHandler(req)
 			if err != nil {
 				pctx.Error = denyError{err}
 				return req, rejectResponse(pctx, pctx.Error)

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -1023,10 +1024,15 @@ func TestVerifyRequestHandler(t *testing.T) {
 	r := require.New(t)
 	testHeader := "X-Verify-Request-Header"
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(testHeader) != "" {
+			w.Write([]byte("header not removed!"))
+			return
+		}
 		w.Write([]byte("OK"))
 	})
 	customRequestHandler := func(r *http.Request) error {
 		header := r.Header.Get(testHeader)
+		r.Header.Del(testHeader)
 		if header == "" {
 			return errors.New("header doesn't exist")
 		}
@@ -1077,6 +1083,10 @@ func TestVerifyRequestHandler(t *testing.T) {
 			} else {
 				r.NoError(err)
 				r.Equal(200, resp.StatusCode)
+				body, err := ioutil.ReadAll(resp.Body)
+				r.NoError(err)
+				resp.Body.Close()
+				r.Equal([]byte("OK"), body)
 			}
 		}
 	})
@@ -1129,6 +1139,11 @@ func TestVerifyRequestHandler(t *testing.T) {
 			} else {
 				r.NoError(err)
 				r.Equal(200, resp.StatusCode)
+				body, err := ioutil.ReadAll(resp.Body)
+				r.NoError(err)
+				resp.Body.Close()
+				r.Equal([]byte("OK"), body)
+
 			}
 		}
 	})

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -1184,7 +1184,7 @@ func proxyServer(conf *Config) *httptest.Server {
 	return httptest.NewServer(proxy)
 }
 
-func proxyClient(proxy string, h http.Header) (*http.Client, error) {
+func proxyClient(proxy string, proxyConnectHeaders http.Header) (*http.Client, error) {
 	proxyUrl, err := url.Parse(proxy)
 	if err != nil {
 		return nil, err
@@ -1196,7 +1196,7 @@ func proxyClient(proxy string, h http.Header) (*http.Client, error) {
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
-			ProxyConnectHeader:    h,
+			ProxyConnectHeader:    proxyConnectHeaders,
 		},
 	}, nil
 }

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -1091,7 +1091,7 @@ func TestVerifyRequestHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("test that it works for HTTP (invalid)", func(t *testing.T) {
+	t.Run("test that it works for HTTP", func(t *testing.T) {
 		testCases := []struct {
 			header        string
 			expectedError bool

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -182,7 +182,7 @@ func TestClearsErrorHeader(t *testing.T) {
 		defer proxySrv.Close()
 
 		// Create a http.Client that uses our proxy
-		client, err := proxyClient(proxySrv.URL)
+		client, err := proxyClient(proxySrv.URL, nil)
 		r.NoError(err)
 
 		// Talk "through" the proxy to our malicious upstream that sets the
@@ -220,7 +220,7 @@ func TestClearsErrorHeader(t *testing.T) {
 		defer proxySrv.Close()
 
 		// Create a http.Client that uses our proxy
-		client, err := proxyClient(proxySrv.URL)
+		client, err := proxyClient(proxySrv.URL, nil)
 		r.NoError(err)
 
 		resp, err := client.Get("http://127.0.0.1")
@@ -255,7 +255,7 @@ func TestConsistentHostHeader(t *testing.T) {
 	proxy := BuildProxy(conf)
 	proxySrv := httptest.NewServer(proxy)
 
-	client, err := proxyClient(proxySrv.URL)
+	client, err := proxyClient(proxySrv.URL, nil)
 	r.NoError(err)
 
 	req, err := http.NewRequest("GET", ts.URL, nil)
@@ -296,7 +296,7 @@ func TestClearsTraceIDHeader(t *testing.T) {
 	proxy := BuildProxy(conf)
 	proxySrv := httptest.NewServer(proxy)
 
-	client, err := proxyClient(proxySrv.URL)
+	client, err := proxyClient(proxySrv.URL, nil)
 	r.NoError(err)
 
 	req, err := http.NewRequest("GET", ts.URL, nil)
@@ -416,7 +416,7 @@ func TestInvalidHost(t *testing.T) {
 			defer proxySrv.Close()
 
 			// Create a http.Client that uses our proxy
-			client, err := proxyClient(proxySrv.URL)
+			client, err := proxyClient(proxySrv.URL, nil)
 			r.NoError(err)
 
 			resp, err := client.Get(fmt.Sprintf("%s://notarealhost.test", testCase.scheme))
@@ -473,7 +473,7 @@ func TestHostSquareBrackets(t *testing.T) {
 			defer proxySrv.Close()
 
 			// Create a http.Client that uses our proxy
-			client, err := proxyClient(proxySrv.URL)
+			client, err := proxyClient(proxySrv.URL, nil)
 			r.NoError(err)
 
 			resp, err := client.Get(fmt.Sprintf("%s://%s", testCase.scheme, testCase.hostname))
@@ -509,7 +509,7 @@ func TestErrorHeader(t *testing.T) {
 	defer proxySrv.Close()
 
 	// Create a http.Client that uses our proxy
-	client, err := proxyClient(proxySrv.URL)
+	client, err := proxyClient(proxySrv.URL, nil)
 	r.NoError(err)
 
 	resp, err := client.Get("http://example.com")
@@ -548,7 +548,7 @@ func TestProxyProtocols(t *testing.T) {
 		logHook := proxyLogHook(cfg)
 		proxy := proxyServer(cfg)
 		remote := httptest.NewServer(h)
-		client, err := proxyClient(proxy.URL)
+		client, err := proxyClient(proxy.URL, nil)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -588,7 +588,7 @@ func TestProxyProtocols(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewTLSServer(h)
-		client, err := proxyClient(proxy.URL)
+		client, err := proxyClient(proxy.URL, nil)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -640,7 +640,7 @@ func TestProxyTimeouts(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewServer(h)
-		client, err := proxyClient(proxy.URL)
+		client, err := proxyClient(proxy.URL, nil)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -680,7 +680,7 @@ func TestProxyTimeouts(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewTLSServer(h)
-		client, err := proxyClient(proxy.URL)
+		client, err := proxyClient(proxy.URL, nil)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -719,7 +719,7 @@ func TestProxyTimeouts(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewTLSServer(h)
-		client, err := proxyClient(proxy.URL)
+		client, err := proxyClient(proxy.URL, nil)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -755,7 +755,7 @@ func TestProxyTimeouts(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewServer(h)
-		client, err := proxyClient(proxy.URL)
+		client, err := proxyClient(proxy.URL, nil)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -793,7 +793,7 @@ func TestProxyConnectFailure(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewTLSServer(h)
-		client, err := proxyClient(proxy.URL)
+		client, err := proxyClient(proxy.URL, nil)
 		r.NoError(err)
 
 		// Shut down the handler so that the proxy won't be able to connect at all
@@ -859,7 +859,7 @@ func TestProxyHalfClosed(t *testing.T) {
 
 	proxy := proxyServer(cfg)
 	remote := httptest.NewTLSServer(h)
-	client, err := proxyClient(proxy.URL)
+	client, err := proxyClient(proxy.URL, nil)
 	r.NoError(err)
 
 	req, err := http.NewRequest("GET", remote.URL, nil)
@@ -909,7 +909,7 @@ func TestCustomDialTimeout(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewTLSServer(h)
-		client, err := proxyClient(proxy.URL)
+		client, err := proxyClient(proxy.URL, nil)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -952,7 +952,7 @@ func TestCustomDialTimeout(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewServer(h)
-		client, err := proxyClient(proxy.URL)
+		client, err := proxyClient(proxy.URL, nil)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -995,11 +995,13 @@ func TestRejectResponseHandler(t *testing.T) {
 		defer proxySrv.Close()
 
 		// Create a http.Client that uses our proxy
-		client, err := proxyClient(proxySrv.URL)
+		client, err := proxyClient(proxySrv.URL, nil)
 		r.NoError(err)
 
 		// Send a request that should be blocked
-		resp, err := client.Get("http://127.0.0.1")
+		req, err := http.NewRequest("GET", "http://127.0.0.1", nil)
+		req.Header.Set("hello", "hi")
+		resp, err := client.Do(req)
 		r.NoError(err)
 
 		// The RejectResponseHandler should set our custom header
@@ -1015,6 +1017,121 @@ func TestRejectResponseHandler(t *testing.T) {
 		h = resp.Header.Get(testHeader)
 		if h != "" {
 			t.Errorf("Expecting header %s to not be set by RejectResponseHandler", testHeader)
+		}
+	})
+}
+
+func TestVerifyRequestHandler(t *testing.T) {
+	r := require.New(t)
+	testHeader := "X-Verify-Request-Header"
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("OK"))
+	})
+	v := func(r *http.Request) error {
+		header := r.Header.Get(testHeader)
+		if header == "" {
+			return errors.New("header doesn't exist")
+		}
+		if header != "valid" {
+			return errors.New("invalid header")
+		}
+		return nil
+	}
+
+	t.Run("Testing that verify request handler works for HTTPS", func(t *testing.T) {
+		testCases := []struct {
+			header        http.Header
+			expectedError bool
+		}{
+			{
+				header:        http.Header{testHeader: []string{"valid"}},
+				expectedError: false,
+			},
+			{
+				header:        http.Header{testHeader: []string{"invalid"}},
+				expectedError: true,
+			},
+		}
+		cfg, err := testConfig("test-local-srv")
+		r.NoError(err)
+		err = cfg.SetAllowAddresses([]string{"127.0.0.1"})
+		r.NoError(err)
+		cfg.VerifyRequestHandler = v
+
+		l, err := net.Listen("tcp", "localhost:0")
+		r.NoError(err)
+		cfg.Listener = l
+
+		proxy := proxyServer(cfg)
+		remote := httptest.NewTLSServer(h)
+		defer proxy.Close()
+		for _, testCase := range testCases {
+
+			client, err := proxyClient(proxy.URL, testCase.header)
+			r.NoError(err)
+
+			req, err := http.NewRequest("GET", remote.URL, nil)
+			r.NoError(err)
+			resp, err := client.Do(req)
+			if testCase.expectedError {
+				r.Nil(resp)
+				r.Contains(err.Error(), "Request rejected by proxy")
+			} else {
+				r.NoError(err)
+				r.Equal(200, resp.StatusCode)
+			}
+		}
+	})
+
+	t.Run("test that it works for HTTP (invalid)", func(t *testing.T) {
+		testCases := []struct {
+			header        string
+			expectedError bool
+		}{
+			{
+				header:        "valid",
+				expectedError: false,
+			},
+			{
+				header:        "invalid",
+				expectedError: true,
+			},
+		}
+		cfg, err := testConfig("test-local-srv")
+		r.NoError(err)
+		err = cfg.SetAllowAddresses([]string{"127.0.0.1"})
+		r.NoError(err)
+		cfg.VerifyRequestHandler = v
+
+		l, err := net.Listen("tcp", "localhost:0")
+		r.NoError(err)
+		cfg.Listener = l
+
+		remote := httptest.NewServer(h)
+
+		proxySrv := proxyServer(cfg)
+		r.NoError(err)
+		defer proxySrv.Close()
+
+		// Create a http.Client that uses our proxy
+		client, err := proxyClient(proxySrv.URL, nil)
+		r.NoError(err)
+
+		for _, testCase := range testCases {
+			// Send a request that should be blocked
+			req, err := http.NewRequest("GET", remote.URL, nil)
+			r.NoError(err)
+			req.Header.Set(testHeader, testCase.header)
+			resp, err := client.Do(req)
+			if testCase.expectedError {
+				r.NoError(err)
+				errorMessage := resp.Header.Get("X-Smokescreen-Error")
+				r.Contains(errorMessage, "invalid header")
+
+			} else {
+				r.NoError(err)
+				r.Equal(200, resp.StatusCode)
+			}
 		}
 	})
 }
@@ -1069,7 +1186,7 @@ func proxyServer(conf *Config) *httptest.Server {
 	return httptest.NewServer(proxy)
 }
 
-func proxyClient(proxy string) (*http.Client, error) {
+func proxyClient(proxy string, h http.Header) (*http.Client, error) {
 	proxyUrl, err := url.Parse(proxy)
 	if err != nil {
 		return nil, err
@@ -1081,6 +1198,9 @@ func proxyClient(proxy string) (*http.Client, error) {
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+			GetProxyConnectHeader: func(ctx context.Context, proxyURL *url.URL, target string) (http.Header, error) {
+				return h, nil
+			},
 		},
 	}, nil
 }

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -1126,7 +1126,6 @@ func TestVerifyRequestHandler(t *testing.T) {
 		r.NoError(err)
 
 		for _, testCase := range testCases {
-			// Send a request that should be blocked
 			req, err := http.NewRequest("GET", remote.URL, nil)
 			r.NoError(err)
 			req.Header.Set(testHeader, testCase.header)

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -183,7 +183,7 @@ func TestClearsErrorHeader(t *testing.T) {
 		defer proxySrv.Close()
 
 		// Create a http.Client that uses our proxy
-		client, err := proxyClient(proxySrv.URL, nil)
+		client, err := proxyClient(proxySrv.URL)
 		r.NoError(err)
 
 		// Talk "through" the proxy to our malicious upstream that sets the
@@ -221,7 +221,7 @@ func TestClearsErrorHeader(t *testing.T) {
 		defer proxySrv.Close()
 
 		// Create a http.Client that uses our proxy
-		client, err := proxyClient(proxySrv.URL, nil)
+		client, err := proxyClient(proxySrv.URL)
 		r.NoError(err)
 
 		resp, err := client.Get("http://127.0.0.1")
@@ -256,7 +256,7 @@ func TestConsistentHostHeader(t *testing.T) {
 	proxy := BuildProxy(conf)
 	proxySrv := httptest.NewServer(proxy)
 
-	client, err := proxyClient(proxySrv.URL, nil)
+	client, err := proxyClient(proxySrv.URL)
 	r.NoError(err)
 
 	req, err := http.NewRequest("GET", ts.URL, nil)
@@ -297,7 +297,7 @@ func TestClearsTraceIDHeader(t *testing.T) {
 	proxy := BuildProxy(conf)
 	proxySrv := httptest.NewServer(proxy)
 
-	client, err := proxyClient(proxySrv.URL, nil)
+	client, err := proxyClient(proxySrv.URL)
 	r.NoError(err)
 
 	req, err := http.NewRequest("GET", ts.URL, nil)
@@ -417,7 +417,7 @@ func TestInvalidHost(t *testing.T) {
 			defer proxySrv.Close()
 
 			// Create a http.Client that uses our proxy
-			client, err := proxyClient(proxySrv.URL, nil)
+			client, err := proxyClient(proxySrv.URL)
 			r.NoError(err)
 
 			resp, err := client.Get(fmt.Sprintf("%s://notarealhost.test", testCase.scheme))
@@ -474,7 +474,7 @@ func TestHostSquareBrackets(t *testing.T) {
 			defer proxySrv.Close()
 
 			// Create a http.Client that uses our proxy
-			client, err := proxyClient(proxySrv.URL, nil)
+			client, err := proxyClient(proxySrv.URL)
 			r.NoError(err)
 
 			resp, err := client.Get(fmt.Sprintf("%s://%s", testCase.scheme, testCase.hostname))
@@ -510,7 +510,7 @@ func TestErrorHeader(t *testing.T) {
 	defer proxySrv.Close()
 
 	// Create a http.Client that uses our proxy
-	client, err := proxyClient(proxySrv.URL, nil)
+	client, err := proxyClient(proxySrv.URL)
 	r.NoError(err)
 
 	resp, err := client.Get("http://example.com")
@@ -549,7 +549,7 @@ func TestProxyProtocols(t *testing.T) {
 		logHook := proxyLogHook(cfg)
 		proxy := proxyServer(cfg)
 		remote := httptest.NewServer(h)
-		client, err := proxyClient(proxy.URL, nil)
+		client, err := proxyClient(proxy.URL)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -589,7 +589,7 @@ func TestProxyProtocols(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewTLSServer(h)
-		client, err := proxyClient(proxy.URL, nil)
+		client, err := proxyClient(proxy.URL)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -641,7 +641,7 @@ func TestProxyTimeouts(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewServer(h)
-		client, err := proxyClient(proxy.URL, nil)
+		client, err := proxyClient(proxy.URL)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -681,7 +681,7 @@ func TestProxyTimeouts(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewTLSServer(h)
-		client, err := proxyClient(proxy.URL, nil)
+		client, err := proxyClient(proxy.URL)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -720,7 +720,7 @@ func TestProxyTimeouts(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewTLSServer(h)
-		client, err := proxyClient(proxy.URL, nil)
+		client, err := proxyClient(proxy.URL)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -756,7 +756,7 @@ func TestProxyTimeouts(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewServer(h)
-		client, err := proxyClient(proxy.URL, nil)
+		client, err := proxyClient(proxy.URL)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -794,7 +794,7 @@ func TestProxyConnectFailure(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewTLSServer(h)
-		client, err := proxyClient(proxy.URL, nil)
+		client, err := proxyClient(proxy.URL)
 		r.NoError(err)
 
 		// Shut down the handler so that the proxy won't be able to connect at all
@@ -860,7 +860,7 @@ func TestProxyHalfClosed(t *testing.T) {
 
 	proxy := proxyServer(cfg)
 	remote := httptest.NewTLSServer(h)
-	client, err := proxyClient(proxy.URL, nil)
+	client, err := proxyClient(proxy.URL)
 	r.NoError(err)
 
 	req, err := http.NewRequest("GET", remote.URL, nil)
@@ -910,7 +910,7 @@ func TestCustomDialTimeout(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewTLSServer(h)
-		client, err := proxyClient(proxy.URL, nil)
+		client, err := proxyClient(proxy.URL)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -953,7 +953,7 @@ func TestCustomDialTimeout(t *testing.T) {
 
 		proxy := proxyServer(cfg)
 		remote := httptest.NewServer(h)
-		client, err := proxyClient(proxy.URL, nil)
+		client, err := proxyClient(proxy.URL)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -996,7 +996,7 @@ func TestRejectResponseHandler(t *testing.T) {
 		defer proxySrv.Close()
 
 		// Create a http.Client that uses our proxy
-		client, err := proxyClient(proxySrv.URL, nil)
+		client, err := proxyClient(proxySrv.URL)
 		r.NoError(err)
 
 		// Send a request that should be blocked
@@ -1071,7 +1071,7 @@ func TestCustomRequestHandler(t *testing.T) {
 		defer proxy.Close()
 		for _, testCase := range testCases {
 
-			client, err := proxyClient(proxy.URL, testCase.header)
+			client, err := proxyClientWithConnectHeaders(proxy.URL, testCase.header)
 			r.NoError(err)
 
 			req, err := http.NewRequest("GET", remote.URL, nil)
@@ -1122,7 +1122,7 @@ func TestCustomRequestHandler(t *testing.T) {
 		defer proxySrv.Close()
 
 		// Create a http.Client that uses our proxy
-		client, err := proxyClient(proxySrv.URL, nil)
+		client, err := proxyClient(proxySrv.URL)
 		r.NoError(err)
 
 		for _, testCase := range testCases {
@@ -1198,7 +1198,11 @@ func proxyServer(conf *Config) *httptest.Server {
 	return httptest.NewServer(proxy)
 }
 
-func proxyClient(proxy string, proxyConnectHeaders http.Header) (*http.Client, error) {
+func proxyClient(proxy string) (*http.Client, error) {
+	return proxyClientWithConnectHeaders(proxy, nil)
+}
+
+func proxyClientWithConnectHeaders(proxy string, proxyConnectHeaders http.Header) (*http.Client, error) {
 	proxyUrl, err := url.Parse(proxy)
 	if err != nil {
 		return nil, err

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -999,9 +999,7 @@ func TestRejectResponseHandler(t *testing.T) {
 		r.NoError(err)
 
 		// Send a request that should be blocked
-		req, err := http.NewRequest("GET", "http://127.0.0.1", nil)
-		req.Header.Set("hello", "hi")
-		resp, err := client.Do(req)
+		resp, err := client.Get("http://127.0.0.1")
 		r.NoError(err)
 
 		// The RejectResponseHandler should set our custom header

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -1020,7 +1020,7 @@ func TestRejectResponseHandler(t *testing.T) {
 	})
 }
 
-func TestVerifyRequestHandler(t *testing.T) {
+func TestCustomRequestHandler(t *testing.T) {
 	r := require.New(t)
 	testHeader := "X-Verify-Request-Header"
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1042,7 +1042,7 @@ func TestVerifyRequestHandler(t *testing.T) {
 		return nil
 	}
 
-	t.Run("Testing that verify request handler works for HTTPS", func(t *testing.T) {
+	t.Run("CustomRequestHandler works for HTTPS", func(t *testing.T) {
 		testCases := []struct {
 			header        http.Header
 			expectedError bool
@@ -1091,7 +1091,7 @@ func TestVerifyRequestHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("test that it works for HTTP", func(t *testing.T) {
+	t.Run("CustomRequestHandler works for HTTP", func(t *testing.T) {
 		testCases := []struct {
 			header        string
 			expectedError bool

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -1198,9 +1198,7 @@ func proxyClient(proxy string, h http.Header) (*http.Client, error) {
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
-			GetProxyConnectHeader: func(ctx context.Context, proxyURL *url.URL, target string) (http.Header, error) {
-				return h, nil
-			},
+			ProxyConnectHeader:    h,
 		},
 	}, nil
 }

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -1025,7 +1025,7 @@ func TestVerifyRequestHandler(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("OK"))
 	})
-	v := func(r *http.Request) error {
+	customRequestHandler := func(r *http.Request) error {
 		header := r.Header.Get(testHeader)
 		if header == "" {
 			return errors.New("header doesn't exist")
@@ -1054,7 +1054,7 @@ func TestVerifyRequestHandler(t *testing.T) {
 		r.NoError(err)
 		err = cfg.SetAllowAddresses([]string{"127.0.0.1"})
 		r.NoError(err)
-		cfg.VerifyRequestHandler = v
+		cfg.CustomRequestHandler = customRequestHandler
 
 		l, err := net.Listen("tcp", "localhost:0")
 		r.NoError(err)
@@ -1099,7 +1099,7 @@ func TestVerifyRequestHandler(t *testing.T) {
 		r.NoError(err)
 		err = cfg.SetAllowAddresses([]string{"127.0.0.1"})
 		r.NoError(err)
-		cfg.VerifyRequestHandler = v
+		cfg.CustomRequestHandler = customRequestHandler
 
 		l, err := net.Listen("tcp", "localhost:0")
 		r.NoError(err)


### PR DESCRIPTION
This PR adds support for passing in a callback method to verify requests. We're doing this because we want to verify requests internally at Stripe.

Motivation: https://jira.corp.stripe.com/browse/SECURE_FRAMEWORKS-2919

Test plan: I've added tests for both HTTP and HTTPS cases.

r? @cds2-stripe 