### PR TITLE
Configurable http and https proxy addrs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         go test -race -v -timeout 2m -failfast -covermode atomic -coverprofile=.covprofile ./... -tags=nointegration
         # Run integration tests hermetically to avoid nondeterministic races on environment variables
         go test -race -v -timeout 2m -failfast ./cmd/... -run TestSmokescreenIntegration
+        go test -race -v -timeout 2m -failfast ./cmd/... -run TestInvalidUpstreamProxyConfiguratedFromEnv
         go test -race -v -timeout 2m -failfast ./cmd/... -run TestInvalidUpstreamProxyConfiguration
         go test -race -v -timeout 2m -failfast ./cmd/... -run TestClientHalfCloseConnection
     - name: Install goveralls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 on: [push, pull_request]
 name: Test
+# Workaround for coveralls error "Can't add a job to a build that is already closed"
+# See https://github.com/lemurheavy/coveralls-public/issues/1716
+env:
+  COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}-${{ github.run_attempt }}
 jobs:
   test:
     strategy:

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -649,8 +649,8 @@ func startSmokescreen(t *testing.T, useTLS bool, logHook logrus.Hook, httpProxyA
 	}
 
 	if httpProxyAddr != ""{
-		args = append(args, "--transport-http-proxy-addr="+httpProxyAddr)
-		args = append(args, "--transport-https-proxy-addr="+httpProxyAddr)
+		args = append(args, fmt.Sprintf("--transport-http-proxy-addr=%s", httpProxyAddr))
+		args = append(args, fmt.Sprintf("--transport-https-proxy-addr=%s", httpProxyAddr))
 	}
 
 	conf, err := NewConfiguration(args, nil)

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -649,8 +649,8 @@ func startSmokescreen(t *testing.T, useTLS bool, logHook logrus.Hook, httpProxyA
 	}
 
 	if httpProxyAddr != ""{
-		args = append(args, fmt.Sprintf("--transport-http-proxy-addr=%s", httpProxyAddr))
-		args = append(args, fmt.Sprintf("--transport-https-proxy-addr=%s", httpProxyAddr))
+		args = append(args, fmt.Sprintf("--upstream-http-proxy-addr=%s", httpProxyAddr))
+		args = append(args, fmt.Sprintf("--upstream-https-proxy-addr=%s", httpProxyAddr))
 	}
 
 	conf, err := NewConfiguration(args, nil)

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -94,11 +94,11 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			Value: "/metrics",
 			Usage: "Expose prometheus metrics on `ENDPOINT`. Requires --expose-prometheus-metrics to be set. Defaults to \"/metrics\"",
 		},
-    cli.StringFlag{
-      Name: "prometheus-listen-ip",
-      Value: "0.0.0.0",
-      Usage: "Listen for prometheus metrics on interface with address IP. Requires --expose-prometheus-metrics to be set. Defaults to \"0.0.0.0\"",
-    },
+		cli.StringFlag{
+			Name: "prometheus-listen-ip",
+			Value: "0.0.0.0",
+			Usage: "Listen for prometheus metrics on interface with address IP. Requires --expose-prometheus-metrics to be set. Defaults to \"0.0.0.0\"",
+		},
 		cli.StringFlag{
 			Name:  "prometheus-port",
 			Value: "9810",
@@ -145,6 +145,16 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 		cli.BoolFlag{
 			Name:  "unsafe-allow-private-ranges",
 			Usage: "Allow private ip ranges by default",
+		},
+		cli.StringFlag{
+			Name:  "transport-http-proxy-addr",
+			Value: "",
+			Usage: "Set the smokescreen's HTTP transport proxy address",
+		},
+		cli.StringFlag{
+			Name:  "transport-https-proxy-addr",
+			Value: "",
+			Usage: "Set the smokescreen's HTTPS transport proxy address",
 		},
 	}
 
@@ -285,6 +295,14 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 				c.StringSlice("tls-client-ca-file")); err != nil {
 				return err
 			}
+		}
+
+		if c.IsSet("transport-http-proxy-addr") {
+			conf.TransportHttpProxyAddr = c.String("transport-http-proxy-addr")
+		}
+
+		if c.IsSet("transport-https-proxy-addr") {
+			conf.TransportHttpsProxyAddr = c.String("transport-https-proxy-addr")
 		}
 
 		// Setup the connection tracker if there is not yet one in the config

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -147,14 +147,14 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			Usage: "Allow private ip ranges by default",
 		},
 		cli.StringFlag{
-			Name:  "transport-http-proxy-addr",
+			Name:  "upstream-http-proxy-addr",
 			Value: "",
-			Usage: "Set the smokescreen's HTTP transport proxy address",
+			Usage: "Set Smokescreen's upstream HTTP proxy address",
 		},
 		cli.StringFlag{
-			Name:  "transport-https-proxy-addr",
+			Name:  "upstream-https-proxy-addr",
 			Value: "",
-			Usage: "Set the smokescreen's HTTPS transport proxy address",
+			Usage: "Set Smokescreen's upstream HTTPS proxy address",
 		},
 	}
 
