### PR TITLE
bump minimum Go version to 1.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ['1.19', '1.20']
+        go-version: ['1.20', '1.21']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Per our docs, we only support the most recent two versions of Go. This is currently 1.20 and 1.21.

r? @jjiang-stripe 