### PR TITLE
Add support for username / password auth in URLs to external CONNECT proxies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
-	github.com/stripe/goproxy v0.0.0-20231206175114-560c3ba6a2a1
+	github.com/stripe/goproxy v0.0.0-20240702223215-529f11a6f861
 	golang.org/x/net v0.17.0
 	gopkg.in/urfave/cli.v1 v1.20.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
-	github.com/stripe/goproxy v0.0.0-20240702232545-72d7dbc6d4fe
+	github.com/stripe/goproxy v0.0.0-20240711170433-75b93c00dfb0
 	golang.org/x/net v0.17.0
 	gopkg.in/urfave/cli.v1 v1.20.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
-	github.com/stripe/goproxy v0.0.0-20240702223215-529f11a6f861
+	github.com/stripe/goproxy v0.0.0-20240702232545-72d7dbc6d4fe
 	golang.org/x/net v0.17.0
 	gopkg.in/urfave/cli.v1 v1.20.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stripe/goproxy v0.0.0-20231206175114-560c3ba6a2a1 h1:kA8wVCrTI7UE2Z8oj24W75/J+IUA/fFn8vYYXs/sJeE=
 github.com/stripe/goproxy v0.0.0-20231206175114-560c3ba6a2a1/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20240702223215-529f11a6f861 h1:dlR0X8/38L9ip1ydDazfTRyPe0iW6cepmIcaygH2r5Q=
+github.com/stripe/goproxy v0.0.0-20240702223215-529f11a6f861/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/stripe/goproxy v0.0.0-20240702223215-529f11a6f861 h1:dlR0X8/38L9ip1yd
 github.com/stripe/goproxy v0.0.0-20240702223215-529f11a6f861/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/stripe/goproxy v0.0.0-20240702232545-72d7dbc6d4fe h1:RzjmXDVOjWq9sPRc/rn6a9g1N3C+q9LzP8pI7aPEzPQ=
 github.com/stripe/goproxy v0.0.0-20240702232545-72d7dbc6d4fe/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20240711170433-75b93c00dfb0 h1:1xKgjoLWAosf0yoKocNN4mel1++AKqJw9axpJyz1JRw=
+github.com/stripe/goproxy v0.0.0-20240711170433-75b93c00dfb0/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/stripe/goproxy v0.0.0-20231206175114-560c3ba6a2a1 h1:kA8wVCrTI7UE2Z8o
 github.com/stripe/goproxy v0.0.0-20231206175114-560c3ba6a2a1/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/stripe/goproxy v0.0.0-20240702223215-529f11a6f861 h1:dlR0X8/38L9ip1ydDazfTRyPe0iW6cepmIcaygH2r5Q=
 github.com/stripe/goproxy v0.0.0-20240702223215-529f11a6f861/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20240702232545-72d7dbc6d4fe h1:RzjmXDVOjWq9sPRc/rn6a9g1N3C+q9LzP8pI7aPEzPQ=
