### PR TITLE
Update goproxy version to v0.0.0-20241022131412-58117846327a

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
-	github.com/stripe/goproxy v0.0.0-20241017101008-e12ef0653f22
+	github.com/stripe/goproxy v0.0.0-20241022131412-58117846327a
 	golang.org/x/net v0.17.0
 	gopkg.in/urfave/cli.v1 v1.20.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -228,6 +228,10 @@ github.com/stripe/goproxy v0.0.0-20240909161309-906e92b723dd h1:+GFSUmU0/RS984Zp
 github.com/stripe/goproxy v0.0.0-20240909161309-906e92b723dd/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/stripe/goproxy v0.0.0-20241017101008-e12ef0653f22 h1:tyY7UmUjUv1FF6/bv7P9hgRoNJEuKC2wktIm7e+SHeI=
 github.com/stripe/goproxy v0.0.0-20241017101008-e12ef0653f22/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20241022121110-37ebb5c1cae0 h1:4tKku4LktTP2RI8+7f0hV4nlXB8hQK+Bddmnj3oBI5Q=
+github.com/stripe/goproxy v0.0.0-20241022121110-37ebb5c1cae0/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20241022131412-58117846327a h1:7i7jyPHkHbyyqgyoE9dfmP4JtysKB42EemnBRjNofX0=
+github.com/stripe/goproxy v0.0.0-20241022131412-58117846327a/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vendor/github.com/stripe/goproxy/https.go
+++ b/vendor/github.com/stripe/goproxy/https.go
@@ -362,7 +362,7 @@ func createCustomConnectResponse(ctx *ProxyCtx) ([]byte, error) {
 	if ctx.proxy.ConnectRespHandler == nil {
 		return nil, nil
 	}
-	resp := &http.Response{Status: "200 OK", StatusCode: 200, Proto: "HTTP/1.0", ProtoMajor: 1, ProtoMinor: 0, Header: http.Header{}}
+	resp := &http.Response{Status: "200 OK", StatusCode: 200, Proto: "HTTP/1.0", ProtoMajor: 1, ProtoMinor: 0, ContentLength: -1, Header: http.Header{}}
 	err := ctx.proxy.ConnectRespHandler(ctx, resp)
 	if err != nil {
 		return nil, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/sirupsen/logrus/hooks/test
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/stripe/goproxy v0.0.0-20241017101008-e12ef0653f22
+# github.com/stripe/goproxy v0.0.0-20241022131412-58117846327a
 ## explicit; go 1.13
 github.com/stripe/goproxy
 # golang.org/x/mod v0.8.0


### PR DESCRIPTION
### Summary 

Update goproxy version to v0.0.0-20241022131412-58117846327a.

This includes goproxy bug fixes related to content-length coming as 0 along with 200 OK HTTP/1.0 while using goproxy customconnect handlers. This is not RFC-9110 compliant which states that a server MUST NOT send any Transfer-Encoding or Content-Length header fields in a 2xx (Successful) response to CONNECT.

