### PR TITLE
Allow listen address specification for prometheus metrics

### DIFF
--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -94,6 +94,11 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			Value: "/metrics",
 			Usage: "Expose prometheus metrics on `ENDPOINT`. Requires --expose-prometheus-metrics to be set. Defaults to \"/metrics\"",
 		},
+    cli.StringFlag{
+      Name: "prometheus-listen-ip",
+      Value: "0.0.0.0",
+      Usage: "Listen for prometheus metrics on interface with address IP. Requires --expose-prometheus-metrics to be set. Defaults to \"0.0.0.0\"",
+    },
 		cli.StringFlag{
 			Name:  "prometheus-port",
 			Value: "9810",
@@ -244,7 +249,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 		}
 
 		if c.IsSet("expose-prometheus-metrics") {
-			if err := conf.SetupPrometheus(c.String("prometheus-endpoint"), c.String("prometheus-port")); err != nil {
+			if err := conf.SetupPrometheus(c.String("prometheus-endpoint"), c.String("prometheus-port"), c.String("prometheus-listen-ip")); err != nil {
 				return err
 			}
 		}

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -335,8 +335,8 @@ func (config *Config) SetupStatsd(addr string) error {
 	return config.SetupStatsdWithNamespace(addr, DefaultStatsdNamespace)
 }
 
-func (config *Config) SetupPrometheus(endpoint string, port string) error {
-	metricsClient, err := metrics.NewPrometheusMetricsClient(endpoint, port)
+func (config *Config) SetupPrometheus(endpoint string, port string, listenAddr string) error {
+	metricsClient, err := metrics.NewPrometheusMetricsClient(endpoint, port, listenAddr)
 	if err != nil {
 		return err
 	}

--- a/pkg/smokescreen/metrics/prometheus_metrics.go
+++ b/pkg/smokescreen/metrics/prometheus_metrics.go
@@ -24,9 +24,9 @@ type PrometheusMetricsClient struct {
 	timings    map[string]prometheus.HistogramVec
 }
 
-func NewPrometheusMetricsClient(endpoint string, port string) (*PrometheusMetricsClient, error) {
+func NewPrometheusMetricsClient(endpoint string, port string, listenAddr string) (*PrometheusMetricsClient, error) {
 	http.Handle(endpoint, promhttp.Handler())
-	go http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
+	go http.ListenAndServe(fmt.Sprintf("%s:%s", listenAddr, port), nil)
 
 	metricsTags := make(map[string]map[string]string)
 	for _, m := range metrics {


### PR DESCRIPTION
Hey! 

Stumbled upon a problem that smokescreen will expose prometheus metrics for all of the interfaces; there is no way to change listen address, so the only way to limit metrics access is by using iptables, which is not desireable in my situation.

Hence, this patch.