### PR TITLE
Pulled in new goproxy changes for HTTPS Proxying

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
-	github.com/stripe/goproxy v0.0.0-20231113215313-dbbdf2f6d709
+	github.com/stripe/goproxy v0.0.0-20231206175114-560c3ba6a2a1
 	golang.org/x/net v0.17.0
 	gopkg.in/urfave/cli.v1 v1.20.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/stripe/goproxy v0.0.0-20230801191332-fabc3ecb7251 h1:wR1exp7OglR0ctk8
 github.com/stripe/goproxy v0.0.0-20230801191332-fabc3ecb7251/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/stripe/goproxy v0.0.0-20231113215313-dbbdf2f6d709 h1:b0AttHAJ5f9rIK2frq9Q4WEeeBNQccr1j+cjQCmOl6s=
 github.com/stripe/goproxy v0.0.0-20231113215313-dbbdf2f6d709/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20231206175114-560c3ba6a2a1 h1:kA8wVCrTI7UE2Z8oj24W75/J+IUA/fFn8vYYXs/sJeE=
+github.com/stripe/goproxy v0.0.0-20231206175114-560c3ba6a2a1/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/smokescreen/acl/v1/yaml_loader.go
+++ b/pkg/smokescreen/acl/v1/yaml_loader.go
@@ -17,6 +17,7 @@ func NewYAMLLoader(path string) *YAMLLoader {
 	return &YAMLLoader{path}
 }
 
+// TODO: modify these to accomodate the new config??
 type YAMLConfig struct {
 	Services        []YAMLRule `yaml:"services"`
 	Default         *YAMLRule  `yaml:"default"`
@@ -26,10 +27,11 @@ type YAMLConfig struct {
 }
 
 type YAMLRule struct {
-	Name         string   `yaml:"name"`
-	Project      string   `yaml:"project"` // owner
-	Action       string   `yaml:"action"`
-	AllowedHosts []string `yaml:"allowed_domains"`
+	Name                      string   `yaml:"name"`
+	Project                   string   `yaml:"project"` // owner
+	Action                    string   `yaml:"action"`
+	AllowedHosts              []string `yaml:"allowed_domains"`
+	AllowedExternalProxyHosts []string `yaml:"allowed_external_proxies"`
 }
 
 func (yc *YAMLConfig) ValidateConfig() error {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -508,6 +508,7 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 	})
 
 	// Handle CONNECT proxy to TLS & other TCP protocols destination
+	// TODO: this is the function that wshould be modified to accomodate the new config
 	proxy.OnRequest().HandleConnectFunc(func(_ string, pctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
 		pctx.UserData = newContext(config, connectProxy, pctx.Req)
 		pctx.HTTPErrorHandler = HTTPErrorHandler
@@ -644,6 +645,7 @@ func handleConnect(config *Config, pctx *goproxy.ProxyCtx) (string, error) {
 
 	// checkIfRequestShouldBeProxied can return an error if either the resolved address is disallowed,
 	// or if there is a DNS resolution failure.
+	// TODO: add support here for checkIfRequestShouldBeProxied to return an error if the X-Https-Proxy address is set and disallowed
 	sctx.Decision, sctx.lookupTime, pctx.Error = checkIfRequestShouldBeProxied(config, pctx.Req, destination)
 	if pctx.Error != nil {
 		// DNS resolution failure

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/sirupsen/logrus/hooks/test
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/stripe/goproxy v0.0.0-20231113215313-dbbdf2f6d709
+# github.com/stripe/goproxy v0.0.0-20231206175114-560c3ba6a2a1
 ## explicit; go 1.13
 github.com/stripe/goproxy
 # golang.org/x/mod v0.8.0


### PR DESCRIPTION
Just updating smokescreen's `goproxy` dependency to pull in some new changes that I made in a PR [here](https://github.com/stripe/goproxy/pull/23). 