### PR TITLE
Add timing metric for DNS resolution

### DIFF
--- a/pkg/smokescreen/metrics/metrics.go
+++ b/pkg/smokescreen/metrics/metrics.go
@@ -39,6 +39,7 @@ var metrics = []string{
 	"resolver.deny.not_global_unicast",
 	"resolver.deny.private_range",
 	"resolver.deny.user_configured",
+	"resolver.lookup_time", // DNS lookup time in ms, not tagged
 	"resolver.errors_total",
 }
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -216,11 +216,15 @@ func resolveTCPAddr(config *Config, network, addr string) (*net.TCPAddr, error) 
 
 func safeResolve(config *Config, network, addr string) (*net.TCPAddr, string, error) {
 	config.MetricsClient.Incr("resolver.attempts_total", 1)
+
+	resolveStart := time.Now()
 	resolved, err := resolveTCPAddr(config, network, addr)
+	resolveDuration := time.Since(resolveStart)
 	if err != nil {
 		config.MetricsClient.Incr("resolver.errors_total", 1)
 		return nil, "", err
 	}
+	config.MetricsClient.Timing("resolver.lookup_time", resolveDuration, 0.5)
 
 	classification := classifyAddr(config, resolved)
 	config.MetricsClient.Incr(classification.statsdString(), 1)

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -559,8 +559,22 @@ func TestProxyProtocols(t *testing.T) {
 			client.Do(req)
 			clientCh <- true
 		}()
-
 		<-clientCh
+
+		// Metrics should show one successful connection and a corresponding successful
+		// DNS request along with its timing metric.
+		tmc, ok := cfg.MetricsClient.(*metrics.MockMetricsClient)
+		r.True(ok)
+		i, err := tmc.GetCount("cn.atpt.total", "success:true")
+		r.NoError(err)
+		r.Equal(i, uint64(1))
+		lookups, err := tmc.GetCount("resolver.attempts_total")
+		r.NoError(err)
+		r.Equal(lookups, uint64(1))
+		ltime, err := tmc.GetCount("resolver.lookup_time")
+		r.NoError(err)
+		r.Equal(ltime, uint64(1))
+
 		entry := findCanonicalProxyDecision(logHook.AllEntries())
 		r.NotNil(entry)
 
@@ -610,6 +624,20 @@ func TestProxyProtocols(t *testing.T) {
 
 		serverCh <- true
 		<-clientCh
+
+		// Metrics should show one successful connection and a corresponding successful
+		// DNS request along with its timing metric.
+		tmc, ok := cfg.MetricsClient.(*metrics.MockMetricsClient)
+		r.True(ok)
+		i, err := tmc.GetCount("cn.atpt.total", "success:true")
+		r.NoError(err)
+		r.Equal(i, uint64(1))
+		lookups, err := tmc.GetCount("resolver.attempts_total")
+		r.NoError(err)
+		r.Equal(lookups, uint64(1))
+		ltime, err := tmc.GetCount("resolver.lookup_time")
+		r.NoError(err)
+		r.Equal(ltime, uint64(1))
 
 		entry := findCanonicalProxyDecision(logHook.AllEntries())
 		r.NotNil(entry)


### PR DESCRIPTION
This PR adds a `resolver.lookup_time` timing metric that is emitted when Smokescreen looks up a hostname. This is meant to enable measurable experiments with DNS plumbing for egress proxy hosts.

I set metric sampling to 50% (a "rate" of `0.5`). Plausibly this could be a configuration setting that could be dialed up and down, but I'll leave that to a future refactor.

Tested locally to confirm that the new metric is emitted with meaningful timing:

```shellsession
$ cat config.yaml
---
allow_missing_role: true
statsd_address: 127.0.0.1:8200

$ nc -uklv 127.0.0.1 8200 &
[1] 98820

$ ./smokescreen --config-file config.yaml &
[2] 98829
{"level":"info","msg":"starting","time":"2022-11-30T14:21:34-08:00"}

$ curl --proxytunnel -x localhost:4750 google.com
{"allow":true,"decision_reason":"Egress ACL is not configured","dns_lookup_time_ms":1,"enforce_would_deny":false,"id":"ce3tes292d3o439nlfa0","inbound_remote_addr":"127.0.0.1:58585","level":"info","msg":"CANONICAL-PROXY-DECISION","project":"","proxy_type":"connect","requested_host":"google.com:80","role":"","start_time":"2022-11-30T22:21:36.081078Z","time":"2022-11-30T14:21:36-08:00","trace_id":""}
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.com/">here</A>.
</BODY></HTML>
{"bytes_in":732,"bytes_out":74,"conn_establish_time_ms":4,"duration":0.025030375,"end_time":"2022-11-30T22:21:36.112313Z","error":"","id":"ce3tes292d3o439nlfa0","inbound_remote_addr":"127.0.0.1:58585","last_activity":"2022-11-30T22:21:36.112056Z","level":"info","msg":"CANONICAL-PROXY-CN-CLOSE","outbound_remote_addr":"142.251.211.238:80","project":"","proxy_type":"connect","requested_host":"google.com:80","role":"","start_time":"2022-11-30T22:21:36.081078Z","time":"2022-11-30T14:21:36-08:00","trace_id":""}
smokescreen.cn.bytes_in:732|h|#role:smokescreen.cn.duration:0.025030375|h|#role:
smokescreen.cn.bytes_out:74|h|#role:smokescreen.resolver.allow.default:1|csmokescreen.resolver.attempts_total:1|csmokescreen.cn.atpt.total:1|c|#success:truesmokescreen.proxy_duration_ms:1.781917|mssmokescreen.cn.close:1|c|#role:smokescreen.resolver.lookup_time:1.578333|ms|@0.5
```

r? @cds2-stripe