### PR TITLE
Add MITM support to smokescreen

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "smokescreen",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "./",
+            "args": ["--config-file", "config.yaml", "--egress-acl-file", "acl.yaml"]
+        }
+    ]
+}

--- a/Development.md
+++ b/Development.md
@@ -229,8 +229,9 @@ default:
   name: default
   project: security
   action: enforce
-  allowed_domains: []
-  allowed_domains_mitm:
+  allowed_domains:
+    - wttr.in
+  mitm_domains:
   - domain: wttr.in
     add_headers:
       Accept-Language: el
@@ -278,8 +279,9 @@ services:
   - name: localhost
     project: github
     action: enforce
-    allowed_domains: []
-    allowed_domains_mitm:
+    allowed_domains:
+      - wttr.in
+    mitm_domains:
       - domain: wttr.in
         add_headers:
           Accept-Language: el

--- a/Development.md
+++ b/Development.md
@@ -1,0 +1,306 @@
+
+# Development and Testing
+
+## Testing
+```bash
+go test ./...
+```
+
+## Running locally
+
+This section describes how to run Smokescreen locally with different scenarios and using `curl` as a client.
+
+- [HTTP Proxy](#http-proxy)
+- [HTTP CONNECT Proxy](#http-connect-proxy)
+- [Monitor metrics Smokescreen emits](#monitor-metrics-smokescreen-emits)
+- [HTTP CONNECT Proxy over TLS](#http-connect-proxy-over-tls)
+- [MITM (Man in the middle) Proxy](#mitm-man-in-the-middle-proxy)
+- [MITM (Man in the middle) Proxy over TLS](#mitm-man-in-the-middle-proxy-over-tls)
+
+### HTTP Proxy
+
+#### Configurations
+
+```yaml
+# config.yaml
+---
+allow_missing_role: true  # skip mTLS client validation (use default ACL)
+```
+
+```yaml
+# acl.yaml
+---
+version: v1
+services: []
+default:
+  name: default
+  project: security
+  action: enforce
+  allowed_domains: 
+    - example.com
+```
+
+#### Run
+
+```bash
+# Run smokescreen (in a different shell)
+go run . --config-file config.yaml --egress-acl-file acl.yaml
+
+# Curl
+curl -x localhost:4750 http://example.com
+# Curl with ALL_PROXY
+ALL_PROXY=localhost:4750 curl -v http://example.com
+```
+
+### HTTP CONNECT Proxy
+
+#### Configurations
+
+```yaml
+# config.yaml
+---
+allow_missing_role: true  # skip mTLS client validation (use default ACL)
+```
+
+```yaml
+# acl.yaml
+---
+version: v1
+services: []
+default:
+  name: default
+  project: security
+  action: enforce
+  allowed_domains: 
+    - api.github.com
+```
+
+#### Run
+
+```bash
+# Run smokescreen (in a different shell)
+go run . --config-file config.yaml --egress-acl-file acl.yaml
+
+# Curl
+curl --proxytunnel -x localhost:4750 https://api.github.com/zen
+# Curl with HTTPS_PROXY
+HTTPS_PROXY=localhost:4750 curl https://api.github.com/zen
+```
+
+### Monitor metrics Smokescreen emits
+
+#### Configurations
+
+```yaml
+# config.yaml
+---
+allow_missing_role: true  # skip mTLS client validation (use default ACL)
+statsd_address: 127.0.0.1:8200
+```
+
+```yaml
+# acl.yaml
+---
+version: v1
+services: []
+default:
+  name: default
+  project: security
+  action: enforce
+  allowed_domains: 
+    - api.github.com
+```
+
+#### Run
+
+```bash
+# Listen to a local port with nc (in a different shell)
+nc -uklv 127.0.0.1 8200
+
+# Run smokescreen (in a different shell)
+go run . --config-file config.yaml --egress-acl-file acl.yaml
+
+# Curl
+curl --proxytunnel -x localhost:4750 https://api.github.com/zen
+# Curl with HTTPS_PROXY
+HTTPS_PROXY=localhost:4750 curl https://api.github.com/zen
+```
+
+### HTTP CONNECT Proxy over TLS
+
+#### Set-up
+
+##### Generate certificates
+```bash
+mkdir -p mtls_setup
+# Private keys for CAs
+openssl genrsa -out mtls_setup/server-ca.key 2048
+openssl genrsa -out mtls_setup/client-ca.key 2048
+
+# Generate client and server CA certificates
+openssl req -new -x509 -nodes -days 1000 -key mtls_setup/server-ca.key -out mtls_setup/server-ca.crt \
+    -subj "/C=AQ/ST=Petrel Island/L=Dumont-d'Urville
+/O=Penguin/OU=Publishing house/CN=server CA"
+    
+openssl req -new -x509 -nodes -days 1000 -key mtls_setup/client-ca.key -out mtls_setup/client-ca.crt \
+    -subj "/C=MA/ST=Tarfaya/L=Tarfaya/O=Fennec/OU=Aviator/CN=Client CA"
+
+# Generate a certificate signing request (client CN is localhost which is used by smokescreen as the service name by default)
+openssl req -newkey rsa:2048 -nodes -keyout mtls_setup/server.key -out mtls_setup/server.req \
+    -subj "/C=AQ/ST=Petrel Island/L=Dumont-d'Urville/O=Chionis/OU=Publishing house/CN=server req"
+openssl req -newkey rsa:2048 -nodes -keyout mtls_setup/client.key -out mtls_setup/client.req \
+    -subj "/C=MA/ST=Tarfaya/L=Tarfaya/O=Addax/OU=Writer/CN=localhost"
+
+# Have the CA sign the certificate requests and output the certificates.
+echo "authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+" > mtls_setup/localhost.ext
+
+openssl x509 -req -in mtls_setup/server.req -days 1000 -CA mtls_setup/server-ca.crt -CAkey mtls_setup/server-ca.key -set_serial 01 -out mtls_setup/server.crt -extfile mtls_setup/localhost.ext
+
+openssl x509 -req -in mtls_setup/client.req -days 1000 -CA mtls_setup/client-ca.crt -CAkey mtls_setup/client-ca.key -set_serial 01 -out mtls_setup/client.crt
+```
+
+##### Configurations
+
+```yaml
+# config.yaml
+---
+tls:
+  cert_file: "mtls_setup/server.crt"
+  key_file: "mtls_setup/server.key"
+  client_ca_files:
+    - "mtls_setup/client-ca.crt"
+```
+
+```yaml
+# acl.yaml
+---
+version: v1
+services:
+  - name: localhost
+    project: github
+    action: enforce
+    allowed_domains:
+      - api.github.com
+default:
+  name: default
+  project: security
+  action: enforce
+  allowed_domains: []
+```
+
+#### Run
+
+```bash
+# Run smokescreen (in a different shell)
+go run . --config-file config.yaml --egress-acl-file acl.yaml
+
+# Curl
+curl --proxytunnel -x https://localhost:4750 --proxy-cacert mtls_setup/server-ca.crt --proxy-cert mtls_setup/client.crt --proxy-key mtls_setup/client.key https://api.github.com/zen
+# Curl with HTTPS_PROXY
+HTTPS_PROXY=https://localhost:4750 curl --proxy-cacert mtls_setup/server-ca.crt --proxy-cert mtls_setup/client.crt --proxy-key mtls_setup/client.key https://api.github.com/zen
+```
+
+### MITM (Man in the middle) Proxy
+
+#### Set-up
+
+```yaml
+# config.yaml
+---
+allow_missing_role: true  # skip mTLS client validation (use default ACL)
+# Re-using goproxy library CA and key
+mitm_ca_cert_file: "vendor/github.com/stripe/goproxy/ca.pem"
+mitm_ca_key_file: "vendor/github.com/stripe/goproxy/key.pem"
+```
+
+```yaml
+# acl.yaml
+---
+version: v1
+services: []
+default:
+  name: default
+  project: security
+  action: enforce
+  allowed_domains: []
+  allowed_domains_mitm:
+  - domain: wttr.in
+    add_headers:
+      Accept-Language: el
+    detailed_http_logs: true
+    detailed_http_logs_full_headers:
+      - User-Agent
+```
+
+#### Run
+
+```bash
+# Run smokescreen (in a different shell)
+go run . --config-file config.yaml --egress-acl-file acl.yaml
+
+# Curl (weather should be in Greek since we set the Accept-Language header)
+curl --proxytunnel -x localhost:4750 --cacert vendor/github.com/stripe/goproxy/ca.pem https://wttr.in
+# Curl with HTTPS_PROXY
+HTTPS_PROXY=localhost:4750 curl --cacert vendor/github.com/stripe/goproxy/ca.pem https://wttr.in
+```
+
+### MITM (Man in the middle) Proxy over TLS
+
+#### Set-up
+
+Please generate the certificates from the TLS Generate certificates section.
+
+```yaml
+# config.yaml
+---
+tls:
+  cert_file: "mtls_setup/server.crt"
+  key_file: "mtls_setup/server.key"
+  client_ca_files:
+    - "mtls_setup/client-ca.crt"
+# Re-using goproxy library CA and key
+mitm_ca_cert_file: "vendor/github.com/stripe/goproxy/ca.pem"
+mitm_ca_key_file: "vendor/github.com/stripe/goproxy/key.pem"
+```
+
+```yaml
+# acl.yaml
+---
+version: v1
+services:
+  - name: localhost
+    project: github
+    action: enforce
+    allowed_domains: []
+    allowed_domains_mitm:
+      - domain: wttr.in
+        add_headers:
+          Accept-Language: el
+        detailed_http_logs: true
+        detailed_http_logs_full_headers:
+          - User-Agent
+default:
+  name: default
+  project: security
+  action: enforce
+  allowed_domains: []
+```
+
+#### Run
+
+```bash
+# Run smokescreen (in a different shell)
+go run . --config-file config.yaml --egress-acl-file acl.yaml
+
+# Curl (weather should be in Greek since we set the Accept-Language header)
+curl --proxytunnel -x https://localhost:4750 --cacert vendor/github.com/stripe/goproxy/ca.pem --proxy-cacert mtls_setup/server-ca.crt --proxy-cert mtls_setup/client.crt --proxy-key mtls_setup/client.key https://wttr.in
+# Curl with HTTPS_PROXY
+HTTPS_PROXY=https://localhost:4750 curl --cacert vendor/github.com/stripe/goproxy/ca.pem --proxy-cacert mtls_setup/server-ca.crt --proxy-cert mtls_setup/client.crt --proxy-key mtls_setup/client.key https://wttr.in
+```

--- a/README.md
+++ b/README.md
@@ -171,41 +171,7 @@ If a domain matches both the `global_allow_list` and the `global_deny_list`, the
 
 # Development and Testing
 
-## Running locally
-
-To run Smokescreen locally, you can provide a minimal configuration file and use `curl` as a client. For example:
-
-```yaml
-# config.yaml
----
-allow_missing_role: true  # skip mTLS client validation
-statsd_address: 127.0.0.1:8200
-```
-
-If you want to see metrics Smokescreen emits, listen on a local port:
-
-```shellsession
-$ nc -uklv 127.0.0.1 8200
-```
-
-Build and run Smokescreen:
-
-```shellsession
-$ go run . --config-file config.yaml
-{"level":"info","msg":"starting","time":"2022-11-30T15:19:08-08:00"}
-```
-
-Make a request using `curl`:
-
-```shellsession
-$ curl --proxytunnel -x localhost:4750 https://stripe.com/
-```
-
-## Testing
-
-```shellsession
-$ go test ./...
-```
+See [Development.md](Development.md)
 
 # Contributors
 

--- a/README.md
+++ b/README.md
@@ -186,3 +186,4 @@ See [Development.md](Development.md)
 - Evan Broder
 - Marc-André Tremblay
 - Ryan Koppenhaver
+- Harold Simpson

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
-	github.com/stripe/goproxy v0.0.0-20240711170433-75b93c00dfb0
+	github.com/stripe/goproxy v0.0.0-20240909161309-906e92b723dd
 	golang.org/x/net v0.17.0
 	gopkg.in/urfave/cli.v1 v1.20.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/stripe/goproxy v0.0.0-20240702232545-72d7dbc6d4fe h1:RzjmXDVOjWq9sPRc
 github.com/stripe/goproxy v0.0.0-20240702232545-72d7dbc6d4fe/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/stripe/goproxy v0.0.0-20240711170433-75b93c00dfb0 h1:1xKgjoLWAosf0yoKocNN4mel1++AKqJw9axpJyz1JRw=
 github.com/stripe/goproxy v0.0.0-20240711170433-75b93c00dfb0/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20240909161309-906e92b723dd h1:+GFSUmU0/RS984Zp8KvYxjU95DxVIGJflsOfITHkF68=
+github.com/stripe/goproxy v0.0.0-20240909161309-906e92b723dd/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/smokescreen/acl/v1/acl.go
+++ b/pkg/smokescreen/acl/v1/acl.go
@@ -83,7 +83,7 @@ func (acl *ACL) Add(svc string, r Rule) error {
 		return err
 	}
 
-	err = acl.ValidateRuleDomainsGlobsAndMitm(svc, r)
+	err = acl.ValidateRule(svc, r)
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func (acl *ACL) DisablePolicies(actions []string) error {
 // and is not utilizing a disabled enforcement policy.
 func (acl *ACL) Validate() error {
 	for svc, r := range acl.Rules {
-		err := acl.ValidateRuleDomainsGlobsAndMitm(svc, r)
+		err := acl.ValidateRule(svc, r)
 		if err != nil {
 			return err
 		}
@@ -218,7 +218,7 @@ func (acl *ACL) Validate() error {
 	return nil
 }
 
-func (acl *ACL) ValidateRuleDomainsGlobsAndMitm(svc string, r Rule) error {
+func (acl *ACL) ValidateRule(svc string, r Rule) error {
 	var err error
 	for _, d := range r.DomainGlobs {
 		err = acl.ValidateDomainGlob(svc, d)

--- a/pkg/smokescreen/acl/v1/acl_test.go
+++ b/pkg/smokescreen/acl/v1/acl_test.go
@@ -377,10 +377,36 @@ func TestMitmComfig(t *testing.T) {
 	d, err := acl.Decide(mitmService, "example-mitm.com", "")
 	a.NoError(err)
 	a.Equal(Allow, d.Result)
-	a.Equal("host matched allowed domain in MITM rule", d.Reason)
+	a.Equal("host matched allowed domain in rule", d.Reason)
 
 	a.NotNil(d.MitmConfig)
 	a.Equal(true, d.MitmConfig.DetailedHttpLogs)
 	a.Equal([]string{"User-Agent"}, d.MitmConfig.DetailedHttpLogsFullHeaders)
 	a.Equal(map[string]string{"Accept-Language": "el"}, d.MitmConfig.AddHeaders)
+}
+
+func TestInvalidMitmComfig(t *testing.T) {
+	a := assert.New(t)
+
+	acl := &ACL{
+		Rules: map[string]Rule{
+			"enforce-dummy-mitm-srv": {
+				Project: "usersec",
+				Policy:  Enforce,
+				DomainGlobs: []string{
+					"example.com",
+				},
+				MitmDomains: []MitmDomain{{
+					Domain: "example-mitm.com",
+					AddHeaders: map[string]string{
+						"Accept-Language": "el",
+					},
+					DetailedHttpLogs: true,
+				}},
+			},
+		},
+	}
+
+	err := acl.Validate()
+	a.Error(err)
 }

--- a/pkg/smokescreen/acl/v1/acl_test.go
+++ b/pkg/smokescreen/acl/v1/acl_test.go
@@ -358,3 +358,29 @@ func TestHostMatchesGlob(t *testing.T) {
 		})
 	}
 }
+
+func TestMitmComfig(t *testing.T) {
+	a := assert.New(t)
+
+	yl := NewYAMLLoader(path.Join("testdata", "mitm_config.yaml"))
+	acl, err := New(logrus.New(), yl, []string{})
+
+	a.NoError(err)
+	a.NotNil(acl)
+
+	mitmService := "enforce-dummy-mitm-srv"
+
+	proj, err := acl.Project(mitmService)
+	a.NoError(err)
+	a.Equal("usersec", proj)
+
+	d, err := acl.Decide(mitmService, "example-mitm.com", "")
+	a.NoError(err)
+	a.Equal(Allow, d.Result)
+	a.Equal("host matched allowed domain in rule", d.Reason)
+
+	a.NotNil(d.MitmConfig)
+	a.Equal(true, d.MitmConfig.DetailedHttpLogs)
+	a.Equal([]string{"User-Agent"}, d.MitmConfig.DetailedHttpLogsFullHeaders)
+	a.Equal(map[string]string{"Accept-Language": "el"}, d.MitmConfig.AddHeaders)
+}

--- a/pkg/smokescreen/acl/v1/acl_test.go
+++ b/pkg/smokescreen/acl/v1/acl_test.go
@@ -377,7 +377,7 @@ func TestMitmComfig(t *testing.T) {
 	d, err := acl.Decide(mitmService, "example-mitm.com", "")
 	a.NoError(err)
 	a.Equal(Allow, d.Result)
-	a.Equal("host matched allowed domain in rule", d.Reason)
+	a.Equal("host matched allowed domain in MITM rule", d.Reason)
 
 	a.NotNil(d.MitmConfig)
 	a.Equal(true, d.MitmConfig.DetailedHttpLogs)

--- a/pkg/smokescreen/acl/v1/testdata/mitm_config.yaml
+++ b/pkg/smokescreen/acl/v1/testdata/mitm_config.yaml
@@ -1,0 +1,23 @@
+---
+version: v1
+services:
+  - name: enforce-dummy-mitm-srv
+    project: usersec
+    action: enforce
+    allowed_domains:
+      - examplea.com
+      - exampleb.com
+    allowed_domains_mitm:
+      - domain: example-mitm.com
+        add_headers:
+          Accept-Language: el
+        detailed_http_logs: true
+        detailed_http_logs_full_headers:
+          - User-Agent
+
+default:
+    project: other
+    action: enforce
+    allowed_domains:
+      - default.example.com
+

--- a/pkg/smokescreen/acl/v1/testdata/mitm_config.yaml
+++ b/pkg/smokescreen/acl/v1/testdata/mitm_config.yaml
@@ -7,7 +7,8 @@ services:
     allowed_domains:
       - examplea.com
       - exampleb.com
-    allowed_domains_mitm:
+      - example-mitm.com
+    mitm_domains:
       - domain: example-mitm.com
         add_headers:
           Accept-Language: el

--- a/pkg/smokescreen/acl/v1/yaml_loader.go
+++ b/pkg/smokescreen/acl/v1/yaml_loader.go
@@ -89,14 +89,7 @@ func (cfg *YAMLConfig) Load() (*ACL, error) {
 		var allowedHostsMitm []MitmDomain
 
 		for _, w := range v.AllowedHostsMitm {
-			mitmDomain := MitmDomain{
-				MitmConfig: MitmConfig{
-					AddHeaders:                  w.AddHeaders,
-					DetailedHttpLogs:            w.DetailedHttpLogs,
-					DetailedHttpLogsFullHeaders: w.DetailedHttpLogsFullHeaders,
-				},
-				Domain: w.Domain,
-			}
+			mitmDomain := NewMITMDomain(w)
 			allowedHostsMitm = append(allowedHostsMitm, mitmDomain)
 		}
 
@@ -123,14 +116,7 @@ func (cfg *YAMLConfig) Load() (*ACL, error) {
 		var allowedHostsMitm []MitmDomain
 
 		for _, w := range cfg.Default.AllowedHostsMitm {
-			mitmDomain := MitmDomain{
-				MitmConfig: MitmConfig{
-					AddHeaders:                  w.AddHeaders,
-					DetailedHttpLogs:            w.DetailedHttpLogs,
-					DetailedHttpLogsFullHeaders: w.DetailedHttpLogsFullHeaders,
-				},
-				Domain: w.Domain,
-			}
+			mitmDomain := NewMITMDomain(w)
 			allowedHostsMitm = append(allowedHostsMitm, mitmDomain)
 		}
 
@@ -154,4 +140,13 @@ func (cfg *YAMLConfig) Load() (*ACL, error) {
 	}
 
 	return &acl, nil
+}
+
+func NewMITMDomain(w YAMLMitmRule) MitmDomain {
+	return MitmDomain{
+		AddHeaders:                  w.AddHeaders,
+		DetailedHttpLogs:            w.DetailedHttpLogs,
+		DetailedHttpLogsFullHeaders: w.DetailedHttpLogsFullHeaders,
+		Domain:                      w.Domain,
+	}
 }

--- a/pkg/smokescreen/acl/v1/yaml_loader_test.go
+++ b/pkg/smokescreen/acl/v1/yaml_loader_test.go
@@ -47,6 +47,16 @@ func TestYAMLLoader(t *testing.T) {
 		a.NotNil(err)
 		a.Nil(acl)
 	}
+
+	// Load a valid MITM config
+	{
+		yl := NewYAMLLoader("testdata/mitm_config.yaml")
+		acl, err := New(logrus.New(), yl, []string{})
+		a.Nil(err)
+		a.NotNil(acl)
+		a.Equal(1, len(acl.Rules))
+		a.Equal(1, len(acl.Rules["enforce-dummy-mitm-srv"].MitmDomains))
+	}
 }
 
 func TestYAMLLoaderInvalidGlob(t *testing.T) {

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -73,7 +73,7 @@ type Config struct {
 	TransportMaxIdleConns        int
 	TransportMaxIdleConnsPerHost int
 
-	// These are the http and https address for the upstream proxy 
+	// These are the http and https address for the upstream proxy
 	UpstreamHttpProxyAddr  string
 	UpstreamHttpsProxyAddr string
 
@@ -99,6 +99,8 @@ type Config struct {
 	// If smokescreen denies a request, this handler is not called.
 	// If the handler returns an error, smokescreen will deny the request.
 	PostDecisionRequestHandler func(*http.Request) error
+	// MitmCa is used to provide a custom CA for MITM
+	MitmCa *tls.Certificate
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/stripe/goproxy"
 	acl "github.com/stripe/smokescreen/pkg/smokescreen/acl/v1"
 	"github.com/stripe/smokescreen/pkg/smokescreen/conntrack"
 	"github.com/stripe/smokescreen/pkg/smokescreen/metrics"
@@ -100,7 +101,7 @@ type Config struct {
 	// If the handler returns an error, smokescreen will deny the request.
 	PostDecisionRequestHandler func(*http.Request) error
 	// MitmCa is used to provide a custom CA for MITM
-	MitmCa *tls.Certificate
+	MitmTLSConfig func(host string, ctx *goproxy.ProxyCtx) (*tls.Config, error)
 }
 
 type missingRoleError struct {

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -1,6 +1,8 @@
 package smokescreen
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -48,7 +50,9 @@ type yamlConfig struct {
 	Tls *yamlConfigTls
 	// Currently not configurable via YAML: RoleFromRequest, Log, DisabledAclPolicyActions
 
-	UnsafeAllowPrivateRanges bool `yaml:"unsafe_allow_private_ranges"`
+	UnsafeAllowPrivateRanges bool   `yaml:"unsafe_allow_private_ranges"`
+	MitmCaCertFile           string `yaml:"mitm_ca_cert_file"`
+	MitmCaKeyFile            string `yaml:"mitm_ca_key_file"`
 }
 
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -150,6 +154,23 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	c.AdditionalErrorMessageOnDeny = yc.DenyMessageExtra
 	c.TimeConnect = yc.TimeConnect
 	c.UnsafeAllowPrivateRanges = yc.UnsafeAllowPrivateRanges
+
+	if yc.MitmCaCertFile != "" || yc.MitmCaKeyFile != "" {
+		if yc.MitmCaCertFile == "" {
+			return errors.New("mitm_ca_cert_file required when mitm_ca_key_file is set")
+		}
+		if yc.MitmCaKeyFile == "" {
+			return errors.New("mitm_ca_key_file required when mitm_ca_cert_file is set")
+		}
+		mitmCa, err := tls.LoadX509KeyPair(yc.MitmCaCertFile, yc.MitmCaKeyFile)
+		if err != nil {
+			return fmt.Errorf("could not load mitmCa: %v", err)
+		}
+		if mitmCa.Leaf, err = x509.ParseCertificate(mitmCa.Certificate[0]); err != nil {
+			return fmt.Errorf("could not populate x509 Leaf value: %v", err)
+		}
+		c.MitmCa = &mitmCa
+	}
 
 	return nil
 }

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/stripe/goproxy"
 	"gopkg.in/yaml.v2"
 )
 
@@ -169,7 +170,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if mitmCa.Leaf, err = x509.ParseCertificate(mitmCa.Certificate[0]); err != nil {
 			return fmt.Errorf("could not populate x509 Leaf value: %v", err)
 		}
-		c.MitmCa = &mitmCa
+		c.MitmTLSConfig = goproxy.TLSConfigFromCA(&mitmCa)
 	}
 
 	return nil

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -165,10 +165,14 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 		mitmCa, err := tls.LoadX509KeyPair(yc.MitmCaCertFile, yc.MitmCaKeyFile)
 		if err != nil {
-			return fmt.Errorf("could not load mitmCa: %v", err)
+			return fmt.Errorf("mitm_ca_key_file error tls.LoadX509KeyPair: %w", err)
+		}
+		// set the leaf certificat to reduce per-handshake processing
+		if len(mitmCa.Certificate) == 0 {
+			return errors.New("mitm_ca_key_file error: mitm_ca_key_file contains no certificates")
 		}
 		if mitmCa.Leaf, err = x509.ParseCertificate(mitmCa.Certificate[0]); err != nil {
-			return fmt.Errorf("could not populate x509 Leaf value: %v", err)
+			return fmt.Errorf("could not populate x509 Leaf value: %w", err)
 		}
 		c.MitmTLSConfig = goproxy.TLSConfigFromCA(&mitmCa)
 	}

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -695,7 +695,7 @@ func handleConnect(config *Config, pctx *goproxy.ProxyCtx) (*goproxy.ConnectActi
 	connectAction := goproxy.OkConnect
 	// If the ACLDecision matched a MITM rule
 	if sctx.Decision.MitmConfig != nil {
-		if config.MitmCa == nil {
+		if config.MitmTLSConfig == nil {
 			deny := denyError{errors.New("ACLDecision specified MITM but Smokescreen doesn't have MITM enabled")}
 			sctx.Decision.allow = false
 			sctx.Decision.MitmConfig = nil
@@ -716,7 +716,7 @@ func handleConnect(config *Config, pctx *goproxy.ProxyCtx) (*goproxy.ConnectActi
 
 		connectAction = &goproxy.ConnectAction{
 			Action:            goproxy.ConnectMitm,
-			TLSConfig:         goproxy.TLSConfigFromCA(config.MitmCa),
+			TLSConfig:         config.MitmTLSConfig,
 			MitmMutateRequest: mitmMutateRequest,
 		}
 	}

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -60,6 +60,9 @@ const (
 	CanonicalProxyDecision   = "CANONICAL-PROXY-DECISION"
 	LogFieldConnEstablishMS  = "conn_establish_time_ms"
 	LogFieldDNSLookupTime    = "dns_lookup_time_ms"
+	LogMitmReqUrl            = "mitm_req_url"
+	LogMitmReqMethod         = "mitm_req_method"
+	LogMitmReqHeaders        = "mitm_req_headers"
 )
 
 type ipType int
@@ -69,6 +72,7 @@ type ACLDecision struct {
 	ResolvedAddr                        *net.TCPAddr
 	allow                               bool
 	enforceWouldDeny                    bool
+	MitmConfig                          *acl.MitmConfig
 }
 
 type SmokescreenContext struct {
@@ -314,9 +318,20 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	}
 	sctx.logger = sctx.logger.WithFields(fields)
 
-	// Only wrap CONNECT conns with an InstrumentedConn. Connections used for traditional HTTP proxy
+	// Only wrap CONNECT conns and MITM http conns with an InstrumentedConn. Connections used for traditional HTTP proxy
 	// requests are pooled and reused by net.Transport.
-	if sctx.proxyType == connectProxy {
+	if sctx.proxyType == connectProxy || pctx.ConnectAction == goproxy.ConnectMitm {
+		// If we have a MITM and option is enabled, we can add detailed Request log fields
+		if pctx.ConnectAction == goproxy.ConnectMitm && sctx.Decision.MitmConfig != nil && sctx.Decision.MitmConfig.DetailedHttpLogs {
+			fields := logrus.Fields{
+				LogMitmReqUrl:     pctx.Req.URL.String(),
+				LogMitmReqMethod:  pctx.Req.Method,
+				LogMitmReqHeaders: redactHeaders(pctx.Req.Header, sctx.Decision.MitmConfig.DetailedHttpLogsFullHeaders),
+			}
+
+			sctx.logger = sctx.logger.WithFields(fields)
+
+		}
 		ic := sctx.cfg.ConnTracker.NewInstrumentedConnWithTimeout(conn, sctx.cfg.IdleTimeout, sctx.logger, d.role, d.outboundHost, sctx.proxyType)
 		pctx.ConnErrorHandler = ic.Error
 		conn = ic
@@ -455,6 +470,13 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 
 	// Handle traditional HTTP proxy
 	proxy.OnRequest().DoFunc(func(req *http.Request, pctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		// Set this on every request as every request mints a new goproxy.ProxyCtx
+		pctx.RoundTripper = rtFn
+
+		// For MITM requests intended for the remote host, the sole requirement was to configure the RoundTripper
+		if pctx.ConnectAction == goproxy.ConnectMitm {
+			return req, nil
+		}
 
 		// We are intentionally *not* setting pctx.HTTPErrorHandler because with traditional HTTP
 		// proxy requests we are able to specify the request during the call to OnResponse().
@@ -469,9 +491,7 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 			req.Header.Del(traceHeader)
 		}()
 
-		// Set this on every request as every request mints a new goproxy.ProxyCtx
-		pctx.RoundTripper = rtFn
-
+		sctx.logger.WithField("url", req.RequestURI).Debug("received HTTP proxy request")
 		// Build an address parsable by net.ResolveTCPAddr
 		destination, err := hostport.NewWithScheme(req.Host, req.URL.Scheme, false)
 		if err != nil {
@@ -479,7 +499,6 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 			return req, rejectResponse(pctx, pctx.Error)
 		}
 
-		sctx.logger.WithField("url", req.RequestURI).Debug("received HTTP proxy request")
 		sctx.Decision, sctx.lookupTime, pctx.Error = checkIfRequestShouldBeProxied(config, req, destination)
 
 		// Returning any kind of response in this handler is goproxy's way of short circuiting
@@ -512,15 +531,15 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 
 		// Defer logging the proxy event here because logProxy relies
 		// on state set in handleConnect
-		defer logProxy(config, pctx)
+		defer logProxy(pctx)
 		defer pctx.Req.Header.Del(traceHeader)
 
-		destination, err := handleConnect(config, pctx)
+		connectAction, destination, err := handleConnect(config, pctx)
 		if err != nil {
 			pctx.Resp = rejectResponse(pctx, err)
 			return goproxy.RejectConnect, ""
 		}
-		return goproxy.OkConnect, destination
+		return connectAction, destination
 	})
 
 	// Strangely, goproxy can invoke this same function twice for a single HTTP request.
@@ -552,9 +571,17 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 			return rejectResponse(pctx, pctx.Error)
 		}
 
-		// In case of an error, this function is called a second time to filter the
-		// response we generate so this logger will be called once.
-		logProxy(config, pctx)
+		if pctx.ConnectAction == goproxy.ConnectMitm {
+			// If the connection is a MITM
+			// 1 we don't want to log as it will be done in HandleConnectFunc
+			// 2 we want to close idle connections as they are not closed by default
+			// and CANONICAL-PROXY-CN-CLOSE is called on InstrumentedConn.Close
+			proxy.Tr.CloseIdleConnections()
+		} else {
+			// In case of an error, this function is called a second time to filter the
+			// response we generate so this logger will be called once.
+			logProxy(pctx)
+		}
 		return resp
 	})
 
@@ -573,32 +600,11 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 	return proxy
 }
 
-func logProxy(config *Config, pctx *goproxy.ProxyCtx) {
+func logProxy(pctx *goproxy.ProxyCtx) {
 	sctx := pctx.UserData.(*SmokescreenContext)
 
 	fields := logrus.Fields{}
-
-	// attempt to retrieve information about the host originating the proxy request
-	if pctx.Req.TLS != nil && len(pctx.Req.TLS.PeerCertificates) > 0 {
-		fields[LogFieldInRemoteX509CN] = pctx.Req.TLS.PeerCertificates[0].Subject.CommonName
-		var ouEntries = pctx.Req.TLS.PeerCertificates[0].Subject.OrganizationalUnit
-		if len(ouEntries) > 0 {
-			fields[LogFieldInRemoteX509OU] = ouEntries[0]
-		}
-	}
-
 	decision := sctx.Decision
-	if sctx.Decision != nil {
-		fields[LogFieldRole] = decision.role
-		fields[LogFieldProject] = decision.project
-	}
-
-	// add the above fields to all future log messages sent using this smokescreen context's logger
-	sctx.logger = sctx.logger.WithFields(fields)
-
-	// start a new set of fields used only in this log message
-	fields = logrus.Fields{}
-
 	// If a lookup takes less than 1ms it will be rounded down to zero. This can separated from
 	// actual failures where the default zero value will also have the error field set.
 	fields[LogFieldDNSLookupTime] = sctx.lookupTime.Milliseconds()
@@ -630,14 +636,35 @@ func logProxy(config *Config, pctx *goproxy.ProxyCtx) {
 	logMethod(CanonicalProxyDecision)
 }
 
-func handleConnect(config *Config, pctx *goproxy.ProxyCtx) (string, error) {
+func extractContextLogFields(pctx *goproxy.ProxyCtx, sctx *SmokescreenContext) logrus.Fields {
+	fields := logrus.Fields{}
+
+	// attempt to retrieve information about the host originating the proxy request
+	if pctx.Req.TLS != nil && len(pctx.Req.TLS.PeerCertificates) > 0 {
+		fields[LogFieldInRemoteX509CN] = pctx.Req.TLS.PeerCertificates[0].Subject.CommonName
+		var ouEntries = pctx.Req.TLS.PeerCertificates[0].Subject.OrganizationalUnit
+		if len(ouEntries) > 0 {
+			fields[LogFieldInRemoteX509OU] = ouEntries[0]
+		}
+	}
+
+	// Retrieve information from the ACL decision
+	decision := sctx.Decision
+	if sctx.Decision != nil {
+		fields[LogFieldRole] = decision.role
+		fields[LogFieldProject] = decision.project
+	}
+	return fields
+}
+
+func handleConnect(config *Config, pctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string, error) {
 	sctx := pctx.UserData.(*SmokescreenContext)
 
 	// Check if requesting role is allowed to talk to remote
 	destination, err := hostport.New(pctx.Req.Host, false)
 	if err != nil {
 		pctx.Error = denyError{err}
-		return "", pctx.Error
+		return nil, "", pctx.Error
 	}
 
 	// checkIfRequestShouldBeProxied can return an error if either the resolved address is disallowed,
@@ -646,10 +673,14 @@ func handleConnect(config *Config, pctx *goproxy.ProxyCtx) (string, error) {
 	sctx.Decision, sctx.lookupTime, pctx.Error = checkIfRequestShouldBeProxied(config, pctx.Req, destination)
 	if pctx.Error != nil {
 		// DNS resolution failure
-		return "", pctx.Error
+		return nil, "", pctx.Error
 	}
+
+	// add context fields to all future log messages sent using this smokescreen context's logger
+	sctx.logger = sctx.logger.WithFields(extractContextLogFields(pctx, sctx))
+
 	if !sctx.Decision.allow {
-		return "", denyError{errors.New(sctx.Decision.reason)}
+		return nil, "", denyError{errors.New(sctx.Decision.reason)}
 	}
 
 	// Call the custom request handler if it exists
@@ -657,11 +688,40 @@ func handleConnect(config *Config, pctx *goproxy.ProxyCtx) (string, error) {
 		err = config.PostDecisionRequestHandler(pctx.Req)
 		if err != nil {
 			pctx.Error = denyError{err}
-			return "", pctx.Error
+			return nil, "", pctx.Error
 		}
 	}
 
-	return destination.String(), nil
+	connectAction := goproxy.OkConnect
+	// If the ACLDecision matched a MITM rule
+	if sctx.Decision.MitmConfig != nil {
+		if config.MitmCa == nil {
+			deny := denyError{errors.New("ACLDecision specified MITM but Smokescreen doesn't have MITM enabled")}
+			sctx.Decision.allow = false
+			sctx.Decision.MitmConfig = nil
+			sctx.Decision.reason = deny.Error()
+			return nil, "", deny
+		}
+		mitm := sctx.Decision.MitmConfig
+
+		var mitmMutateRequest func(req *http.Request, ctx *goproxy.ProxyCtx)
+
+		if len(mitm.AddHeaders) > 0 {
+			mitmMutateRequest = func(req *http.Request, ctx *goproxy.ProxyCtx) {
+				for k, v := range mitm.AddHeaders {
+					req.Header.Set(k, v)
+				}
+			}
+		}
+
+		connectAction = &goproxy.ConnectAction{
+			Action:            goproxy.ConnectMitm,
+			TLSConfig:         goproxy.TLSConfigFromCA(config.MitmCa),
+			MitmMutateRequest: mitmMutateRequest,
+		}
+	}
+
+	return connectAction, destination.String(), nil
 }
 
 func findListener(ip string, defaultPort uint16) (net.Listener, error) {
@@ -964,6 +1024,7 @@ func checkACLsForRequest(config *Config, req *http.Request, destination hostport
 	ACLDecision, err := config.EgressACL.Decide(role, destination.Host, connectProxyHost)
 	decision.project = ACLDecision.Project
 	decision.reason = ACLDecision.Reason
+	decision.MitmConfig = ACLDecision.MitmConfig
 	if err != nil {
 		config.Log.WithFields(logrus.Fields{
 			"error": err,
@@ -1006,4 +1067,33 @@ func checkACLsForRequest(config *Config, req *http.Request, destination hostport
 	}
 
 	return decision
+}
+
+func redactHeaders(originalHeaders http.Header, allowedHeaders []string) http.Header {
+	// Create a new map to store the redacted headers
+	redactedHeaders := make(http.Header)
+
+	// Convert allowedHeaders to a map for faster lookup
+	allowedHeadersMap := make(map[string]bool)
+	for _, h := range allowedHeaders {
+		allowedHeadersMap[strings.ToLower(h)] = true
+	}
+
+	// Iterate through the original headers
+	for key, values := range originalHeaders {
+		lowerKey := strings.ToLower(key)
+		if allowedHeadersMap[lowerKey] {
+			// If the header is in the allowed list, copy it as is
+			redactedHeaders[key] = values
+		} else {
+			// If not, redact the values
+			redactedValues := make([]string, len(values))
+			for i := range values {
+				redactedValues[i] = "[REDACTED]"
+			}
+			redactedHeaders[key] = redactedValues
+		}
+	}
+
+	return redactedHeaders
 }

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -1403,7 +1403,7 @@ func TestMitm(t *testing.T) {
 		r.NoError(err)
 		mitmCa.Leaf, err = x509.ParseCertificate(mitmCa.Certificate[0])
 		r.NoError(err)
-		cfg.MitmCa = &mitmCa
+		cfg.MitmTLSConfig = goproxy.TLSConfigFromCA(&mitmCa)
 		r.NoError(err)
 		err = cfg.SetAllowAddresses([]string{"127.0.0.1"})
 		r.NoError(err)

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -1432,9 +1432,10 @@ func TestMitm(t *testing.T) {
 		r.NoError(err)
 		cfg.Listener = l
 
-		proxy := proxyServer(cfg)
+		proxy := BuildProxy(cfg)
+		httpProxy := httptest.NewServer(proxy)
 		remote := httptest.NewTLSServer(h)
-		client, err := proxyClient(proxy.URL)
+		client, err := proxyClient(httpProxy.URL)
 		r.NoError(err)
 
 		req, err := http.NewRequest("GET", remote.URL, nil)
@@ -1480,6 +1481,7 @@ func TestMitm(t *testing.T) {
 		r.NotNil(proxyDecision)
 		r.Contains(proxyDecision.Data, "proxy_type")
 		r.Equal("connect", proxyDecision.Data["proxy_type"])
+		proxy.Tr.CloseIdleConnections()
 		// check proxyclose log entry has information about the request headers
 		proxyClose := findCanonicalProxyClose(logHook.AllEntries())
 		r.NotNil(proxyClose)

--- a/pkg/smokescreen/testdata/acl.yaml
+++ b/pkg/smokescreen/testdata/acl.yaml
@@ -36,7 +36,9 @@ services:
   - name: test-mitm
     project: security
     action: enforce
-    allowed_domains_mitm:
+    allowed_domains:
+      - 127.0.0.1
+    mitm_domains:
       - domain: 127.0.0.1
         add_headers:
           Accept-Language: el

--- a/pkg/smokescreen/testdata/acl.yaml
+++ b/pkg/smokescreen/testdata/acl.yaml
@@ -33,6 +33,16 @@ services:
       - myproxy.com
       - myproxy2.com
       - thisisaproxy.com
+  - name: test-mitm
+    project: security
+    action: enforce
+    allowed_domains_mitm:
+      - domain: 127.0.0.1
+        add_headers:
+          Accept-Language: el
+        detailed_http_logs: true
+        detailed_http_logs_full_headers:
+          - User-Agent
 
 global_deny_list:
   - stripe.com

--- a/vendor/github.com/stripe/goproxy/ctx.go
+++ b/vendor/github.com/stripe/goproxy/ctx.go
@@ -25,8 +25,9 @@ type ProxyCtx struct {
 	// call of RespHandler
 	UserData interface{}
 	// Will connect a request to a response
-	Session int64
-	proxy   *ProxyHttpServer
+	Session       int64
+	proxy         *ProxyHttpServer
+	ConnectAction ConnectActionLiteral
 }
 
 type RoundTripper interface {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/sirupsen/logrus/hooks/test
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/stripe/goproxy v0.0.0-20240711170433-75b93c00dfb0
+# github.com/stripe/goproxy v0.0.0-20240909161309-906e92b723dd
 ## explicit; go 1.13
 github.com/stripe/goproxy
 # golang.org/x/mod v0.8.0


### PR DESCRIPTION
## Description
This PR adds MITM support:
- New DSL for config and ACL which:
  - allows adding headers on the fly
  - detailed HTTP logging (URL, method and headers with values redacted)
  - allowlist of headers that should not be redacted
- YAML support for this DSL

I've also:
- Updated the [stripe/goproxy](https://github.com/stripe/goproxy) dependency as this PR depends on it
- Created a `Development.md` which now includes instructions on how to run locally for multiple scenarios:
  - HTTP Proxy
  - HTTP CONNECT Proxy
  - Monitor metrics Smokescreen emits
  - HTTP CONNECT Proxy over TL
  - MITM (Man in the middle) Proxy
  - MITM (Man in the middle) Proxy over TLS
- Added `.vscode/launch.json` to allow debugging easily in Vscode
- Removed `config *Config` argument from `logProxy` as it was un-used
- Changes the way `extractContextLogFields` are added to accommodate the MITM code

`pctx.RoundTripper` which is normally used for `http` proxy request is now also used by the MITM outbound request. By default it pools requests and keep them idle for a short period of time to potentially re-use. (even when `Response.Body.Close()` is run) This doesn't work well with `InstrumentedConn` that logs `CANONICAL-PROXY-CN-CLOSE` once the connection is closed.

There are multiple ways to go around this  but I chose to run `proxy.Tr.CloseIdleConnections` as this `closes any connections which were previously connected from previous requests but are now sitting idle in a "keep-alive" state`. This proxy is not primarily intended to support browser traffic and the performance gain of keeping this connection is negligible for our use-case.

Alternatives considered:
- `req.Header.Set("Connection", "close")` would work but  the header is wiped in goproxy which calls [removeProxyHeaders](https://github.com/stripe/goproxy/blob/906e92b723dddbed30dd17e7b274b4e577cb14fb/https.go#L297) which deletes the [Connection](https://github.com/stripe/goproxy/blob/906e92b723dddbed30dd17e7b274b4e577cb14fb/proxy.go#L133) header.
- Create a custom dialer and close the connection manually but this added unnecessary complexity.

## Testing
I have added automated tests for ACL and the whole MITM flow.

### HTTP Proxy (happy path) ✅
See set-up from [Development.md HTTP Proxy](225/files#Development.md))
```bash
go run . --config-file config.yaml --egress-acl-file acl.yaml
{"level":"info","msg":"Loading egress ACL from acl.yaml","time":"2024-09-09T17:16:34.234136+02:00"}
{"level":"info","msg":"starting","time":"2024-09-09T17:16:34+02:00"}
{"allow":true,"conn_establish_time_ms":98,"content_length":-1,"decision_reason":"host matched allowed domain in rule","dns_lookup_time_ms":1,"enforce_would_deny":false,"id":"crfn7lut29fjr92l4g70","inbound_remote_addr":"[::1]:52470","level":"info","msg":"CANONICAL-PROXY-DECISION","outbound_local_addr":"[2a02:8428:5ae6:a601:854:83b0:cc2a:fc61]:52471","outbound_remote_addr":"[2606:2800:21f:cb07:6820:80da:af6b:8b2c]:80","proxy_type":"http","requested_host":"example.com","start_time":"2024-09-09T15:16:55.303862Z","time":"2024-09-09T17:16:55+02:00","trace_id":""}
```

### HTTP CONNECT Proxy (happy path) ✅
See set-up from [Development.md HTTP CONNECT Proxy](225/files#Development.md))
```bash
go run . --config-file config.yaml --egress-acl-file acl.yaml
{"level":"info","msg":"Loading egress ACL from acl.yaml","time":"2024-09-09T17:42:55.710681+02:00"}
{"level":"info","msg":"starting","time":"2024-09-09T17:42:55+02:00"}
{"allow":true,"decision_reason":"host matched allowed domain in rule","dns_lookup_time_ms":6,"enforce_would_deny":false,"id":"crflrnut29fufb87e880","inbound_remote_addr":"[::1]:64026","level":"info","msg":"CANONICAL-PROXY-DECISION","project":"security","proxy_type":"connect","requested_host":"api.github.com:443","role":"","start_time":"2024-09-09T15:43:11.728056Z","time":"2024-09-09T17:43:11+02:00","trace_id":""}
{"bytes_in":4706,"bytes_out":594,"conn_establish_time_ms":92,"duration":0.468236125,"end_time":"2024-09-09T15:43:12.295369Z","error":"","id":"crflrnut29fufb87e880","inbound_remote_addr":"[::1]:64026","last_activity":"2024-09-09T15:43:12.294314Z","level":"info","msg":"CANONICAL-PROXY-CN-CLOSE","outbound_local_addr":"192.168.1.65:64027","outbound_remote_addr":"140.82.121.5:443","project":"security","proxy_type":"connect","requested_host":"api.github.com:443","role":"","start_time":"2024-09-09T15:43:11.728056Z","time":"2024-09-09T17:43:12+02:00","trace_id":""}
```

### HTTP CONNECT Proxy over TLS (happy path) ✅
See set-up from [Development.md HTTP CONNECT Proxy over TLS](225/files#Development.md))

```
go run . --config-file config.yaml --egress-acl-file acl.yaml
warn: no statsd addr provided, using noop client
info: Loaded CA with Authority ID 'ffdb815e7ba5132cbd786c176175c6107d26809b'
warn: no CRL loaded for Authority ID 'ffdb815e7ba5132cbd786c176175c6107d26809b'
{"level":"info","msg":"Loading egress ACL from acl.yaml","time":"2024-09-09T17:54:56.824782+02:00"}
{"level":"info","msg":"starting","time":"2024-09-09T17:54:56+02:00"}
{"allow":true,"decision_reason":"host matched allowed domain in rule","dns_lookup_time_ms":593,"enforce_would_deny":false,"id":"crfm1d6t29fgv2nj56n0","inbound_remote_addr":"[::1]:52641","inbound_remote_x509_cn":"localhost","inbound_remote_x509_ou":"Writer","level":"info","msg":"CANONICAL-PROXY-DECISION","project":"github","proxy_type":"connect","requested_host":"api.github.com:443","role":"localhost","start_time":"2024-09-09T15:55:16.019972Z","time":"2024-09-09T17:55:16+02:00","trace_id":""}
{"bytes_in":4680,"bytes_out":594,"conn_establish_time_ms":219,"duration":0.893843,"end_time":"2024-09-09T15:55:17.727861Z","error":"","id":"crfm1d6t29fgv2nj56n0","inbound_remote_addr":"[::1]:52641","inbound_remote_x509_cn":"localhost","inbound_remote_x509_ou":"Writer","last_activity":"2024-09-09T15:55:17.726988Z","level":"info","msg":"CANONICAL-PROXY-CN-CLOSE","outbound_local_addr":"192.168.1.65:52648","outbound_remote_addr":"140.82.121.6:443","project":"github","proxy_type":"connect","requested_host":"api.github.com:443","role":"localhost","start_time":"2024-09-09T15:55:16.019972Z","time":"2024-09-09T17:55:17+02:00","trace_id":""}
```

### MITM (Man in the middle) Proxy (happy path) ✅
See set-up from [Development.md MITM (Man in the middle) Proxy](225/files#Development.md))
```
go run . --config-file config.yaml --egress-acl-file acl.yaml
warn: no statsd addr provided, using noop client
{"level":"info","msg":"Loading egress ACL from acl.yaml","time":"2024-09-09T18:11:30.835473+02:00"}
{"level":"info","msg":"starting","time":"2024-09-09T18:11:30+02:00"}
{"allow":true,"decision_reason":"host matched allowed domain in rule","dns_lookup_time_ms":87,"enforce_would_deny":false,"id":"crfm93mt29fikttq21bg","inbound_remote_addr":"[::1]:59008","level":"info","msg":"CANONICAL-PROXY-DECISION","project":"security","proxy_type":"connect","requested_host":"wttr.in:443","role":"","start_time":"2024-09-09T16:11:42.641312Z","time":"2024-09-09T18:11:42+02:00","trace_id":""}
{"bytes_in":12109,"bytes_out":479,"conn_establish_time_ms":25,"duration":0.497213875,"end_time":"2024-09-09T16:11:43.461775Z","error":"","id":"crfm93mt29fikttq21bg","inbound_remote_addr":"[::1]:59008","last_activity":"2024-09-09T16:11:43.461714Z","level":"info","mitm_req_headers":{"Accept":["[REDACTED]"],"Accept-Language":["[REDACTED]"],"User-Agent":["curl/8.7.1"]},"mitm_req_method":"GET","mitm_req_url":"https://wttr.in:443/","msg":"CANONICAL-PROXY-CN-CLOSE","outbound_local_addr":"192.168.1.65:59009","outbound_remote_addr":"5.9.243.187:443","project":"security","proxy_type":"connect","requested_host":"wttr.in:443","role":"","start_time":"2024-09-09T16:11:42.641312Z","time":"2024-09-09T18:11:43+02:00","trace_id":""}
```
`Accept-Language: el` was correctly sent
<img width="988" alt="image" src="https://github.com/user-attachments/assets/fbd1ea9e-641f-4468-9079-51bb69c89f88">
Notice the `mitm_req_headers`, `mitm_req_method` and `mitm_req_url` fields

### MITM (Man in the middle) Proxy over TLS (happy path) ✅
See set-up from [Development.md MITM (Man in the middle) Proxy over TLS](225/files#Development.md))
`Accept-Language: el` was correctly sent (weather is in Greek)

```
go run . --config-file config.yaml --egress-acl-file acl.yaml
warn: no statsd addr provided, using noop client
info: Loaded CA with Authority ID 'ffdb815e7ba5132cbd786c176175c6107d26809b'
warn: no CRL loaded for Authority ID 'ffdb815e7ba5132cbd786c176175c6107d26809b'
{"level":"info","msg":"Loading egress ACL from acl.yaml","time":"2024-09-09T18:17:01.764258+02:00"}
{"level":"info","msg":"starting","time":"2024-09-09T18:17:01+02:00"}
{"allow":true,"decision_reason":"host matched allowed domain in rule","dns_lookup_time_ms":15,"enforce_would_deny":false,"id":"crfmbket29fj5e1mvrag","inbound_remote_addr":"[::1]:61252","inbound_remote_x509_cn":"localhost","inbound_remote_x509_ou":"Writer","level":"info","msg":"CANONICAL-PROXY-DECISION","project":"github","proxy_type":"connect","requested_host":"wttr.in:443","role":"localhost","start_time":"2024-09-09T16:17:05.96784Z","time":"2024-09-09T18:17:05+02:00","trace_id":""}
{"bytes_in":12109,"bytes_out":479,"conn_establish_time_ms":36,"duration":0.065963916,"end_time":"2024-09-09T16:17:06.243684Z","error":"","id":"crfmbket29fj5e1mvrag","inbound_remote_addr":"[::1]:61252","inbound_remote_x509_cn":"localhost","inbound_remote_x509_ou":"Writer","last_activity":"2024-09-09T16:17:06.243663Z","level":"info","mitm_req_headers":{"Accept":["[REDACTED]"],"Accept-Language":["[REDACTED]"],"User-Agent":["curl/8.7.1"]},"mitm_req_method":"GET","mitm_req_url":"https://wttr.in:443/","msg":"CANONICAL-PROXY-CN-CLOSE","outbound_local_addr":"192.168.1.44:61255","outbound_remote_addr":"5.9.243.187:443","project":"github","proxy_type":"connect","requested_host":"wttr.in:443","role":"localhost","start_time":"2024-09-09T16:17:05.96784Z","time":"2024-09-09T18:17:06+02:00","trace_id":""}
```

Notice the `mitm_req_headers`, `mitm_req_method`, `mitm_req_url` (MITM), `inbound_remote_x509_cn` and `inbound_remote_x509_ou` (TLS) fields.


### MITM config not configured with ACL configured ✅

```yaml
# config.yaml
---
tls:
  cert_file: "mtls_setup/server.crt"
  key_file: "mtls_setup/server.key"
  client_ca_files:
    - "mtls_setup/client-ca.crt"
```

```yaml
# acl.yaml
---
version: v1
services:
  - name: localhost
    project: github
    action: enforce
    allowed_domains: []
    allowed_domains_mitm:
      - domain: wttr.in
        add_headers:
          Accept-Language: el
        detailed_http_logs: true
        detailed_http_logs_full_headers:
          - User-Agent
default:
  name: default
  project: security
  action: enforce
  allowed_domains: []
```

```bash
go run . --config-file config.yaml --egress-acl-file acl.yaml

warn: no statsd addr provided, using noop client
info: Loaded CA with Authority ID 'ffdb815e7ba5132cbd786c176175c6107d26809b'
warn: no CRL loaded for Authority ID 'ffdb815e7ba5132cbd786c176175c6107d26809b'
{"level":"info","msg":"Loading egress ACL from acl.yaml","time":"2024-09-09T18:58:32.027806+02:00"}
{"level":"info","msg":"starting","time":"2024-09-09T18:58:32+02:00"}
{"allow":false,"content_length":119,"decision_reason":"ACLDecision specified MITM but Smokescreen doesn't have MITM enabled","dns_lookup_time_ms":18,"enforce_would_deny":false,"id":"crfmv56t29fhhhmhr5i0","inbound_remote_addr":"[::1]:61235","inbound_remote_x509_cn":"localhost","inbound_remote_x509_ou":"Writer","level":"warning","msg":"CANONICAL-PROXY-DECISION","project":"github","proxy_type":"connect","requested_host":"wttr.in:443","role":"localhost","start_time":"2024-09-09T16:58:44.319077Z","time":"2024-09-09T18:58:44+02:00","trace_id":""}
````
Miss-configuration fails gracefully 
