### PR TITLE
Make error messages more descriptive and user friendly

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -441,7 +441,7 @@ func validateProxyResponseWithUpstream(t *testing.T, test *TestCase, resp *http.
 	t.Logf("HTTP Response: %#v", resp)
 
 	if test.OverConnect {
-		a.Contains(err.Error(), "Failed to resolve remote hostname")
+		a.Contains(err.Error(), fmt.Sprintf("DNS resolution failed for 'api.stripe.com:443'"))
 	} else {
 		a.Equal(http.StatusBadGateway, resp.StatusCode)
 	}
@@ -648,7 +648,7 @@ func startSmokescreen(t *testing.T, useTLS bool, logHook logrus.Hook, httpProxyA
 		)
 	}
 
-	if httpProxyAddr != ""{
+	if httpProxyAddr != "" {
 		args = append(args, fmt.Sprintf("--upstream-http-proxy-addr=%s", httpProxyAddr))
 		args = append(args, fmt.Sprintf("--upstream-https-proxy-addr=%s", httpProxyAddr))
 	}

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -444,7 +444,7 @@ func TestInvalidHost(t *testing.T) {
 
 				defer resp.Body.Close()
 				b, _ := ioutil.ReadAll(resp.Body)
-				r.Contains(string(b), "Failed to resolve remote hostname")
+				r.Contains(string(b), "DNS resolution failed for 'notarealhost.test'")
 			}
 
 			entry := findCanonicalProxyDecision(logHook.AllEntries())


### PR DESCRIPTION
Improve error messages to be more descriptive and user friendly.

## Testing Details
DNS Resolution Failure
```
HTTPS_PROXY=localhost:4750 curl https://abccda.com 
```

Logs:
```
{"id":"crt8k5qf8flecbs1t3qg","inbound_remote_addr":"[::1]:51673","level":"error","msg":"DNS resolution failed for 'abccda.com:443'. This could be due to an incorrect hostname or DNS issues. Error Details: lookup abccda.com: no such host","proxy_type":"connect","requested_host":"abccda.com:443","start_time":"2024-09-30T11:23:03.39828Z","time":"2024-09-30T16:53:03+05:30","trace_id":""}
{"allow":true,"content_length":149,"decision_reason":"host matched allowed domain in rule","dns_lookup_time_ms":151,"enforce_would_deny":false,"error":"lookup abccda.com: no such host","id":"crt8k5qf8flecbs1t3qg","inbound_remote_addr":"[::1]:51673","level":"error","msg":"CANONICAL-PROXY-DECISION","proxy_type":"connect","requested_host":"abccda.com:443","start_time":"2024-09-30T11:23:03.39828Z","time":"2024-09-30T16:53:03+05:30","trace_id":""}
```
Timeout Failure
```
 HTTPS_PROXY=localhost:4750 curl https://localhost.com
 
```

Logs
```
{"allow":true,"decision_reason":"host matched allowed domain in rule","dns_lookup_time_ms":11,"enforce_would_deny":false,"id":"crt8pvaf8flecbs1t3r0","inbound_remote_addr":"[::1]:52498","level":"info","msg":"CANONICAL-PROXY-DECISION","project":"security","proxy_type":"connect","requested_host":"localhost.com:443","role":"","start_time":"2024-09-30T11:35:25.314705Z","time":"2024-09-30T17:05:25+05:30","trace_id":""}
{"conn_establish_time_ms":75000,"id":"crt8pvaf8flecbs1t3r0","inbound_remote_addr":"[::1]:52498","level":"error","msg":"Connection to remote host 'localhost.com:443' timed out. This could be due to network issues or the remote host being down. Error Details: dial tcp 74.125.224.72:443: connect: operation timed out","project":"security","proxy_type":"connect","requested_host":"localhost.com:443","role":"","start_time":"2024-09-30T11:35:25.314705Z","time":"2024-09-30T17:06:40+05:30","trace_id":""}

```