### PR TITLE
add AcceptResponseHandler to modify accepted responses

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -82,6 +82,9 @@ type Config struct {
 	// Customer handler to allow clients to modify reject responses
 	RejectResponseHandler func(*http.Response)
 
+	// Customer handler to allow clients to modify accept responses
+	AcceptResponseHandler func(*http.Response)
+
 	// UnsafeAllowPrivateRanges inverts the default behavior, telling smokescreen to allow private IP
 	// ranges by default (exempting loopback and unicast ranges)
 	// This setting can be used to configure Smokescreen with a blocklist, rather than an allowlist

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -79,10 +79,10 @@ type Config struct {
 	// Custom Dial Timeout function to be called
 	ProxyDialTimeout func(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error)
 
-	// Customer handler to allow clients to modify reject responses
+	// Custom handler to allow clients to modify reject responses
 	RejectResponseHandler func(*http.Response)
 
-	// Customer handler to allow clients to modify accept responses
+	// Custom handler to allow clients to modify accept responses
 	AcceptResponseHandler func(*http.Response)
 
 	// UnsafeAllowPrivateRanges inverts the default behavior, telling smokescreen to allow private IP

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -541,9 +541,12 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 	proxy.OnResponse().DoFunc(func(resp *http.Response, pctx *goproxy.ProxyCtx) *http.Response {
 		sctx := pctx.UserData.(*smokescreenContext)
 
-		if resp != nil && resp.Header.Get(errorHeader) != "" {
-			if pctx.Error == nil && sctx.decision.allow {
+		if resp != nil && pctx.Error == nil && sctx.decision.allow {
+			if resp.Header.Get(errorHeader) != "" {
 				resp.Header.Del(errorHeader)
+			}
+			if sctx.cfg.AcceptResponseHandler != nil {
+				sctx.cfg.AcceptResponseHandler(resp)
 			}
 		}
 


### PR DESCRIPTION
This change adds an AcceptReponseHandler to the config, which provides a hook to modify an accepted CONNECT response before it is returned to the client. This complements the existing RejectResponseHandler.