### PR TITLE
Fix CRL for client certificates

### DIFF
--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -95,7 +95,7 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			Usage: "Expose prometheus metrics on `ENDPOINT`. Requires --expose-prometheus-metrics to be set. Defaults to \"/metrics\"",
 		},
 		cli.StringFlag{
-			Name: "prometheus-listen-ip",
+			Name:  "prometheus-listen-ip",
 			Value: "0.0.0.0",
 			Usage: "Listen for prometheus metrics on interface with address IP. Requires --expose-prometheus-metrics to be set. Defaults to \"0.0.0.0\"",
 		},
@@ -270,12 +270,6 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			}
 		}
 
-		if c.IsSet("tls-crl-file") {
-			if err := conf.SetupCrls(c.StringSlice("tls-crl-file")); err != nil {
-				return err
-			}
-		}
-
 		if c.IsSet("unsafe-allow-private-ranges") {
 			conf.UnsafeAllowPrivateRanges = c.Bool("unsafe-allow-private-ranges")
 		}
@@ -293,6 +287,12 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 				bundleFile,
 				bundleFile,
 				c.StringSlice("tls-client-ca-file")); err != nil {
+				return err
+			}
+		}
+
+		if c.IsSet("tls-crl-file") {
+			if err := conf.SetupCrls(c.StringSlice("tls-crl-file")); err != nil {
 				return err
 			}
 		}

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -266,7 +266,7 @@ func NewConfig() *Config {
 
 func (config *Config) SetupCrls(crlFiles []string) error {
 	for _, crlFile := range crlFiles {
-		crlBytes, err := ioutil.ReadFile(crlFile)
+		crlBytes, err := os.ReadFile(crlFile)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Hi! 

CRL feature does not seem to work. There are two main issues with it:
1) CRLs are loaded into `Config` structure, but **are not used anywhere**. I've implemented `VerifyPeerCertificate` function in config.TlsConfig
2) Even with implemented `VerifyPeerCertificate`, CRLs do not work since CRL loading occurs earlier, than CA loading. Smokescreen cannot find CA for CRL and fails. That's why I rearranged them.

I wrote an integration test with its own CA generation procedure - I did not want to figure how to use your test PKI in testdata, so I generate PKI on the fly and clean it up afterwards. 

This may look terrible, as it is just a draft. I'll clean it up, fix deprecation issues and resolve any of your comments if you are willing to merge it. 