### PR TITLE
Add log enrichment with role in HTTP proxy mode

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -503,6 +503,9 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 
 		sctx.Decision, sctx.lookupTime, pctx.Error = checkIfRequestShouldBeProxied(config, req, destination)
 
+		// add context fields to all future log messages sent using this smokescreen context's Logger
+		sctx.Logger = sctx.Logger.WithFields(extractContextLogFields(pctx, sctx))
+
 		// Returning any kind of response in this handler is goproxy's way of short circuiting
 		// the request. The original request will never be sent, and goproxy will invoke our
 		// response filter attached via the OnResponse() handler.

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -504,7 +504,7 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 		sctx.Decision, sctx.lookupTime, pctx.Error = checkIfRequestShouldBeProxied(config, req, destination)
 
 		// add context fields to all future log messages sent using this smokescreen context's Logger
-		sctx.Logger = sctx.Logger.WithFields(extractContextLogFields(pctx, sctx))
+		// sctx.Logger = sctx.Logger.WithFields(extractContextLogFields(pctx, sctx))
 
 		// Returning any kind of response in this handler is goproxy's way of short circuiting
 		// the request. The original request will never be sent, and goproxy will invoke our

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -504,7 +504,7 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 		sctx.Decision, sctx.lookupTime, pctx.Error = checkIfRequestShouldBeProxied(config, req, destination)
 
 		// add context fields to all future log messages sent using this smokescreen context's Logger
-		// sctx.Logger = sctx.Logger.WithFields(extractContextLogFields(pctx, sctx))
+		sctx.Logger = sctx.Logger.WithFields(extractContextLogFields(pctx, sctx))
 
 		// Returning any kind of response in this handler is goproxy's way of short circuiting
 		// the request. The original request will never be sent, and goproxy will invoke our


### PR DESCRIPTION
## Problem
CANONICAL-PROXY-DECISION logs were inconsistent in their role logging behavior. Specifically for HTTP requests, role information was missing from logs.

## Root Cause
The issue was in library's request handling logic:
CONNECT requests properly enriched the logger context with role information via extractContextLogFields() before generating logs.
HTTP requests were missing this logger context enrichment step, so when logProxy() generated CANONICAL-PROXY-DECISION logs, the role information wasn't available in the logger context.

## Solution
Added the missing logger context enrichment for HTTP requests. After this both HTTP and CONNECT requests follow the same pattern for enriching the logger context with role information before logs are generated.

## Test Coverage
Added test TestRoleLoggingInCanonicalProxyDecision that verifies:
* HTTP requests now include role information in CANONICAL-PROXY-DECISION logs
* CONNECT requests continue to work correctly (no regession)
* Both request types have proper proxy_type field for identification
* Role extraction works end-to-end for both modes