### PR TITLE
[Fix] Add validation for Default ACL Rules

### DIFF
--- a/pkg/smokescreen/acl/v1/acl.go
+++ b/pkg/smokescreen/acl/v1/acl.go
@@ -215,6 +215,17 @@ func (acl *ACL) Validate() error {
 			return err
 		}
 	}
+	if acl.DefaultRule != nil {
+		err := acl.ValidateRule("default_rule", *acl.DefaultRule)
+		if err != nil {
+			return err
+		}
+		err = acl.PolicyDisabled("default_rule", acl.DefaultRule.Policy)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/smokescreen/acl/v1/acl_test.go
+++ b/pkg/smokescreen/acl/v1/acl_test.go
@@ -410,3 +410,18 @@ func TestInvalidMitmComfig(t *testing.T) {
 	err := acl.Validate()
 	a.Error(err)
 }
+func TestDefaultRuleValidationWithDisableActions(t *testing.T) {
+	a := assert.New(t)
+	logger := logrus.New()
+
+	// Config with open default rule
+	yamlFilePath := path.Join("testdata", "sample_default_bypass_config.yaml")
+	yl := NewYAMLLoader(yamlFilePath)
+
+	// Attempt to load the ACL with "open" policy disabled
+	acl, err := New(logger, yl, []string{"open"})
+
+	// Updated behavior: An error should be returned because the default rule uses a disabled "open" policy.
+	a.Error(err, "ACL loading should have errored due to invalid default rule.")
+	a.Nil(acl, "ACL should not be loaded when the default rule is invalid.")
+}

--- a/pkg/smokescreen/acl/v1/acl_test.go
+++ b/pkg/smokescreen/acl/v1/acl_test.go
@@ -421,7 +421,6 @@ func TestDefaultRuleValidationWithDisableActions(t *testing.T) {
 	// Attempt to load the ACL with "open" policy disabled
 	acl, err := New(logger, yl, []string{"open"})
 
-	// Updated behavior: An error should be returned because the default rule uses a disabled "open" policy.
 	a.Error(err, "ACL loading should have errored due to invalid default rule.")
 	a.Nil(acl, "ACL should not be loaded when the default rule is invalid.")
 }

--- a/pkg/smokescreen/acl/v1/acl_test.go
+++ b/pkg/smokescreen/acl/v1/acl_test.go
@@ -424,3 +424,18 @@ func TestDefaultRuleValidationWithDisableActions(t *testing.T) {
 	a.Error(err, "ACL loading should have errored due to invalid default rule.")
 	a.Nil(acl, "ACL should not be loaded when the default rule is invalid.")
 }
+
+func TestDefaultRuleValidationWithInvalidGlob(t *testing.T) {
+	a := assert.New(t)
+	logger := logrus.New()
+
+	// Config with open default rule
+	yamlFilePath := path.Join("testdata", "contains_invalid_glob_default.yaml")
+	yl := NewYAMLLoader(yamlFilePath)
+
+	// Attempt to load the ACL with "open" policy disabled
+	acl, err := New(logger, yl, []string{"open"})
+
+	a.Error(err, "ACL loading should have errored due to invalid default rule.")
+	a.Nil(acl, "ACL should not be loaded when the default rule is invalid.")
+}

--- a/pkg/smokescreen/acl/v1/testdata/contains_invalid_glob_default.yaml
+++ b/pkg/smokescreen/acl/v1/testdata/contains_invalid_glob_default.yaml
@@ -1,0 +1,13 @@
+---
+version: v1
+services:
+  - name: dummy-glob
+    project: phony
+    action: enforce
+
+
+default:
+    project: security
+    action: enforce
+    allowed_domains:
+      - "*bob.example.com"

--- a/pkg/smokescreen/acl/v1/testdata/sample_default_bypass_config.yaml
+++ b/pkg/smokescreen/acl/v1/testdata/sample_default_bypass_config.yaml
@@ -1,0 +1,12 @@
+version: v1
+services:
+  - name: some-service # Keep at least one valid service to ensure basic parsing works
+    project: test-project
+    action: enforce
+    allowed_domains:
+      - "example.com"
+default:
+  project: default-project
+  action: open # This policy will be globally disabled
+  allowed_domains:
+    - "allowedbydefault.com"


### PR DESCRIPTION
## Description
 The default rule within an ACL configuration file was not subjected to the same validation checks as named service-specific rules.  Specifically, if an administrator globally disables an enforcement policy (e.g., the "open" policy), this disablement is not honored for the default rule. 

 This change checks that the every rule in ACL including default rule has a conformant domain glob and is not utilizing a disabled enforcement policy
 
 ## Testing
 ### Normal server start
```
smokescreen [saurabhbhatia/default_bypass_fix] go run . --config-file config.yaml --egress-acl-file acl.yaml 
warn: no statsd addr provided, using noop client
{"level":"info","msg":"Loading egress ACL from acl.yaml","time":"2025-05-15T18:31:06.02364+05:30"}
{"level":"info","msg":"starting","time":"2025-05-15T18:31:06+05:30"}
  
```
### Server start with default disable open policy

 ```
 ☁  smokescreen [saurabhbhatia/default_bypass_fix] cat acl.yaml
# acl.yaml
---
version: v1
services: []
default:
  name: default
  project: security
  action: open
  allowed_domains: 
    - api.github.com
☁  smokescreen [saurabhbhatia/default_bypass_fix] go run . --config-file config.yaml --egress-acl-file acl.yaml --disable-acl-policy-action open 
warn: no statsd addr provided, using noop client
{"level":"info","msg":"Loading egress ACL from acl.yaml","time":"2025-05-15T18:35:11.23607+05:30"}
{"level":"info","msg":"rule for svc:default_rule utilizes a disabled policy:Open","time":"2025-05-15T18:35:11.236735+05:30"}
panic: runtime error: invalid memory address or nil pointer dereference
```
