### PR TITLE
Add a header for metadata to log

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -59,7 +59,7 @@ const (
 	CanonicalProxyDecision   = "CANONICAL-PROXY-DECISION"
 	LogFieldConnEstablishMS  = "conn_establish_time_ms"
 	LogFieldDNSLookupTime    = "dns_lookup_time_ms"
-	LogFieldLogMetadata      = "log_metadata"
+	LogFieldLogMetadata      = "custom_metadata"
 )
 
 type ipType int


### PR DESCRIPTION
Adds a header "X-Smokescreen-Log-Metadata" that works similarly to the  "X-Smokescreen-Trace-ID" header. The log metadata header takes in a string that is included in proxy logs under "log_metadata"