### PR TITLE
Use ElementsMatch to ignore order

### DIFF
--- a/pkg/smokescreen/metrics/prometheus_metrics_test.go
+++ b/pkg/smokescreen/metrics/prometheus_metrics_test.go
@@ -1,13 +1,12 @@
 package metrics
 
 import (
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func TestMapKeys(t *testing.T) {
-	a := assert.New(t)
+	r := require.New(t)
 
 	inputMap := map[string]string{
 		"firstKey":  "firstValue",
@@ -21,7 +20,7 @@ func TestMapKeys(t *testing.T) {
 		"thirdKey",
 	}
 
-	a.ElementsMatch(expectedKeys, mapKeys(inputMap))
+	r.ElementsMatch(expectedKeys, mapKeys(inputMap))
 }
 
 func TestMergeMaps(t *testing.T) {

--- a/pkg/smokescreen/metrics/prometheus_metrics_test.go
+++ b/pkg/smokescreen/metrics/prometheus_metrics_test.go
@@ -1,12 +1,13 @@
 package metrics
 
 import (
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func TestMapKeys(t *testing.T) {
-	r := require.New(t)
+	a := assert.New(t)
 
 	inputMap := map[string]string{
 		"firstKey":  "firstValue",
@@ -20,7 +21,7 @@ func TestMapKeys(t *testing.T) {
 		"thirdKey",
 	}
 
-	r.Equal(expectedKeys, mapKeys(inputMap))
+	a.ElementsMatch(expectedKeys, mapKeys(inputMap))
 }
 
 func TestMergeMaps(t *testing.T) {


### PR DESCRIPTION
Fixes a non-deterministic failing test TestMapKeys.

This change switches the test comparison to `require.ElementsMatch` to compare slices, which ignores ordering, since iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next.

https://go.dev/ref/spec#For_statements

Verified that consecutive tests now pass:
```
➜  smokescreen git:(kevinv/fix-test-map-keys) ✗ go test ./pkg/smokescreen/metrics/... -count=1
ok  	github.com/stripe/smokescreen/pkg/smokescreen/metrics	0.169s
➜  smokescreen git:(kevinv/fix-test-map-keys) ✗ go test ./pkg/smokescreen/metrics/... -count=1
ok  	github.com/stripe/smokescreen/pkg/smokescreen/metrics	0.152s
➜  smokescreen git:(kevinv/fix-test-map-keys) ✗ go test ./pkg/smokescreen/metrics/... -count=1
ok  	github.com/stripe/smokescreen/pkg/smokescreen/metrics	0.160s
➜  smokescreen git:(kevinv/fix-test-map-keys) ✗ go test ./pkg/smokescreen/metrics/... -count=1
ok  	github.com/stripe/smokescreen/pkg/smokescreen/metrics	0.156s
➜  smokescreen git:(kevinv/fix-test-map-keys) ✗ go test ./pkg/smokescreen/metrics/... -count=1
ok  	github.com/stripe/smokescreen/pkg/smokescreen/metrics	0.159s
➜  smokescreen git:(kevinv/fix-test-map-keys) ✗ go test ./pkg/smokescreen/metrics/... -count=1
ok  	github.com/stripe/smokescreen/pkg/smokescreen/metrics	0.141s
➜  smokescreen git:(kevinv/fix-test-map-keys) ✗ go test ./pkg/smokescreen/metrics/... -count=1
ok  	github.com/stripe/smokescreen/pkg/smokescreen/metrics	0.159s
```