### PR TITLE
Revert "Add timeout for client request headers"

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -70,11 +70,6 @@ type Config struct {
 	// A connection is idle if it has been inactive (no bytes in/out) for this many seconds.
 	IdleTimeout time.Duration
 
-	// HTTP server timeouts to prevent DoS attacks
-	ReadHeaderTimeout time.Duration // Maximum time to read request headers
-	ReadTimeout       time.Duration // Maximum time to read entire request
-	WriteTimeout      time.Duration // Maximum time to write response
-
 	// These are *only* used for traditional HTTP proxy requests
 	TransportMaxIdleConns        int
 	TransportMaxIdleConnsPerHost int
@@ -274,10 +269,6 @@ func NewConfig() *Config {
 		ShuttingDown:            atomic.Value{},
 		MetricsClient:           metrics.NewNoOpMetricsClient(),
 		Network:                 "ip",
-		// Set secure defaults to prevent DoS attacks
-		ReadHeaderTimeout: 5 * time.Second,
-		ReadTimeout:       5 * time.Second,
-		WriteTimeout:      5 * time.Second,
 	}
 }
 

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -42,11 +42,6 @@ type yamlConfig struct {
 	IdleTimeout    time.Duration  `yaml:"idle_timeout"`
 	ExitTimeout    *time.Duration `yaml:"exit_timeout"`
 
-	// HTTP server timeouts to prevent DoS attacks
-	ReadHeaderTimeout time.Duration `yaml:"read_header_timeout"`
-	ReadTimeout       time.Duration `yaml:"read_timeout"`
-	WriteTimeout      time.Duration `yaml:"write_timeout"`
-
 	StatsSocketDir      string `yaml:"stats_socket_dir"`
 	StatsSocketFileMode string `yaml:"stats_socket_file_mode"`
 
@@ -107,17 +102,6 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	c.ConnectTimeout = yc.ConnectTimeout
 	if yc.ExitTimeout != nil {
 		c.ExitTimeout = *yc.ExitTimeout
-	}
-
-	// Apply HTTP server timeouts if configured, otherwise keep defaults
-	if yc.ReadHeaderTimeout != 0 {
-		c.ReadHeaderTimeout = yc.ReadHeaderTimeout
-	}
-	if yc.ReadTimeout != 0 {
-		c.ReadTimeout = yc.ReadTimeout
-	}
-	if yc.WriteTimeout != 0 {
-		c.WriteTimeout = yc.WriteTimeout
 	}
 
 	err = c.SetupStatsd(yc.StatsdAddress)

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -903,10 +903,7 @@ func StartWithConfig(config *Config, quit <-chan interface{}) {
 	}
 
 	server := http.Server{
-		Handler:           handler,
-		ReadHeaderTimeout: config.ReadHeaderTimeout,
-		ReadTimeout:       config.ReadTimeout,
-		WriteTimeout:      config.WriteTimeout,
+		Handler: handler,
 	}
 
 	// This sets an IdleTimeout on _all_ client connections. CONNECT requests


### PR DESCRIPTION
Reverts stripe/smokescreen#262 due CI timeouts