### PR TITLE
Do not return a denyError for DNS resolution failures

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -441,7 +441,7 @@ func validateProxyResponseWithUpstream(t *testing.T, test *TestCase, resp *http.
 	t.Logf("HTTP Response: %#v", resp)
 
 	if test.OverConnect {
-		a.Contains(err.Error(), "Failed to connect to remote host")
+		a.Contains(err.Error(), "Failed to resolve remote hostname")
 	} else {
 		a.Equal(http.StatusBadGateway, resp.StatusCode)
 	}

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -356,15 +356,16 @@ func rejectResponse(pctx *goproxy.ProxyCtx, err error) *http.Response {
 			status = "Gateway timeout"
 			code = http.StatusGatewayTimeout
 			msg = "Timed out connecting to remote host: " + e.Error()
+
+		} else if e, ok := err.(*net.DNSError); ok {
+			status = "Bad gateway"
+			code = http.StatusBadGateway
+			msg = "Failed to resolve remote hostname: " + e.Error()
 		} else {
 			status = "Bad gateway"
 			code = http.StatusBadGateway
 			msg = "Failed to connect to remote host: " + e.Error()
 		}
-	} else if e, ok := err.(*net.DNSError); ok {
-		status = "Gateway timeout"
-		code = http.StatusBadGateway
-		msg = "Failed to resolve remote hostname: " + e.Error()
 	} else if e, ok := err.(denyError); ok {
 		status = "Request rejected by proxy"
 		code = http.StatusProxyAuthRequired

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -406,11 +406,10 @@ func TestHealthcheck(t *testing.T) {
 
 var invalidHostCases = []struct {
 	scheme    string
-	expectErr bool
 	proxyType string
 }{
-	{"http", false, "http"},
-	{"https", true, "connect"},
+	{"http", "http"},
+	{"https", "connect"},
 }
 
 func TestInvalidHost(t *testing.T) {
@@ -430,10 +429,13 @@ func TestInvalidHost(t *testing.T) {
 			client, err := proxyClient(proxySrv.URL)
 			r.NoError(err)
 
+			// This hostname does not exist and should never resolve
 			resp, err := client.Get(fmt.Sprintf("%s://notarealhost.test", testCase.scheme))
-			if testCase.expectErr {
-				r.Contains(err.Error(), "Request rejected by proxy")
+			if testCase.scheme == "https" {
+				r.Error(err)
+				r.Contains(err.Error(), "Bad gateway")
 			} else {
+				// Plain HTTP
 				r.NoError(err)
 				r.Equal(http.StatusBadGateway, resp.StatusCode)
 			}

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -438,6 +438,10 @@ func TestInvalidHost(t *testing.T) {
 				// Plain HTTP
 				r.NoError(err)
 				r.Equal(http.StatusBadGateway, resp.StatusCode)
+
+				defer resp.Body.Close()
+				b, _ := ioutil.ReadAll(resp.Body)
+				r.Contains(string(b), "Failed to resolve remote hostname")
 			}
 
 			entry := findCanonicalProxyDecision(logHook.AllEntries())


### PR DESCRIPTION
This PR ensures that the correct errors are surfaced when a DNS resolution error happens during the call to `checkIfRequestShouldBeProxied()`. Previously, any kind of error, irrespective of the kind, was surfaced as a `denyError`  even if the domain name was allowed by the ACL. This obfuscated the true source of the error and some users were seeing ACL denials that were actually DNS lookup failures.

In the event of an actual ACL denial, `pctx.Error` will be nil and we should not wrap the returned error with ` denyError{}`. Instead, we now return the raw `pctx.Error`.

I also added a more granular type assertion for `*net.DNSError` and included the additional context in the response body.

We had a few tests which were already suitable for checking for this condition. I updated them with the new behavior and response messages.

r? @jjiang-stripe 