### PR TITLE
Sanitize client role before emitting metrics

### DIFF
--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stripe/smokescreen/pkg/smokescreen/metrics"
 )
 
 const (
@@ -92,7 +93,7 @@ func (ic *InstrumentedConn) Close() error {
 	duration := end.Sub(ic.Start).Seconds()
 
 	tags := map[string]string{
-		"role": ic.Role,
+		"role": metrics.SanitizeTagValue(ic.Role),
 	}
 
 	ic.tracker.statsc.IncrWithTags("cn.close", tags, 1)

--- a/pkg/smokescreen/metrics/metrics.go
+++ b/pkg/smokescreen/metrics/metrics.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"errors"
 	"net"
+	"regexp"
 	"syscall"
 	"time"
 )
@@ -78,4 +79,13 @@ func ReportConnError(mc MetricsClientInterface, err error) {
 	}
 
 	mc.IncrWithTags("cn.atpt.connect.err", errorTag, 1)
+}
+
+// SanitizeTagValue sanitizes tag values to prevent injection attacks in both
+// StatsD and Prometheus metrics. This removes or replaces characters that could
+// be used to inject malicious content through metric tags.
+func SanitizeTagValue(value string) string {
+	dangerousChars := regexp.MustCompile(`[|@#:"}{\\[:cntrl:]]`)
+
+	return dangerousChars.ReplaceAllString(value, "_")
 }

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -1145,7 +1145,7 @@ func checkACLsForRequest(config *Config, req *http.Request, destination hostport
 	}
 
 	tags := map[string]string{
-		"role":     decision.Role,
+		"role":     metrics.SanitizeTagValue(decision.Role),
 		"def_rule": fmt.Sprintf("%t", ACLDecision.Default),
 		"project":  ACLDecision.Project,
 	}


### PR DESCRIPTION
### Notify
cc @stripe-internal/network-infra 
r? @sohamsen-stripe 

<!--
Assign codeowner reviewers by commenting `r?` on a single line. See go/code-review for more guidance on the code review process.

If you'd like to get an extra review from a language expert, add `r? @stripe-internal/go-tutors` to assign one!

More information on extra language reviews at go/go-language-reviews.
-->

### Summary
<!-- What does the code do? What have you changed? If this is a command-line utility change, consider including before / after output. -->
This PR sanitizes the client role string by replacing delimeters with underscore.

### Motivation
<!-- Why are you making this change? This can be a link to a Jira task. -->
Smokescreen derives the client “role” from the Common Name (CN) of the mTLS client certificate and emits it verbatim as a metric tag/label. In the ACL decision path, this value flows into StatsD and/or Prometheus metrics without sanitization by Smokescreen.
For StatsD, while the vendored client strips newlines, it does not sanitize section delimiters like | and #; embedding those inside the role tag breaks DogStatsD grammar so the line is rejected and the metric is lost.
For Prometheus, label values are used verbatim, allowing scrape poisoning and high-cardinality label attacks. The code sanitizes the metric name in Prometheus but not label keys/values, and Smokescreen performs no sanitization for tag values.
### Test plan
<!-- How did you test this change? What were you unable to test? Please include additional context, e.g. were you able to cover failures and edge cases? Reference automated tests or describe a manual test plan and confirm the outcome. Please keep the frontpage test, our auditors (who review a random sample of our PRs), and your reviewer in mind. In cases where you are unable to test your changes, or it is not appropriate, please leave both boxes unchecked. -->

Based on the steps given in the ticket, I tested my changes in 2 ways:

**1. statsd-exporter**

Before my changes:


https://github.com/user-attachments/assets/bc614a01-7d73-40c2-acae-352b7eaf5856

After my changes:




https://github.com/user-attachments/assets/1626aeb8-3337-4577-b560-883eefc3123f


**2. Prometheus metrics**

Before my changes:

https://github.com/user-attachments/assets/a7bdbace-28b8-4c2d-b5e7-ee023420297f




After my changes:


https://github.com/user-attachments/assets/34c7173c-8f11-44d9-8f8d-f3f63b315cdc





- [ ] All changes in PR are covered by tests
- [x] Failures and edge cases tested

### Rollout/revert plan
<!-- What services must be deployed as part of this change? Tag these services (or comment `s: example-srv` to have CIBot tag them) so that they are autodeployed. -->

  <!-- If there are any post-deploy steps (e.g. run migration or enable feature flag), or manual/unusual deploy processes required, list them here. -->
  <!-- Is this change safe to roll back, and are there additional steps that need to be taken during rollback? -->

  <!-- Changes in the critical payments path must be decoupled from the deploy (eg: by a feature flag or gate). -->
  <!-- See go/code-reviewer-guide and go/safe-payflows-rollouts for details. -->

Safe to revert unless specified otherwise

### Monitoring plan
<!-- Please choose at least one and fill out the appropriate field. The PR must have a monitoring plan. -->

- [ ] Change has no runtime impact
- [ ] Change is covered by automated alerts
- [ ] Change has other coverage (e.g. Splunk, Dashboards, Sentry, Queries, etc) <!-- provide details below -->