@@ -297,12 +297,12 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			}
 		}
 
-		if c.IsSet("transport-http-proxy-addr") {
-			conf.TransportHttpProxyAddr = c.String("transport-http-proxy-addr")
+		if c.IsSet("upstream-http-proxy-addr") {
+			conf.UpstreamHttpProxyAddr = c.String("upstream-http-proxy-addr")
 		}
 
-		if c.IsSet("transport-https-proxy-addr") {
-			conf.TransportHttpsProxyAddr = c.String("transport-https-proxy-addr")
+		if c.IsSet("upstream-https-proxy-addr") {
+			conf.UpstreamHttpsProxyAddr = c.String("upstream-https-proxy-addr")
 		}
 
 		// Setup the connection tracker if there is not yet one in the config

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
-	github.com/stripe/goproxy v0.0.0-20230801191332-fabc3ecb7251
+	github.com/stripe/goproxy v0.0.0-20231113215313-dbbdf2f6d709
 	golang.org/x/net v0.17.0
 	gopkg.in/urfave/cli.v1 v1.20.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stripe/goproxy v0.0.0-20230801191332-fabc3ecb7251 h1:wR1exp7OglR0ctk8yWPVp1oTOuyaLUlJv3/Wlbvbw64=
 github.com/stripe/goproxy v0.0.0-20230801191332-fabc3ecb7251/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20231113215313-dbbdf2f6d709 h1:b0AttHAJ5f9rIK2frq9Q4WEeeBNQccr1j+cjQCmOl6s=
+github.com/stripe/goproxy v0.0.0-20231113215313-dbbdf2f6d709/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -73,6 +73,10 @@ type Config struct {
 	TransportMaxIdleConns        int
 	TransportMaxIdleConnsPerHost int
 
+	// There are the http and https address for the transport proxy
+	TransportHttpProxyAddr  string
+	TransportHttpsProxyAddr string
+
 	// Used for logging connection time
 	TimeConnect bool
 

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -73,9 +73,9 @@ type Config struct {
 	TransportMaxIdleConns        int
 	TransportMaxIdleConnsPerHost int
 
-	// There are the http and https address for the transport proxy
-	TransportHttpProxyAddr  string
-	TransportHttpsProxyAddr string
+	// These are the http and https address for the upstream proxy 
+	UpstreamHttpProxyAddr  string
+	UpstreamHttpsProxyAddr string
 
 	// Used for logging connection time
 	TimeConnect bool

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -433,7 +433,7 @@ func newContext(cfg *Config, proxyType string, req *http.Request) *SmokescreenCo
 }
 
 func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
-	proxy := goproxy.NewProxyHttpServer()
+	proxy := goproxy.NewProxyHttpServer(goproxy.WithHttpProxyAddr(config.TransportHttpProxyAddr), goproxy.WithHttpsProxyAddr(config.TransportHttpsProxyAddr))
 	proxy.Verbose = false
 	configureTransport(proxy.Tr, config)
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -433,7 +433,7 @@ func newContext(cfg *Config, proxyType string, req *http.Request) *SmokescreenCo
 }
 
 func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
-	proxy := goproxy.NewProxyHttpServer(goproxy.WithHttpProxyAddr(config.TransportHttpProxyAddr), goproxy.WithHttpsProxyAddr(config.TransportHttpsProxyAddr))
+	proxy := goproxy.NewProxyHttpServer(goproxy.WithHttpProxyAddr(config.UpstreamHttpProxyAddr), goproxy.WithHttpsProxyAddr(config.UpstreamHttpsProxyAddr))
 	proxy.Verbose = false
 	configureTransport(proxy.Tr, config)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/sirupsen/logrus/hooks/test
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/stripe/goproxy v0.0.0-20230801191332-fabc3ecb7251
+# github.com/stripe/goproxy v0.0.0-20231113215313-dbbdf2f6d709
 ## explicit; go 1.13
 github.com/stripe/goproxy
 # golang.org/x/mod v0.8.0


### PR DESCRIPTION
### Summary
Update the stripe/goproxy dependency to include https://github.com/stripe/goproxy/pull/22. Allow setting the httpProxyAddr and httpsProxyAddr directly in smokescreen's configuration. When the TransportHttpProxyAddr and TransportHttpsProxyAddr in the smokescreen configuration is non-empty, use these proxy address to create the `NewProxyHttpServer` for smokescreen. If these addresses are not set, use the default values from environment. 

### Motivation
stripe/smokescreen uses this library for the proxy server. Currently, the only way to set the transport proxy for smokescreen are [setting the proxy from environment](https://github.com/stripe/goproxy/blob/master/proxy.go#L192), which requires us to set the environment variables like HTTP_PROXY, HTTPS_PROXY. We would like to have a more robust way of configuring the smokescreen server's transport proxy. Thus we are adding the transport proxy address as another configurations for the smokescreen server and the goproxy library it uses underneath.

### Test plan
- [x] New and existing unit tests
- [x] Vendored the smokescreen change in stripe-internal repo and tested the services that depends on it in QA