+github.com/stripe/goproxy v0.0.0-20240702232545-72d7dbc6d4fe/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/smokescreen/acl/v1/acl.go
+++ b/pkg/smokescreen/acl/v1/acl.go
@@ -101,7 +101,9 @@ func (acl *ACL) Decide(service, host, connectProxyHost string) (Decision, error)
 
 	if connectProxyHost != "" {
 		shouldDeny := true
+		acl.Logger.Log(logrus.InfoLevel, rule.ExternalProxyGlobs, ": ", connectProxyHost)
 		for _, dg := range rule.ExternalProxyGlobs {
+			acl.Logger.Log(logrus.InfoLevel, dg, " _____ ", connectProxyHost)
 			if HostMatchesGlob(connectProxyHost, dg) {
 				shouldDeny = false
 				break
@@ -113,7 +115,7 @@ func (acl *ACL) Decide(service, host, connectProxyHost string) (Decision, error)
 		// continue to check it below (unless we know we should deny it already)
 		if shouldDeny {
 			d.Result = Deny
-			d.Reason = "connect proxy host not allowed in rule"
+			d.Reason = "connect pBAJKLSroxy host not allowed in rule"
 			return d, nil
 		}
 	}

--- a/pkg/smokescreen/acl/v1/acl.go
+++ b/pkg/smokescreen/acl/v1/acl.go
@@ -101,9 +101,7 @@ func (acl *ACL) Decide(service, host, connectProxyHost string) (Decision, error)
 
 	if connectProxyHost != "" {
 		shouldDeny := true
-		acl.Logger.Log(logrus.InfoLevel, rule.ExternalProxyGlobs, ": ", connectProxyHost)
 		for _, dg := range rule.ExternalProxyGlobs {
-			acl.Logger.Log(logrus.InfoLevel, dg, " _____ ", connectProxyHost)
 			if HostMatchesGlob(connectProxyHost, dg) {
 				shouldDeny = false
 				break
@@ -115,7 +113,7 @@ func (acl *ACL) Decide(service, host, connectProxyHost string) (Decision, error)
 		// continue to check it below (unless we know we should deny it already)
 		if shouldDeny {
 			d.Result = Deny
-			d.Reason = "connect pBAJKLSroxy host not allowed in rule"
+			d.Reason = "connect proxy host not allowed in rule"
 			return d, nil
 		}
 	}

--- a/pkg/smokescreen/acl/v1/yaml_loader.go
+++ b/pkg/smokescreen/acl/v1/yaml_loader.go
@@ -98,9 +98,10 @@ func (cfg *YAMLConfig) Load() (*ACL, error) {
 		}
 
 		acl.DefaultRule = &Rule{
-			Project:     cfg.Default.Project,
-			Policy:      p,
-			DomainGlobs: cfg.Default.AllowedHosts,
+			Project:            cfg.Default.Project,
+			Policy:             p,
+			DomainGlobs:        cfg.Default.AllowedHosts,
+			ExternalProxyGlobs: cfg.Default.AllowedExternalProxyHosts,
 		}
 	}
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -941,9 +941,12 @@ func checkACLsForRequest(config *Config, req *http.Request, destination hostport
 
 	if err != nil {
 		config.Log.WithFields(logrus.Fields{
-			"error": err,
-			"role":  role,
-		}).Warn("Unable to parse X-Upstream-Https-Proxy header.")
+			"error":               err,
+			"role":                role,
+			"upstream_proxy_name": req.Header.Get("X-Upstream-Https-Proxy"),
+			"destination_host":    destination.Host,
+			"kind":                "parse_failure",
+		}).Error("Unable to parse X-Upstream-Https-Proxy header.")
 
 		config.MetricsClient.Incr("acl.upstream_proxy_error", 1)
 		return decision

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -945,7 +945,7 @@ func checkACLsForRequest(config *Config, req *http.Request, destination hostport
 			"role":  role,
 		}).Warn("Unable to parse X-Upstream-Https-Proxy header.")
 
-		config.MetricsClient.Incr("acl.decide_error", 1)
+		config.MetricsClient.Incr("acl.upstream_proxy_error", 1)
 		return decision
 	}
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -348,10 +348,6 @@ func rejectResponse(pctx *goproxy.ProxyCtx, err error) *http.Response {
 	var msg, status string
 	var code int
 
-	fmt.Println("**********")
-	fmt.Println(pctx.Resp)
-	fmt.Println(err)
-	fmt.Println("**********")
 	if e, ok := err.(net.Error); ok {
 		// net.Dial timeout
 		if e.Timeout() {
@@ -524,8 +520,6 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 			pctx.Resp = rejectResponse(pctx, err)
 			return goproxy.RejectConnect, ""
 		}
-		fmt.Println("-----MADE IT HERE--------------")
-
 		return goproxy.OkConnect, destination
 	})
 
@@ -553,9 +547,6 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 				sctx.cfg.AcceptResponseHandler(sctx, resp)
 			}
 		}
