### PR TITLE
Add a custom interface for the resolver instead of forcing *net.Resolver

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -29,13 +29,20 @@ type RuleRange struct {
 	Port int
 }
 
+// Resolver implements the interface needed by smokescreen and implemented by *net.Resolver
+// This will allow different resolvers to also be provided
+type Resolver interface {
+	LookupPort(ctx context.Context, network, service string) (port int, err error)
+	LookupIP(ctx context.Context, network, host string) ([]net.IP, error)
+}
+
 type Config struct {
 	Ip                           string
 	Port                         uint16
 	Listener                     net.Listener
 	DenyRanges                   []RuleRange
 	AllowRanges                  []RuleRange
-	Resolver                     *net.Resolver
+	Resolver                     Resolver
 	ConnectTimeout               time.Duration
 	ExitTimeout                  time.Duration
 	MetricsClient                metrics.MetricsClientInterface
@@ -228,6 +235,7 @@ func NewConfig() *Config {
 	})
 
 	return &Config{
+		Resolver:                &net.Resolver{},
 		CrlByAuthorityKeyId:     make(map[string]*pkix.CertificateList),
 		clientCasBySubjectKeyId: make(map[string]*x509.Certificate),
 		Log:                     log.New(),


### PR DESCRIPTION
Hello!

I'd like to suggest using a custom interface instead of the `*net.Resolver` in the Config to allow users to use their own DNS resolver, such as https://github.com/miekg/dns for example, or additional logging around the resolution.

This PR adds this custom interface with the two methods that you use in smokescreen ([here](https://github.com/stripe/smokescreen/blob/4835f355a9d3aa30614051344191aa77fdbd4f1d/pkg/smokescreen/smokescreen.go#L198-L203)) and then puts `&net.Resolver{}` as the default Value in NewConfig if None is provided.

Let me know if you need anything else from me!