### PR TITLE
fix: timer metrics unit

### DIFF
--- a/pkg/smokescreen/metrics/prometheus_metrics.go
+++ b/pkg/smokescreen/metrics/prometheus_metrics.go
@@ -197,13 +197,13 @@ func (mc *PrometheusMetricsClient) observeValuePrometheusTimer(
 	tags map[string]string) {
 	timerMetric := metric + "_timer"
 	if existingHistogram, ok := mc.timings[timerMetric]; ok {
-		existingHistogram.With(tags).Observe(float64(duration.Milliseconds()))
+		existingHistogram.With(tags).Observe(float64(duration.Seconds()))
 	} else {
 		histogram := promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name: timerMetric,
 		}, mapKeys(tags))
 
-		histogram.With(tags).Observe(float64(duration.Milliseconds()))
+		histogram.With(tags).Observe(float64(duration.Seconds()))
 		mc.timings[timerMetric] = *histogram
 	}
 }


### PR DESCRIPTION
[Histograms are built](https://github.com/stripe/smokescreen/blob/1b618edf4d3dda409ab7a00cdf3f202e143b5289/pkg/smokescreen/metrics/prometheus_metrics.go#L202-L204) using the default bucket definitions:

> If `Buckets` is left as nil or set to a slice of length zero, it is replaced by default buckets.
>
> The default buckets are `DefBuckets` if no buckets for a native histogram (see below) are used, otherwise the default is no buckets.

And `DefBuckets` is:

> ```go
> var DefBuckets = [][float64](https://pkg.go.dev/builtin#float64){.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}
> ```
>
> `DefBuckets` are the default Histogram buckets.
>
> The default buckets are tailored to broadly measure the response time **(in seconds)** of a network service.

The timers were measuring values in milliseconds, whereas the underlying buckets are configured to store number as seconds.

I spotted the misconfiguration by checking the DNS resolution timers on our deployments: most of the timers are between 5 and 10 ms (to the last 2 buckets) and all the initial buckets are almost not used.

Changing to seconds instead of milliseconds would fill up in our case the first 2 or 3 buckets and show the higher latencies (if any) more correctly.