### PR TITLE
Fix outbound IP logging

### DIFF
--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -17,7 +17,6 @@ const (
 	LogFieldDuration        = "duration"
 	LogFieldError           = "error"
 	LogFieldLastActivity    = "last_activity"
-	LogFieldOutboundAddr    = "outbound_remote_addr"
 	CanonicalProxyConnClose = "CANONICAL-PROXY-CN-CLOSE"
 )
 
@@ -114,11 +113,6 @@ func (ic *InstrumentedConn) Close() error {
 		errorMessage = ic.ConnError.Error()
 	}
 
-	var outboundAddr string
-	if ic.RemoteAddr() != nil {
-		outboundAddr = ic.RemoteAddr().String()
-	}
-
 	ic.logger.WithFields(logrus.Fields{
 		LogFieldBytesIn:      ic.BytesIn,
 		LogFieldBytesOut:     ic.BytesOut,
@@ -126,7 +120,6 @@ func (ic *InstrumentedConn) Close() error {
 		LogFieldDuration:     duration,
 		LogFieldError:        errorMessage,
 		LogFieldLastActivity: time.Unix(0, atomic.LoadInt64(ic.LastActivity)).UTC(),
-		LogFieldOutboundAddr: outboundAddr,
 	}).Info(CanonicalProxyConnClose)
 
 	ic.tracker.Wg().Done()

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -303,8 +303,6 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	sctx.cfg.ConnTracker.RecordAttempt(sctx.requestedHost, true)
 
 	if conn != nil {
-		fields := logrus.Fields{}
-
 		if addr := conn.LocalAddr(); addr != nil {
 			fields[LogFieldOutLocalAddr] = addr.String()
 		}
@@ -312,7 +310,6 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 		if addr := conn.RemoteAddr(); addr != nil {
 			fields[LogFieldOutRemoteAddr] = addr.String()
 		}
-
 	}
 	sctx.logger = sctx.logger.WithFields(fields)
 


### PR DESCRIPTION
I was staring at this chunk of code earlier trying to figure out how the outbound remote IP was logged, and realized there was actually a little coding error here. `fields` in `pkg/smokescreen/smokescreen.go` was in a closure, so it wasn't writing the fields, and now that it is, we can remove a bit of duplicate code in `pkg/smokescreen/conntrack/instrumented_conn.go`.

I deployed this change to our QA environment internally and verified that we still see `outbound_remote_addr` on connection close, as well as `outbound_local_addr`