### PR TITLE
Use goveralls parallel build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ name: Test
 # See https://github.com/lemurheavy/coveralls-public/issues/1716
 env:
   COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}-${{ github.run_attempt }}
+  COVERALLS_PARALLEL: true
 jobs:
   test:
     strategy:
@@ -36,3 +37,15 @@ jobs:
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: goveralls -coverprofile=.covprofile -service=github
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+      - name: Install goveralls 
+        run: go install github.com/mattn/goveralls@latest
+      - name: Close goveralls parallel build 
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: goveralls -coverprofile=.covprofile -service=github -parallel-finish=true


### PR DESCRIPTION
# Description
Second attempt (https://github.com/stripe/smokescreen/pull/228) to try and fix the build
Following the [parallel builds](https://docs.coveralls.io/parallel-builds) pattern by setting the `COVERALLS_PARALLEL` env  and running `goveralls -parallel-finish=true`

# Test
Looks like it works in https://github.com/stripe/smokescreen/actions/runs/10911519945