### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/smokescreen/metrics/mocks.go
+++ b/pkg/smokescreen/metrics/mocks.go
@@ -66,7 +66,7 @@ func (m *MockMetricsClient) GetCount(metric string, tags map[string]string) (uin
 	}
 	i, ok := m.counts[mName]
 	if !ok {
-		keys := make([]string, len(m.counts))
+		keys := make([]string, 0, len(m.counts))
 		for k, _ := range m.counts {
 			keys = append(keys, k)
 		}
@@ -92,7 +92,7 @@ func (m *MockMetricsClient) GetValues(metric string, tags map[string]string) ([]
 	}
 	i, ok := m.values[mName]
 	if !ok {
-		keys := make([]string, len(m.counts))
+		keys := make([]string, 0, len(m.counts))
 		for k, _ := range m.values {
 			keys = append(keys, k)
 		}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of  `len(m.counts)`  rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW