### PR TITLE
Add Support for Reject Handler with SmokescreenContext

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -85,9 +85,11 @@ type Config struct {
 	ProxyDialTimeout func(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error)
 
 	// Custom handler to allow clients to modify reject responses
+	// Deprecated: RejectResponseHandler is deprecated.Please use RejectResponseHandlerWithCtx instead.
 	RejectResponseHandler func(*http.Response)
 
 	// Custom handler to allow clients to modify reject responses
+	// In case RejectResponseHandler is set, this cannot be used.
 	RejectResponseHandlerWithCtx func(*SmokescreenContext, *http.Response)
 
 	// Custom handler to allow clients to modify successful CONNECT responses
@@ -418,6 +420,13 @@ func (config *Config) SetupTls(certFile, keyFile string, clientCAFiles []string)
 		ClientCAs:    clientCAs,
 	}
 
+	return nil
+}
+
+func (config *Config) Validate() error {
+	if config.RejectResponseHandler != nil && config.RejectResponseHandlerWithCtx != nil {
+		return errors.New("RejectResponseHandler and RejectResponseHandlerWithCtx cannot be used together")
+	}
 	return nil
 }
 

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -87,6 +87,9 @@ type Config struct {
 	// Custom handler to allow clients to modify reject responses
 	RejectResponseHandler func(*http.Response)
 
+	// Custom handler to allow clients to modify reject responses
+	RejectResponseHandlerWithCtx func(*SmokescreenContext, *http.Response)
+
 	// Custom handler to allow clients to modify successful CONNECT responses
 	AcceptResponseHandler func(*SmokescreenContext, *http.Response) error
 

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -787,10 +787,6 @@ func StartWithConfig(config *Config, quit <-chan interface{}) {
 		server.IdleTimeout = config.IdleTimeout
 	}
 
-	if config.RejectResponseHandler != nil && config.RejectResponseHandlerWithCtx != nil {
-		config.Log.Fatal("RejectResponseHandler and RejectResponseHandlerWithCtx cannot be set simultaneously")
-	}
-
 	config.MetricsClient.SetStarted()
 	config.ShuttingDown.Store(false)
 	runServer(config, &server, listener, quit)

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -404,6 +404,9 @@ func rejectResponse(pctx *goproxy.ProxyCtx, err error) *http.Response {
 	if sctx.cfg.RejectResponseHandler != nil {
 		sctx.cfg.RejectResponseHandler(resp)
 	}
+	if sctx.cfg.RejectResponseHandlerWithCtx != nil {
+		sctx.cfg.RejectResponseHandlerWithCtx(sctx, resp)
+	}
 	return resp
 }
 

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -1091,7 +1091,7 @@ func TestRejectResponseHandlerWithCtx(t *testing.T) {
 		resp, err := client.Get("http://127.0.0.1")
 		r.NoError(err)
 
-		// The RejectResponseHandler should set our custom header
+		// The RejectResponseHandlerWithCtx should set our custom header
 		h := resp.Header.Get(testHeader)
 		if h == "" {
 			t.Errorf("Expecting header %s to be set by RejectResponseHandler", testHeader)

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -1535,6 +1535,38 @@ func TestMitm(t *testing.T) {
 	})
 }
 
+func TestConfigValidate(t *testing.T) {
+	t.Run("Test invalid config", func(t *testing.T) {
+		conf := NewConfig()
+		conf.ConnectTimeout = 10 * time.Second
+		conf.ExitTimeout = 10 * time.Second
+		conf.AdditionalErrorMessageOnDeny = "Proxy denied"
+		conf.RejectResponseHandlerWithCtx = func(smokescreenContext *SmokescreenContext, response *http.Response) {
+			fmt.Println("RejectResponseHandlerWithCtx")
+		}
+		conf.RejectResponseHandler = func(response *http.Response) {
+			fmt.Println("RejectResponseHandler")
+		}
+		err := conf.Validate()
+		require.Error(t, err)
+
+	})
+
+	t.Run("Test valid config", func(t *testing.T) {
+		conf := NewConfig()
+		conf.ConnectTimeout = 10 * time.Second
+		conf.ExitTimeout = 10 * time.Second
+		conf.AdditionalErrorMessageOnDeny = "Proxy denied"
+
+		conf.RejectResponseHandler = func(response *http.Response) {
+			fmt.Println("RejectResponseHandler")
+		}
+		err := conf.Validate()
+		require.NoError(t, err)
+
+	})
+}
+
 func findCanonicalProxyDecision(logs []*logrus.Entry) *logrus.Entry {
 	for _, entry := range logs {
 		if entry.Message == CanonicalProxyDecision {

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -1067,6 +1067,47 @@ func TestRejectResponseHandler(t *testing.T) {
 	})
 }
 
+func TestRejectResponseHandlerWithCtx(t *testing.T) {
+	r := require.New(t)
+	testHeader := "TestRejectResponseHandlerWithCtxHeader"
+	t.Run("Testing custom reject response handler", func(t *testing.T) {
+		cfg, err := testConfig("test-local-srv")
+
+		// set a custom RejectResponseHandler that will set a header on every reject response
+		cfg.RejectResponseHandlerWithCtx = func(_ *SmokescreenContext, resp *http.Response) {
+			resp.Header.Set(testHeader, "This header is added by the RejectResponseHandlerWithCtx")
+		}
+		r.NoError(err)
+
+		proxySrv := proxyServer(cfg)
+		r.NoError(err)
+		defer proxySrv.Close()
+
+		// Create a http.Client that uses our proxy
+		client, err := proxyClient(proxySrv.URL)
+		r.NoError(err)
+
+		// Send a request that should be blocked
+		resp, err := client.Get("http://127.0.0.1")
+		r.NoError(err)
+
+		// The RejectResponseHandler should set our custom header
+		h := resp.Header.Get(testHeader)
+		if h == "" {
+			t.Errorf("Expecting header %s to be set by RejectResponseHandler", testHeader)
+		}
+		// Send a request that should be allowed
+		resp, err = client.Get("http://example.com")
+		r.NoError(err)
+
+		// The header set by our custom reject response handler should not be set
+		h = resp.Header.Get(testHeader)
+		if h != "" {
+			t.Errorf("Expecting header %s to not be set by RejectResponseHandler", testHeader)
+		}
+	})
+}
+
 // Test that Smokescreen calls the custom accept response handler (if defined in the Config struct)
 // after every accepted request
 func TestAcceptResponseHandler(t *testing.T) {


### PR DESCRIPTION
## Description 
Enhance Smokescreen to implement reject handler functionality. This handler will be invoked with the Smokescreen context when a connection failure occurs.

## Testing Details 

HTTP Connect Failure
```
HTTPS_PROXY=localhost:4750 curl https://localhost.com
curl: (56) CONNECT tunnel failed, response 504

```
Logs
```
{"conn_establish_time_ms":75001,"id":"crvobmqf8fl8sruiooeg","inbound_remote_addr":"[::1]:52672","level":"error","msg":"Timed out connecting to remote host: dial tcp 74.125.224.72:443: connect: operation timed out","project":"","proxy_type":"connect","requested_host":"localhost.com:443","role":"","start_time":"2024-10-04T06:06:19.38513Z","time":"2024-10-04T11:37:34+05:30","trace_id":""}
RejectResponseHandlerWithCtx Called
```

HTTP Connect Success

```
 HTTPS_PROXY=localhost:4750 curl https://api.github.com/zen 
Practicality beats purity.%       
```                                
Logs
```
{"allow":true,"decision_reason":"Egress ACL is not configured","dns_lookup_time_ms":60,"enforce_would_deny":false,"id":"crvoipaf8fl8sruioohg","inbound_remote_addr":"[::1]:53414","level":"info","msg":"CANONICAL-PROXY-DECISION","project":"","proxy_type":"connect","requested_host":"api.github.com:443","role":"","start_time":"2024-10-04T06:21:25.653434Z","time":"2024-10-04T11:51:25+05:30","trace_id":""}
{"level":"info","msg":"AcceptResponseHandler","stdlog":"1","time":"2024-10-04T11:51:25+05:30"}
{"bytes_in":4684,"bytes_out":594,"conn_establish_time_ms":97,"duration":0.416362375,"end_time":"2024-10-04T06:21:26.227127Z","error":"","id":"crvoipaf8fl8sruioohg","inbound_remote_addr":"[::1]:53414","last_activity":"2024-10-04T06:21:26.226825Z","level":"info","msg":"CANONICAL-PROXY-CN-CLOSE","outbound_local_addr":"10.246.129.166:53415","outbound_remote_addr":"20.207.73.85:443","project":"","proxy_type":"connect","requested_host":"api.github.com:443","role":"","start_time":"2024-10-04T06:21:25.653434Z","time":"2024-10-04T11:51:26+05:30","trace_id":""}

```