### PR TITLE
Use AcceptResponseHandler in goproxy https CONNECT hook

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
-	github.com/stripe/goproxy v0.0.0-20220308202309-3f1dfba6d1a4
+	github.com/stripe/goproxy v0.0.0-20230801191332-fabc3ecb7251
 	golang.org/x/net v0.7.0
 	gopkg.in/urfave/cli.v1 v1.20.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stripe/goproxy v0.0.0-20220308202309-3f1dfba6d1a4 h1:6lqpRCXAhigpiMu6aZYTHryDmLrhIND0H4iUKEntN1M=
 github.com/stripe/goproxy v0.0.0-20220308202309-3f1dfba6d1a4/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20230801191332-fabc3ecb7251 h1:wR1exp7OglR0ctk8yWPVp1oTOuyaLUlJv3/Wlbvbw64=
+github.com/stripe/goproxy v0.0.0-20230801191332-fabc3ecb7251/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/stripe/goproxy"
 	acl "github.com/stripe/smokescreen/pkg/smokescreen/acl/v1"
 	"github.com/stripe/smokescreen/pkg/smokescreen/conntrack"
 	"github.com/stripe/smokescreen/pkg/smokescreen/metrics"
@@ -84,7 +83,7 @@ type Config struct {
 	RejectResponseHandler func(*http.Response)
 
 	// Custom handler to allow clients to modify successful CONNECT responses
-	AcceptResponseHandler func(*goproxy.ProxyCtx, *http.Response) error
+	AcceptResponseHandler func(*smokescreenContext, *http.Response) error
 
 	// UnsafeAllowPrivateRanges inverts the default behavior, telling smokescreen to allow private IP
 	// ranges by default (exempting loopback and unicast ranges)

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/stripe/goproxy"
 	acl "github.com/stripe/smokescreen/pkg/smokescreen/acl/v1"
 	"github.com/stripe/smokescreen/pkg/smokescreen/conntrack"
 	"github.com/stripe/smokescreen/pkg/smokescreen/metrics"
@@ -82,8 +83,8 @@ type Config struct {
 	// Custom handler to allow clients to modify reject responses
 	RejectResponseHandler func(*http.Response)
 
-	// Custom handler to allow clients to modify accept responses
-	AcceptResponseHandler func(*http.Response)
+	// Custom handler to allow clients to modify successful CONNECT responses
+	AcceptResponseHandler func(*goproxy.ProxyCtx, *http.Response) error
 
 	// UnsafeAllowPrivateRanges inverts the default behavior, telling smokescreen to allow private IP
 	// ranges by default (exempting loopback and unicast ranges)

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -560,6 +560,8 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 		return resp
 	})
 
+	// This function will be called on the response to a successful https CONNECT request.
+	// The goproxy OnResponse() function above is only called for non-https responses.
 	if config.AcceptResponseHandler != nil {
 		proxy.ConnectRespHandler = config.AcceptResponseHandler
 	}

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -546,7 +546,7 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 				resp.Header.Del(errorHeader)
 			}
 			if sctx.cfg.AcceptResponseHandler != nil {
-				sctx.cfg.AcceptResponseHandler(resp)
+				sctx.cfg.AcceptResponseHandler(pctx, resp)
 			}
 		}
 
@@ -559,6 +559,11 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 		logProxy(config, pctx)
 		return resp
 	})
+
+	if config.AcceptResponseHandler != nil {
+		proxy.ConnectRespHandler = config.AcceptResponseHandler
+	}
+
 	return proxy
 }
 

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -23,6 +23,7 @@ import (
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stripe/goproxy"
 	"github.com/stripe/smokescreen/pkg/smokescreen/conntrack"
 	"github.com/stripe/smokescreen/pkg/smokescreen/metrics"
 )
