### PR TITLE
Ensure proxy passed in X-Upstream-Https-Proxy is parsable

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -941,6 +941,9 @@ func checkACLsForRequest(config *Config, req *http.Request, destination hostport
 
 	if connectProxyHost != "" {
 		connectProxyUrl, err := url.Parse(connectProxyHost)
+		if err == nil && connectProxyUrl.Hostname() == "" {
+			err = errors.New("proxy header contains invalid URL. The correct format is https://[username:password@]my.proxy.srv:12345")
+		}
 
 		if err != nil {
 			config.Log.WithFields(logrus.Fields{


### PR DESCRIPTION
## Description
Ensure that the https proxy passed in `X-Upstream-Https-Proxy` can be parsed before proceeding.

## Testing Details
```
curl --proxy-header "X-Upstream-Https-Proxy: google.com:443" --proxytunnel -x localhost:4750 https://example3.com
```

Logs:
```
{"destination_host":"example3.com","error":"proxy header contains invalid URL. The correct format is https://[username:password@]my.proxy.srv:12345","kind":"parse_failure","level":"error","msg":"Unable to parse X-Upstream-Https-Proxy header.","role":"","time":"2024-09-05T01:57:45+05:30","upstream_proxy_name":"google.com:443"}
```