### PR TITLE
Enable logging when requested IP is in deny list

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -283,6 +283,11 @@ func selectTargetAddr(config *Config, ips []net.IP, port int) (*net.TCPAddr, err
 		if classification.IsAllowed() {
 			if len(config.TemporarilyDeferredIPs) > 0 && addrIsTemporarilyDeferred(config.TemporarilyDeferredIPs, targetAddr) {
 				// IP is allowed but temporarily deferred, save for fallback
+				config.Log.WithFields(logrus.Fields{
+					"ip":     targetAddr.IP.String(),
+					"port":   targetAddr.Port,
+					"reason": "IP is temporarily deny-listed",
+				}).Info("Temporarily denying IP, will be used as fallback")
 				fallbackTargets = append(fallbackTargets, targetAddr)
 				continue
 			}


### PR DESCRIPTION
### Notify
cc @stripe-internal/network-infra
r?

<!--
Assign codeowner reviewers by commenting `r?` on a single line. See go/code-review for more guidance on the code review process.

If you'd like to get an extra review from a language expert, add `r? @stripe-internal/go-tutors` to assign one!

More information on extra language reviews at go/go-language-reviews.
-->

### Summary
<!-- What does the code do? What have you changed? If this is a command-line utility change, consider including before / after output. -->
This PR adds a log statement which is emitted whenever the requested IP is temporarily deny-listed, and is used as a fallback when no other IPs are available to connect.
### Motivation
<!-- Why are you making this change? This can be a link to a Jira task. -->
This helps to add observability for the IP deny-listing and helps in debugging.

### Test plan
<!-- How did you test this change? What were you unable to test? Please include additional context, e.g. were you able to cover failures and edge cases? Reference automated tests or describe a manual test plan and confirm the outcome. Please keep the frontpage test, our auditors (who review a random sample of our PRs), and your reviewer in mind. In cases where you are unable to test your changes, or it is not appropriate, please leave both boxes unchecked. -->

- [ ] All changes in PR are covered by tests
- [ ] Failures and edge cases tested

### Rollout/revert plan
<!-- What services must be deployed as part of this change? Tag these services (or comment `s: example-srv` to have CIBot tag them) so that they are autodeployed. -->

  <!-- If there are any post-deploy steps (e.g. run migration or enable feature flag), or manual/unusual deploy processes required, list them here. -->
  <!-- Is this change safe to roll back, and are there additional steps that need to be taken during rollback? -->

  <!-- Changes in the critical payments path must be decoupled from the deploy (eg: by a feature flag or gate). -->
  <!-- See go/code-reviewer-guide and go/safe-payflows-rollouts for details. -->

Safe to revert unless specified otherwise

### Monitoring plan
<!-- Please choose at least one and fill out the appropriate field. The PR must have a monitoring plan. -->

- [ ] Change has no runtime impact
- [ ] Change is covered by automated alerts
- [ ] Change has other coverage (e.g. Splunk, Dashboards, Sentry, Queries, etc) <!-- provide details below -->