@@ -1073,8 +1074,9 @@ func TestAcceptResponseHandler(t *testing.T) {
 		cfg, err := testConfig("test-local-srv")
 
 		// set a custom AcceptResponseHandler that will set a header on every reject response
-		cfg.AcceptResponseHandler = func(resp *http.Response) {
+		cfg.AcceptResponseHandler = func(_ *goproxy.ProxyCtx, resp *http.Response) error {
 			resp.Header.Set(testHeader, "This header is added by the AcceptResponseHandler")
+			return nil
 		}
 		r.NoError(err)
 

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -23,7 +23,6 @@ import (
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stripe/goproxy"
 	"github.com/stripe/smokescreen/pkg/smokescreen/conntrack"
 	"github.com/stripe/smokescreen/pkg/smokescreen/metrics"
 )
@@ -1074,7 +1073,7 @@ func TestAcceptResponseHandler(t *testing.T) {
 		cfg, err := testConfig("test-local-srv")
 
 		// set a custom AcceptResponseHandler that will set a header on every reject response
-		cfg.AcceptResponseHandler = func(_ *goproxy.ProxyCtx, resp *http.Response) error {
+		cfg.AcceptResponseHandler = func(_ *smokescreenContext, resp *http.Response) error {
 			resp.Header.Set(testHeader, "This header is added by the AcceptResponseHandler")
 			return nil
 		}

--- a/vendor/github.com/stripe/goproxy/https.go
+++ b/vendor/github.com/stripe/goproxy/https.go
@@ -2,6 +2,7 @@ package goproxy
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -134,7 +135,18 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 		}
 
 		ctx.Logf("Accepting CONNECT to %s", host)
-		proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
+		respBytes, err := createCustomConnectResponse(ctx)
+		if respBytes != nil {
+			// Write the custom response, if one was created
+			proxyClient.Write(respBytes)
+		} else {
+			// Otherwise, log any errors and fallback to the default response
+			if err != nil {
+				ctx.Warnf("Error writing custom CONNECT response: %s", err.Error())
+				return
+			}
+			proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
+		}
 
 		if proxy.ConnectCopyHandler != nil {
 			go proxy.ConnectCopyHandler(ctx, proxyClient, targetSiteCon)
@@ -332,6 +344,22 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 		}
 		proxyClient.Close()
 	}
+}
+
+func createCustomConnectResponse(ctx *ProxyCtx) ([]byte, error) {
+	if ctx.proxy.ConnectRespHandler == nil {
+		return nil, nil
+	}
+	resp := &http.Response{Status: "200 OK", StatusCode: 200, Proto: "HTTP/1.0", Header: http.Header{}}
+	err := ctx.proxy.ConnectRespHandler(ctx, resp)
+	if err != nil {
+		return nil, err
+	}
+	buf := &bytes.Buffer{}
+	if err := resp.Write(buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 func httpError(w io.WriteCloser, ctx *ProxyCtx, err error) {

--- a/vendor/github.com/stripe/goproxy/proxy.go
+++ b/vendor/github.com/stripe/goproxy/proxy.go
@@ -50,6 +50,10 @@ type ProxyHttpServer struct {
 	// the hijacked proxy client net.Conn. This is useful for wrapping the connection
 	// to implement timeouts or additional tracing.
 	ConnectClientConnHandler func(net.Conn) net.Conn
+
+	// ConnectRespHandler allows users to mutate the response to the CONNECT request before it
+	// is returned to the client.
+	ConnectRespHandler func(ctx *ProxyCtx, resp *http.Response) error
 }
 
 var hasPort = regexp.MustCompile(`:\d+$`)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/sirupsen/logrus/hooks/test
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/stripe/goproxy v0.0.0-20220308202309-3f1dfba6d1a4
+# github.com/stripe/goproxy v0.0.0-20230801191332-fabc3ecb7251
 ## explicit; go 1.13
 github.com/stripe/goproxy
 # golang.org/x/mod v0.8.0


### PR DESCRIPTION
Wire up the AcceptResponseHandler to the new goproxy hook that was added in https://github.com/stripe/goproxy/pull/21

This does require changing the type of the AcceptResponseHandler to include a context field, but since this handler was only added to the config ~days ago this shouldn't be disruptive.

Smokescreen takes a function that uses a smokescreenContext and wraps it in a function that takes a goproxy.ProxyCtx before passing it to the underlying goproxy, so that we don't leak any goproxy interfaces in the smokescreen API (remain eternally hopeful that we'll strip out goproxy entirely someday...)

Writing a unit test would require the new go 1.20 [http.OnProxyConnectResponse](https://github.com/golang/go/issues/54299) to hook into the proxy connect response, and I don't think we're ready to upgrade smokescreen to go 1.20 yet, so the https logic here is not covered by unit tests.