### PR TITLE
Update Github build workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ['1.20', '1.21']
+        go-version: ['1.21', '1.22', '1.23']
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     - name: Setup env
@@ -31,9 +31,7 @@ jobs:
         go test -race -v -timeout 2m -failfast ./cmd/... -run TestInvalidUpstreamProxyConfiguration
         go test -race -v -timeout 2m -failfast ./cmd/... -run TestClientHalfCloseConnection
     - name: Install goveralls
-      env:
-        GO111MODULE: off
-      run: go get github.com/mattn/goveralls
+      run: go install github.com/mattn/goveralls@latest
     - name: Send coverage
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description
This PR:
- Update tests to use go `1.21`, `1.22` and `1.23`
- Updates to latest `actions/checkout@v4` and `actions/setup-go@v5`
- Changes `goveralls` config to matche the documentation on https://github.com/mattn/goveralls

# Motivation
Fix build, sending test coverage can go in some sort of race condition error like in https://github.com/stripe/smokescreen/pull/225, https://github.com/stripe/smokescreen/pull/226 and https://github.com/stripe/smokescreen/pull/227

https://github.com/lemurheavy/coveralls-public/issues/1716 suggests upgrading to latest versions.