### PR TITLE
Add fix for denying CGNAT IPs

### DIFF
--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -77,6 +77,14 @@ func TestClassifyAddr(t *testing.T) {
 		testCase{"172.16.1.1", 1, ipAllowUserConfigured},
 		testCase{"192.168.0.1", 1, ipDenyPrivateRange},
 		testCase{"192.168.1.1", 1, ipAllowUserConfigured},
+
+		// CGNAT blocked networks (RFC 6598)
+		testCase{"100.64.0.1", 1, ipDenyCGNAT},
+		testCase{"100.64.0.100", 1, ipDenyCGNAT},
+		testCase{"100.127.255.254", 1, ipDenyCGNAT},
+		testCase{"100.63.255.254", 1, ipAllowDefault}, // Just outside CGNAT range
+		testCase{"100.128.0.1", 1, ipAllowDefault},    // Just outside CGNAT range
+
 		testCase{"8.8.8.8", 321, ipDenyUserConfigured},
 		testCase{"1.1.1.1", 1, ipDenyUserConfigured},
 
@@ -331,6 +339,11 @@ func TestUnsafeAllowPrivateRanges(t *testing.T) {
 		testCase{"172.16.1.1", 1, ipAllowDefault},
 		testCase{"192.168.0.1", 1, ipDenyUserConfigured},
 		testCase{"192.168.1.1", 1, ipAllowDefault},
+
+		// CGNAT blocked networks (RFC 6598) - should still be blocked even with UnsafeAllowPrivateRanges
+		testCase{"100.64.0.1", 1, ipDenyCGNAT},
+		testCase{"100.64.0.100", 1, ipDenyCGNAT},
+		testCase{"100.127.255.254", 1, ipDenyCGNAT},
 
 		// localhost
 		testCase{"127.0.0.1", 1, ipDenyNotGlobalUnicast},


### PR DESCRIPTION
### Notify
cc @stripe-internal/network-infra 
r? @sohamsen-stripe 

<!--
Assign codeowner reviewers by commenting `r?` on a single line. See go/code-review for more guidance on the code review process.

If you'd like to get an extra review from a language expert, add `r? @stripe-internal/go-tutors` to assign one!

More information on extra language reviews at go/go-language-reviews.
-->

### Summary
<!-- What does the code do? What have you changed? If this is a command-line utility change, consider including before / after output. -->
This PR enables Smokescreen to deny CGNAT IPs.

### Motivation
<!-- Why are you making this change? This can be a link to a Jira task. -->
Smokescreen's IP address validation logic in classifyAddr does not block the [Carrier-Grade NAT (CGNAT)](https://en.wikipedia.org/wiki/Carrier-grade_NAT) address space, 100.64.0.0/10. This range, defined in [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598), is intended for use within service provider networks and is not publicly routable. Because Go's standard library does not treat this range as private, Smokescreen's default configuration allows connections to hosts resolving to CGNAT IPs. This creates a Server-Side Request Forgery (SSRF) vulnerability, as an attacker could force Smokescreen to connect to services within the hosting provider's internal network that are not intended to be publicly accessible.
### Test plan
<!-- How did you test this change? What were you unable to test? Please include additional context, e.g. were you able to cover failures and edge cases? Reference automated tests or describe a manual test plan and confirm the outcome. Please keep the frontpage test, our auditors (who review a random sample of our PRs), and your reviewer in mind. In cases where you are unable to test your changes, or it is not appropriate, please leave both boxes unchecked. -->


Before my changes:


https://github.com/user-attachments/assets/2ecfa129-54be-4b86-9c3a-9fd9e5405ce1





Note: The host is not reachable (even by simple curl). But the video shows that the smokescreen allows the denied IP.

After my changes:

https://github.com/user-attachments/assets/cbd46a85-269f-47cf-9936-05d034a4d368


- [x] All changes in PR are covered by tests
- [x] Failures and edge cases tested

### Rollout/revert plan
<!-- What services must be deployed as part of this change? Tag these services (or comment `s: example-srv` to have CIBot tag them) so that they are autodeployed. -->

  <!-- If there are any post-deploy steps (e.g. run migration or enable feature flag), or manual/unusual deploy processes required, list them here. -->
  <!-- Is this change safe to roll back, and are there additional steps that need to be taken during rollback? -->

  <!-- Changes in the critical payments path must be decoupled from the deploy (eg: by a feature flag or gate). -->
  <!-- See go/code-reviewer-guide and go/safe-payflows-rollouts for details. -->

Safe to revert unless specified otherwise

### Monitoring plan
<!-- Please choose at least one and fill out the appropriate field. The PR must have a monitoring plan. -->

- [ ] Change has no runtime impact
- [ ] Change is covered by automated alerts
- [ ] Change has other coverage (e.g. Splunk, Dashboards, Sentry, Queries, etc) <!-- provide details below -->
