### PR TITLE
Tag acl. metrics with requested_host

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -927,6 +927,7 @@ func checkACLsForRequest(config *Config, req *http.Request, destination hostport
 		fmt.Sprintf("role:%s", decision.role),
 		fmt.Sprintf("def_rule:%t", aclDecision.Default),
 		fmt.Sprintf("project:%s", aclDecision.Project),
+		fmt.Sprintf("requested_host:%s", destination.Host),
 	}
 
 	switch aclDecision.Result {


### PR DESCRIPTION
This change tags `acl.` metrics (`acl.deny`, `acl.allow`, ...) with the `requested_host`. The tag can be used to ignore certain known denials in alerting or count the number of requests to a given host.