### PR TITLE
Include status code in timeout response logs

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -366,6 +366,7 @@ func rejectResponse(pctx *goproxy.ProxyCtx, err error) *http.Response {
 			status = "Gateway timeout"
 			code = http.StatusGatewayTimeout
 			msg = "Timed out connecting to remote host: " + e.Error()
+			sctx.Logger = sctx.Logger.WithField("status_code", code)
 
 		} else if e, ok := err.(*net.DNSError); ok {
 			status = "Bad gateway"

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -366,7 +366,6 @@ func rejectResponse(pctx *goproxy.ProxyCtx, err error) *http.Response {
 			status = "Gateway timeout"
 			code = http.StatusGatewayTimeout
 			msg = "Timed out connecting to remote host: " + e.Error()
-			sctx.Logger = sctx.Logger.WithField("status_code", code)
 
 		} else if e, ok := err.(*net.DNSError); ok {
 			status = "Bad gateway"
@@ -387,6 +386,7 @@ func rejectResponse(pctx *goproxy.ProxyCtx, err error) *http.Response {
 		msg = "An unexpected error occurred: " + err.Error()
 		sctx.Logger.WithField("error", err.Error()).Warn("rejectResponse called with unexpected error")
 	}
+	sctx.Logger = sctx.Logger.WithField("status_code", code)
 
 	// Do not double log deny errors, they are logged in a previous call to logProxy.
 	if _, ok := err.(denyError); !ok {

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -703,6 +703,7 @@ func TestProxyTimeouts(t *testing.T) {
 
 		r.Equal("http", entry.Data["proxy_type"])
 		r.Contains(entry.Data["error"], "i/o timeout")
+		r.equal(entry.Data["status_code"], 504)
 	})
 
 	// This isn't quite correct, as there is some nondeterministic behavior with the way

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -703,7 +703,7 @@ func TestProxyTimeouts(t *testing.T) {
 
 		r.Equal("http", entry.Data["proxy_type"])
 		r.Contains(entry.Data["error"], "i/o timeout")
-		r.equal(entry.Data["status_code"], 504)
+		r.Equal(entry.Data["status_code"], 504)
 	})
 
 	// This isn't quite correct, as there is some nondeterministic behavior with the way


### PR DESCRIPTION
### Summary
In this PR, I have included the response status_code inside the log entry object for HTTP error responses.

### Motivation
To analyze and log errors in http responses, we need various information, one of them being HTTP status code. Hence including its value in the log entry would help check for certain conditions, especially during logging.
