### PR TITLE
Adding [allow|deny]_addresses settings to yaml config file

### DIFF
--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -28,6 +28,8 @@ type yamlConfig struct {
 	Port                 *uint16
 	DenyRanges           []string `yaml:"deny_ranges"`
 	AllowRanges          []string `yaml:"allow_ranges"`
+	DenyAddresses        []string `yaml:"deny_addresses"`
+	AllowAddresses       []string `yaml:"allow_addresses"`
 	Resolvers            []string `yaml:"resolver_addresses"`
 	StatsdAddress        string   `yaml:"statsd_address"`
 	EgressAclFile        string   `yaml:"acl_file"`
@@ -77,6 +79,16 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	err = c.SetAllowRanges(yc.AllowRanges)
+	if err != nil {
+		return err
+	}
+
+	err = c.SetDenyAddresses(yc.DenyAddresses)
+	if err != nil {
+		return err
+	}
+
+	err = c.SetAllowAddresses(yc.AllowAddresses)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Pretty straightforward - adding the allow/deny command line arguments to the config loader so they can be included in a yaml configuration. This allows you to have a yaml config that looks like this:

```

ip: "127.0.0.1"
port: 8888

deny_ranges:
  - 93.0.0.0/8 

allow_addresses:
  - 93.184.215.14

allow_ranges:
  - 192.168.0.0/16

deny_addresses:
  - 192.168.1.5
```

I also opened a separate issue (https://github.com/stripe/smokescreen/issues/236) when playing around with this configuration, and discovering that the allow/deny configurations don't work as I would expect. This doesn't make a difference for this PR though.