-		fmt.Println("-----------------------------")
-		fmt.Println(pctx.Error)
-		fmt.Println("-----------------------------")
 
 		if resp == nil && pctx.Error != nil {
 			return rejectResponse(pctx, pctx.Error)
@@ -951,13 +942,6 @@ func checkACLsForRequest(config *Config, req *http.Request, destination hostport
 	if connectProxyHost != "" {
 		connectProxyUrl, err := url.Parse(connectProxyHost)
 
-		config.Log.WithFields(logrus.Fields{
-			"headers":             req.Header,
-			"upstream_proxy_name": req.Header.Get("X-Upstream-Https-Proxy"),
-			"destination_host":    destination.Host,
-			"proxy_host":          connectProxyUrl.Hostname(),
-		}).Info("Info about the headers and destination host.")
-
 		if err != nil {
 			config.Log.WithFields(logrus.Fields{
 				"error":               err,
@@ -973,9 +957,6 @@ func checkACLsForRequest(config *Config, req *http.Request, destination hostport
 
 		connectProxyHost = connectProxyUrl.Hostname()
 	}
-
-	// TODO: add proxy auth params fi if the decision is to allow the request
-	// this will likely mean modifying the config struct
 
 	ACLDecision, err := config.EgressACL.Decide(role, destination.Host, connectProxyHost)
 	decision.project = ACLDecision.Project

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -951,7 +951,7 @@ func checkACLsForRequest(config *Config, req *http.Request, destination hostport
 				"kind":                "parse_failure",
 			}).Error("Unable to parse X-Upstream-Https-Proxy header.")
 
-			config.MetricsClient.Incr("acl.upstream_proxy_error", 1)
+			config.MetricsClient.Incr("acl.upstream_proxy_parse_error", 1)
 			return decision
 		}
 

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -1292,7 +1292,12 @@ func TestCONNECTProxyACLs(t *testing.T) {
 		externalProxy.StartTLS()
 
 		remote := httptest.NewTLSServer(h)
-		client, err := proxyClientWithConnectHeaders(proxy.URL, http.Header{"X-Upstream-Https-Proxy": []string{"myproxy.com"}})
+		client, err := proxyClientWithConnectHeaders(
+			proxy.URL,
+			http.Header{
+				"X-Upstream-Https-Proxy": []string{"https://param1_username-param2-param3:password@myproxy.com:12345"},
+			},
+		)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)

--- a/vendor/github.com/stripe/goproxy/https.go
+++ b/vendor/github.com/stripe/goproxy/https.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -133,7 +134,9 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 		if httpsProxy == "" {
 			targetSiteCon, err = proxy.connectDialContext(ctx, "tcp", host)
 		} else {
-			targetSiteCon, err = proxy.connectDialProxyWithContext(ctx, httpsProxy, host)
+			// parsedProxyURL, _ := url.Parse(httpsProxyURL)
+			// runtime.Breakpoint()
+			targetSiteCon, err = proxy.connectDialProxyWithContext(ctx, httpsProxyURL, host)
 		}
 		if err != nil {
 			httpError(proxyClient, ctx, err)
@@ -460,6 +463,9 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 			}
 			defer resp.Body.Close()
 			if resp.StatusCode != 200 {
+				fmt.Println("1//////////")
+				fmt.Println(resp.StatusCode)
+				fmt.Println("//////////")
 				resp, err := ioutil.ReadAll(io.LimitReader(resp.Body, 500))
 				if err != nil {
 					return nil, err
@@ -501,6 +507,9 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 			}
 			defer resp.Body.Close()
 			if resp.StatusCode != 200 {
+				fmt.Println("2//////////")
+				fmt.Println(resp.StatusCode)
+				fmt.Println("//////////")
 				body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 500))
 				if err != nil {
 					return nil, err
@@ -543,11 +552,15 @@ func (proxy *ProxyHttpServer) connectDialProxyWithContext(ctx *ProxyCtx, proxyHo
 		c = tls.Client(c, proxy.Tr.TLSClientConfig)
 	}
 
+	// possibly need to add the proxy auth header here
+	hdr := make(http.Header)
+	auth := proxyURL.User.String()
+	hdr.Add("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(auth)))
 	connectReq := &http.Request{
 		Method: "CONNECT",
 		URL:    &url.URL{Opaque: host},
 		Host:   host,
-		Header: make(http.Header),
+		Header: hdr,
 	}
 	connectReq.Write(c)
 	// Read response.
@@ -561,6 +574,10 @@ func (proxy *ProxyHttpServer) connectDialProxyWithContext(ctx *ProxyCtx, proxyHo
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
+		fmt.Println("3//////////")
+		fmt.Println(resp.StatusCode)
+		fmt.Println(resp.Header)
+		fmt.Println("//////////")
 		body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 500))
 		if err != nil {
 			return nil, err
@@ -593,6 +610,7 @@ func httpsProxyAddr(reqURL *url.URL, httpsProxy string) (string, error) {
 	reqSchemeURL.Scheme = "https"
 
 	proxyURL, err := cfg.ProxyFunc()(reqSchemeURL)
+	// runtime.Breakpoint()
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/stripe/goproxy/https.go
+++ b/vendor/github.com/stripe/goproxy/https.go
@@ -544,19 +544,21 @@ func (proxy *ProxyHttpServer) connectDialProxyWithContext(ctx *ProxyCtx, proxyHo
 		c = tls.Client(c, proxy.Tr.TLSClientConfig)
 	}
 
-	hdr := make(http.Header)
+	connectRequestHeaders := make(http.Header)
 
-	// Add proxy authentication header if needed
-	auth := proxyURL.User.String()
-	if auth != "" {
-		hdr.Add("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(auth)))
+	// Add authentication header if needed to the CONNECT request to the proxy
+	user := proxyURL.User
+	if user != nil {
+		if auth := user.String(); auth != "" {
+			connectRequestHeaders.Add("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(auth)))
+		}
 	}
 
 	connectReq := &http.Request{
 		Method: "CONNECT",
 		URL:    &url.URL{Opaque: host},
 		Host:   host,
-		Header: hdr,
+		Header: connectRequestHeaders,
 	}
 	connectReq.Write(c)
 	// Read response.
@@ -615,7 +617,7 @@ func httpsProxyAddr(reqURL *url.URL, httpsProxy string) (string, error) {
 	}
 
 	hostname := proxyURL.Hostname()
-	if proxyURL.User.String() != "" {
+	if proxyURL.User != nil && proxyURL.User.String() != "" {
 		hostname = proxyURL.User.String() + "@" + hostname
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/sirupsen/logrus/hooks/test
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/stripe/goproxy v0.0.0-20240702232545-72d7dbc6d4fe
+# github.com/stripe/goproxy v0.0.0-20240711170433-75b93c00dfb0
 ## explicit; go 1.13
 github.com/stripe/goproxy
 # golang.org/x/mod v0.8.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/sirupsen/logrus/hooks/test
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/stripe/goproxy v0.0.0-20240702223215-529f11a6f861
+# github.com/stripe/goproxy v0.0.0-20240702232545-72d7dbc6d4fe
 ## explicit; go 1.13
 github.com/stripe/goproxy
 # golang.org/x/mod v0.8.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/sirupsen/logrus/hooks/test
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/stripe/goproxy v0.0.0-20231206175114-560c3ba6a2a1
+# github.com/stripe/goproxy v0.0.0-20240702223215-529f11a6f861
 ## explicit; go 1.13
 github.com/stripe/goproxy
 # golang.org/x/mod v0.8.0


### PR DESCRIPTION
### Summary
Pulled in goproxy changes with:
```
go get github.com/stripe/goproxy
go mod vendor
```

One note - subdomains are still denied if not explicitly allowed on the ACL! So 
```
https://param1_username-param2-param3:password@myproxy.com:12345
```
may be allowed while:
```
https://param1_username-param2-param3:password@subdomain.myproxy.com:12345
```
### Testing
Tested with:
```
cd pkg/smokescreen
go test -v -run ^TestCONNECTProxyACLs/Allows_an_approved_proxy_when_the_X-Upstream-Https-Proxy_header_is_set$
```

Manually tested as in below! 

<img width="1126" alt="Screenshot 2024-06-26 at 4 02 37 PM" src="https://github.com/stripe/smokescreen/assets/40726826/0fd06506-2abd-497f-bedd-8b77cda00679">
