### PR TITLE
Implement tunnel limiting in smokescreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Here are the options you can give Smokescreen:
    --max-request-rate value                    Maximum requests per second. 0 = unlimited (default: 0)
    --max-request-burst value                   Maximum burst capacity. Must be > max-request-rate when specified.
                                                  Omit to use default (2x max-request-rate).
+   --max-concurrent-connect-tunnels value      Maximum number of concurrent CONNECT tunnels.
+                                                 Unlike max-concurrent-requests, this limits actual long-lived connections.
+                                                 0 = unlimited (default: 0)
    --dns-timeout DURATION                      Maximum time to wait for DNS resolution (default: 5s)
    --version, -v                               print the version
 ```
@@ -138,10 +141,13 @@ Smokescreen supports rate and concurrency limiting to protect against overload:
 | `max-concurrent-requests` | Limits simultaneous in-flight requests. Excess requests receive `503 Service Unavailable`. |
 | `max-request-rate` | Limits requests per second using a token bucket algorithm. Excess requests receive `429 Too Many Requests`. |
 | `max-request-burst` | Sets token bucket capacity. Must be greater than `max-request-rate`. Defaults to 2x the rate if omitted. |
+| `max-concurrent-connect-tunnels` | Limits the number of active CONNECT tunnels (long-lived connections). Unlike `max-concurrent-requests` which only tracks request processing time, this limits actual tunnel connections and prevents resource exhaustion from unbounded CONNECT tunnels. Excess requests receive `429 Too Many Requests`. |
+
+> **Note:** `max-concurrent-requests` limits the number of requests being *processed*, while `max-concurrent-connect-tunnels` limits the number of active *tunnel connections*. For CONNECT requests, the request processing completes quickly but the tunnel connection remains open. Use both settings together for complete protection against resource exhaustion.
 
 **Example (CLI):**
 ```bash
-smokescreen --max-concurrent-requests=100 --max-request-rate=50
+smokescreen --max-concurrent-requests=100 --max-request-rate=50 --max-concurrent-connect-tunnels=50
 ```
 
 **Example (YAML):**
@@ -149,6 +155,7 @@ smokescreen --max-concurrent-requests=100 --max-request-rate=50
 max_concurrent_requests: 100
 max_request_rate: 50
 max_request_burst: 150  # optional, defaults to 2x rate
+max_concurrent_connect_tunnels: 50  # limits active CONNECT tunnel connections
 ```
 
 ### Hostname ACLs

--- a/cmd/smokescreen.go
+++ b/cmd/smokescreen.go
@@ -170,6 +170,11 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			Value: smokescreen.DefaultMaxRequestBurst,
 			Usage: "Maximum burst capacity for rate limiting.\n\t\tMust be greater than max-request-rate when specified.\n\t\tOmit to use default (2x max-request-rate).",
 		},
+		cli.IntFlag{
+			Name:  "max-concurrent-connect-tunnels",
+			Value: smokescreen.DefaultMaxConcurrentConnectTunnels,
+			Usage: "Maximum number of concurrent CONNECT tunnels.\n\t\tUnlike max-concurrent-requests, this limits actual long-lived connections.\n\t\t0 = unlimited (default).",
+		},
 		cli.DurationFlag{
 			Name:  "dns-timeout",
 			Value: smokescreen.DefaultDNSTimeout,
@@ -331,6 +336,11 @@ func NewConfiguration(args []string, logger *log.Logger) (*smokescreen.Config, e
 			if err := conf.SetRateLimits(maxConcurrent, maxRate, maxBurst); err != nil {
 				return err
 			}
+		}
+
+		if c.IsSet("max-concurrent-connect-tunnels") {
+			maxTunnels := c.Int("max-concurrent-connect-tunnels")
+			conf.MaxConcurrentConnectTunnels = maxTunnels
 		}
 
 		if c.IsSet("dns-timeout") {

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -67,7 +67,10 @@ type yamlConfig struct {
 	MaxRequestRate        float64 `yaml:"max_request_rate"`
 	MaxRequestBurst       *int    `yaml:"max_request_burst"`
 
-	DNSTimeout            time.Duration `yaml:"dns_timeout"`
+	// Tunnel limiting (for long-lived CONNECT connections)
+	MaxConcurrentConnectTunnels int `yaml:"max_concurrent_connect_tunnels"`
+
+	DNSTimeout time.Duration `yaml:"dns_timeout"`
 }
 
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -224,6 +227,11 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if err := c.SetRateLimits(yc.MaxConcurrentRequests, yc.MaxRequestRate, maxBurst); err != nil {
 			return err
 		}
+	}
+
+	// Set tunnel limit for CONNECT connections
+	if yc.MaxConcurrentConnectTunnels > 0 {
+		c.MaxConcurrentConnectTunnels = yc.MaxConcurrentConnectTunnels
 	}
 
 	if yc.DNSTimeout > 0 {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -92,6 +92,9 @@ type SmokescreenContext struct {
 	// This is an explicit flag that ensures role reuse only for CONNECT MITM requests
 	// and prevents attacks that try to reuse the role for traditional HTTP proxy requests.
 	isConnectMitm bool
+	// tunnelSlotAcquired indicates whether a tunnel limiter slot was acquired for this connection.
+	// If true, the slot must be released when the connection closes.
+	tunnelSlotAcquired bool
 }
 
 // ExitStatus is used to log Smokescreen's connection status at shutdown time
@@ -495,6 +498,15 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	// cost incurred by Smokescreen.
 	sctx.cfg.MetricsClient.Timing("proxy_duration_ms", time.Since(sctx.start), 1)
 
+	// For CONNECT tunnels, acquire a tunnel limiter slot before dialing.
+	// Unlike the rate limiter, this tracks actual long-lived tunnel connections.
+	if sctx.ProxyType == connectProxy && sctx.cfg.TunnelLimiter != nil {
+		if !sctx.cfg.TunnelLimiter.Acquire() {
+			return nil, denyError{ErrTunnelLimitExceeded}
+		}
+		sctx.tunnelSlotAcquired = true
+	}
+
 	var conn net.Conn
 	var err error
 
@@ -515,6 +527,13 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 		sctx.cfg.MetricsClient.IncrWithTags("cn.atpt.total", map[string]string{"success": "false"}, 1)
 		sctx.cfg.ConnTracker.RecordAttempt(sctx.RequestedHost, false)
 		metrics.ReportConnError(sctx.cfg.MetricsClient, err)
+
+		// Release tunnel slot if acquired since connection failed
+		if sctx.tunnelSlotAcquired && sctx.cfg.TunnelLimiter != nil {
+			sctx.cfg.TunnelLimiter.Release()
+			sctx.tunnelSlotAcquired = false
+		}
+
 		return nil, err
 	}
 	sctx.cfg.MetricsClient.IncrWithTags("cn.atpt.total", map[string]string{"success": "true"}, 1)
@@ -525,6 +544,16 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	if sctx.ProxyType == connectProxy {
 		ic := sctx.cfg.ConnTracker.NewInstrumentedConnWithTimeout(conn, sctx.cfg.IdleTimeout, sctx.Logger, d.Role, d.OutboundHost, sctx.ProxyType, d.Project)
 		pctx.ConnErrorHandler = ic.Error
+
+		// Set up tunnel limiter release callback.
+		// The slot was acquired above right before dialing, and must be released when the connection closes.
+		if sctx.tunnelSlotAcquired && sctx.cfg.TunnelLimiter != nil {
+			ic.OnClose = func() {
+				sctx.cfg.TunnelLimiter.Release()
+				sctx.tunnelSlotAcquired = false
+			}
+		}
+
 		conn = ic
 	} else {
 		conn = NewTimeoutConn(conn, sctx.cfg.IdleTimeout)
@@ -719,7 +748,7 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 			existingSctx, ok := pctx.UserData.(*SmokescreenContext)
 			if !ok || existingSctx.Decision == nil {
 				config.Log.WithFields(logrus.Fields{
-					"context_valid": ok,
+					"context_valid":    ok,
 					"decision_present": existingSctx != nil && existingSctx.Decision != nil,
 				}).Error("MITM request missing required context or decision from CONNECT phase - rejecting request")
 				err := errors.New("MITM request missing context from CONNECT phase")
@@ -1021,6 +1050,14 @@ func StartWithConfig(config *Config, quit <-chan interface{}) {
 			config.MaxConcurrentRequests, config.MaxRequestRate, config.MaxRequestBurst)
 	}
 
+	if config.MaxConcurrentConnectTunnels > 0 {
+		config.initializeTunnelLimiter()
+		if config.TunnelLimiter != nil {
+			config.Log.Printf("CONNECT tunnel limiting enabled (max_concurrent_tunnels=%d)",
+				config.MaxConcurrentConnectTunnels)
+		}
+	}
+
 	if config.Healthcheck != nil {
 		handler = &HealthcheckMiddleware{
 			Proxy:       handler,
@@ -1274,13 +1311,13 @@ func checkACLsForRequest(config *Config, sctx *SmokescreenContext, req *http.Req
 
 	var role string
 	var roleErr error
-	
+
 	// Check if role is already populated in SmokescreenContext (e.g., from CONNECT in MITM mode)
 	if sctx.isConnectMitm {
 		if sctx.Decision == nil || sctx.Decision.Role == "" {
 			config.Log.WithFields(logrus.Fields{
-				"decision_nil":  sctx.Decision == nil,
-				"role_empty":    sctx.Decision != nil && sctx.Decision.Role == "",
+				"decision_nil": sctx.Decision == nil,
+				"role_empty":   sctx.Decision != nil && sctx.Decision.Role == "",
 			}).Error("MITM request missing required role from CONNECT phase")
 			config.MetricsClient.Incr("acl.role_not_determined", 1)
 			decision.Reason = "Client role cannot be determined"
@@ -1288,7 +1325,7 @@ func checkACLsForRequest(config *Config, sctx *SmokescreenContext, req *http.Req
 		}
 		role = sctx.Decision.Role
 		config.Log.WithFields(logrus.Fields{
-			"role": role,
+			"role":        role,
 			"destination": destination.String(),
 		}).Info("Reusing existing role from context (MITM)")
 	} else {

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -123,6 +123,10 @@ type denyError struct {
 	error
 }
 
+type tunnelLimitError struct {
+	error
+}
+
 func (t ipType) IsAllowed() bool {
 	return t == ipAllowDefault || t == ipAllowUserConfigured
 }
@@ -502,7 +506,7 @@ func dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	// Unlike the rate limiter, this tracks actual long-lived tunnel connections.
 	if sctx.ProxyType == connectProxy && sctx.cfg.TunnelLimiter != nil {
 		if !sctx.cfg.TunnelLimiter.Acquire() {
-			return nil, denyError{ErrTunnelLimitExceeded}
+			return nil, tunnelLimitError{ErrTunnelLimitExceeded}
 		}
 		sctx.tunnelSlotAcquired = true
 	}
@@ -625,6 +629,10 @@ func rejectResponse(pctx *goproxy.ProxyCtx, err error) *http.Response {
 		status = "Request rejected by proxy"
 		code = http.StatusProxyAuthRequired
 		msg = fmt.Sprintf(denyMsgTmpl, pctx.Req.Host, e.Error())
+	} else if e, ok := err.(tunnelLimitError); ok {
+		status = "Too Many Requests"
+		code = http.StatusTooManyRequests
+		msg = e.Error()
 	} else {
 		status = "Internal server error"
 		code = http.StatusInternalServerError
@@ -647,6 +655,11 @@ func rejectResponse(pctx *goproxy.ProxyCtx, err error) *http.Response {
 	resp.ProtoMajor = pctx.Req.ProtoMajor
 	resp.ProtoMinor = pctx.Req.ProtoMinor
 	resp.Header.Set(errorHeader, msg)
+	
+	// Add Retry-After header for tunnel limit errors
+	if _, ok := err.(tunnelLimitError); ok {
+		resp.Header.Set("Retry-After", "1")
+	}
 	if sctx.cfg.RejectResponseHandler != nil {
 		sctx.cfg.RejectResponseHandler(resp)
 	}

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2094,5 +2095,160 @@ func TestRoleLoggingInCanonicalProxyDecision(t *testing.T) {
 
 		r.Contains(proxyDecision.Data, "proxy_type")
 		r.Equal("connect", proxyDecision.Data["proxy_type"])
+	})
+}
+
+func TestMaxConcurrentConnectTunnels(t *testing.T) {
+	r := require.New(t)
+
+	// Create a slow backend that holds connections open
+	slowBackend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// Hold the connection open for a bit
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(200)
+		w.Write([]byte("OK"))
+	}))
+	defer slowBackend.Close()
+
+	t.Run("tunnel limit enforced", func(t *testing.T) {
+		cfg, err := testConfig("test-local-srv")
+		r.NoError(err)
+		err = cfg.SetAllowAddresses([]string{"127.0.0.1"})
+		r.NoError(err)
+
+		// Set tunnel limit to 2
+		cfg.MaxConcurrentConnectTunnels = 2
+		cfg.TunnelLimiter = NewTunnelLimiter(2, cfg)
+
+		l, err := net.Listen("tcp", "localhost:0")
+		r.NoError(err)
+		cfg.Listener = l
+
+		proxySrv := proxyServer(cfg)
+		defer proxySrv.Close()
+
+		// Track results
+		var successCount, rejectCount int32
+		var wg sync.WaitGroup
+
+		// Try to open 5 concurrent CONNECT tunnels
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				client, err := proxyClient(proxySrv.URL)
+				if err != nil {
+					t.Logf("Failed to create client: %v", err)
+					return
+				}
+				client.Timeout = 2 * time.Second
+
+				resp, err := client.Get(slowBackend.URL)
+				if err != nil {
+					// Check if it's a tunnel limit error or rejection
+					if strings.Contains(err.Error(), "Service Unavailable") ||
+						strings.Contains(err.Error(), "maximum concurrent connect tunnels") ||
+						strings.Contains(err.Error(), "Request rejected by proxy") {
+						atomic.AddInt32(&rejectCount, 1)
+					} else {
+						t.Logf("Request error: %v", err)
+					}
+					return
+				}
+				defer resp.Body.Close()
+
+				if resp.StatusCode == 200 {
+					atomic.AddInt32(&successCount, 1)
+				} else if resp.StatusCode == 503 || resp.StatusCode == 407 {
+					atomic.AddInt32(&rejectCount, 1)
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		// With limit of 2, we expect at most 2 successes
+		// Some requests should be rejected
+		t.Logf("Success: %d, Rejected: %d", successCount, rejectCount)
+		r.LessOrEqual(int(successCount), 2, "Should not exceed tunnel limit")
+		r.Greater(int(rejectCount), 0, "Some requests should be rejected")
+	})
+
+	t.Run("tunnel slots released on close", func(t *testing.T) {
+		cfg, err := testConfig("test-local-srv")
+		r.NoError(err)
+		err = cfg.SetAllowAddresses([]string{"127.0.0.1"})
+		r.NoError(err)
+
+		// Set tunnel limit to 1
+		cfg.MaxConcurrentConnectTunnels = 1
+		cfg.TunnelLimiter = NewTunnelLimiter(1, cfg)
+
+		l, err := net.Listen("tcp", "localhost:0")
+		r.NoError(err)
+		cfg.Listener = l
+
+		proxySrv := proxyServer(cfg)
+		defer proxySrv.Close()
+
+		// Quick backend that responds immediately
+		quickBackend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(200)
+			w.Write([]byte("OK"))
+		}))
+		defer quickBackend.Close()
+
+		// Make sequential requests - they should all succeed because
+		// each one completes before the next starts
+		for i := 0; i < 3; i++ {
+			client, err := proxyClient(proxySrv.URL)
+			r.NoError(err)
+			client.Timeout = 5 * time.Second
+
+			resp, err := client.Get(quickBackend.URL)
+			r.NoError(err, "Request %d should succeed", i)
+			resp.Body.Close()
+			r.Equal(200, resp.StatusCode, "Request %d should return 200", i)
+
+			// Wait for connection to fully close
+			cfg.ConnTracker.Wg().Wait()
+		}
+	})
+
+	t.Run("zero limit means unlimited", func(t *testing.T) {
+		cfg, err := testConfig("test-local-srv")
+		r.NoError(err)
+		err = cfg.SetAllowAddresses([]string{"127.0.0.1"})
+		r.NoError(err)
+
+		// Set tunnel limit to 0 (unlimited)
+		cfg.MaxConcurrentConnectTunnels = 0
+		cfg.TunnelLimiter = nil // No limiter when unlimited
+
+		l, err := net.Listen("tcp", "localhost:0")
+		r.NoError(err)
+		cfg.Listener = l
+
+		proxySrv := proxyServer(cfg)
+		defer proxySrv.Close()
+
+		// Quick backend
+		quickBackend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(200)
+			w.Write([]byte("OK"))
+		}))
+		defer quickBackend.Close()
+
+		// Should be able to make many requests
+		for i := 0; i < 5; i++ {
+			client, err := proxyClient(proxySrv.URL)
+			r.NoError(err)
+
+			resp, err := client.Get(quickBackend.URL)
+			r.NoError(err, "Request %d should succeed with no limit", i)
+			resp.Body.Close()
+			r.Equal(200, resp.StatusCode)
+		}
 	})
 }

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -2099,8 +2099,6 @@ func TestRoleLoggingInCanonicalProxyDecision(t *testing.T) {
 }
 
 func TestMaxConcurrentConnectTunnels(t *testing.T) {
-	r := require.New(t)
-
 	// Create a slow backend that holds connections open
 	slowBackend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// Hold the connection open for a bit
@@ -2111,6 +2109,7 @@ func TestMaxConcurrentConnectTunnels(t *testing.T) {
 	defer slowBackend.Close()
 
 	t.Run("tunnel limit enforced", func(t *testing.T) {
+		r := require.New(t)
 		cfg, err := testConfig("test-local-srv")
 		r.NoError(err)
 		err = cfg.SetAllowAddresses([]string{"127.0.0.1"})
@@ -2147,7 +2146,7 @@ func TestMaxConcurrentConnectTunnels(t *testing.T) {
 				resp, err := client.Get(slowBackend.URL)
 				if err != nil {
 					// Check if it's a tunnel limit error or rejection
-					if strings.Contains(err.Error(), "Service Unavailable") ||
+					if strings.Contains(err.Error(), "Too Many Requests") ||
 						strings.Contains(err.Error(), "maximum concurrent connect tunnels") ||
 						strings.Contains(err.Error(), "Request rejected by proxy") {
 						atomic.AddInt32(&rejectCount, 1)
@@ -2160,7 +2159,7 @@ func TestMaxConcurrentConnectTunnels(t *testing.T) {
 
 				if resp.StatusCode == 200 {
 					atomic.AddInt32(&successCount, 1)
-				} else if resp.StatusCode == 503 || resp.StatusCode == 407 {
+				} else if resp.StatusCode == 429 || resp.StatusCode == 407 {
 					atomic.AddInt32(&rejectCount, 1)
 				}
 			}()
@@ -2176,6 +2175,7 @@ func TestMaxConcurrentConnectTunnels(t *testing.T) {
 	})
 
 	t.Run("tunnel slots released on close", func(t *testing.T) {
+		r := require.New(t)
 		cfg, err := testConfig("test-local-srv")
 		r.NoError(err)
 		err = cfg.SetAllowAddresses([]string{"127.0.0.1"})
@@ -2217,6 +2217,7 @@ func TestMaxConcurrentConnectTunnels(t *testing.T) {
 	})
 
 	t.Run("zero limit means unlimited", func(t *testing.T) {
+		r := require.New(t)
 		cfg, err := testConfig("test-local-srv")
 		r.NoError(err)
 		err = cfg.SetAllowAddresses([]string{"127.0.0.1"})

--- a/pkg/smokescreen/tunnel_limiter.go
+++ b/pkg/smokescreen/tunnel_limiter.go
@@ -1,0 +1,72 @@
+package smokescreen
+
+import (
+	"errors"
+	"sync/atomic"
+)
+
+// ErrTunnelLimitExceeded is returned when the maximum number of concurrent tunnels is reached.
+var ErrTunnelLimitExceeded = errors.New("maximum concurrent connect tunnels exceeded")
+
+// TunnelLimiter limits the number of concurrent CONNECT tunnels.
+// Unlike the rate limiter which counts request processing time,
+// this tracks actual long-lived tunnel connections.
+type TunnelLimiter struct {
+	maxTunnels    int64
+	activeTunnels int64
+	config        *Config
+}
+
+// NewTunnelLimiter creates a new tunnel limiter with the specified maximum.
+// If max is 0 or negative, limiting is disabled.
+func NewTunnelLimiter(max int, config *Config) *TunnelLimiter {
+	return &TunnelLimiter{
+		maxTunnels: int64(max),
+		config:     config,
+	}
+}
+
+// Acquire attempts to acquire a tunnel slot.
+// Returns true if successful, false if at capacity.
+func (tl *TunnelLimiter) Acquire() bool {
+	if tl == nil || tl.maxTunnels <= 0 {
+		return true // Limiting disabled
+	}
+
+	for {
+		current := atomic.LoadInt64(&tl.activeTunnels)
+		if current >= tl.maxTunnels {
+			if tl.config != nil && tl.config.MetricsClient != nil {
+				tl.config.MetricsClient.Incr("tunnels.concurrency_limited", 1)
+			}
+			return false
+		}
+		if atomic.CompareAndSwapInt64(&tl.activeTunnels, current, current+1) {
+			return true
+		}
+	}
+}
+
+// Release releases a tunnel slot.
+func (tl *TunnelLimiter) Release() {
+	if tl == nil || tl.maxTunnels <= 0 {
+		return
+	}
+	atomic.AddInt64(&tl.activeTunnels, -1)
+}
+
+// ActiveCount returns the current number of active tunnels.
+func (tl *TunnelLimiter) ActiveCount() int64 {
+	if tl == nil {
+		return 0
+	}
+	return atomic.LoadInt64(&tl.activeTunnels)
+}
+
+// MaxTunnels returns the maximum number of allowed tunnels.
+func (tl *TunnelLimiter) MaxTunnels() int64 {
+	if tl == nil {
+		return 0
+	}
+	return tl.maxTunnels
+}

--- a/pkg/smokescreen/tunnel_limiter_test.go
+++ b/pkg/smokescreen/tunnel_limiter_test.go
@@ -1,0 +1,101 @@
+package smokescreen
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTunnelLimiter_NilLimiter(t *testing.T) {
+	var tl *TunnelLimiter
+
+	// Nil limiter should always allow
+	assert.True(t, tl.Acquire())
+	tl.Release() // Should not panic
+	assert.Equal(t, int64(0), tl.ActiveCount())
+	assert.Equal(t, int64(0), tl.MaxTunnels())
+}
+
+func TestTunnelLimiter_ZeroLimit(t *testing.T) {
+	tl := NewTunnelLimiter(0, nil)
+
+	// Zero limit means disabled - should always allow
+	assert.True(t, tl.Acquire())
+	assert.True(t, tl.Acquire())
+	assert.True(t, tl.Acquire())
+	tl.Release()
+	tl.Release()
+	tl.Release()
+}
+
+func TestTunnelLimiter_BasicLimit(t *testing.T) {
+	tl := NewTunnelLimiter(3, nil)
+
+	// Should allow up to 3
+	assert.True(t, tl.Acquire())
+	assert.Equal(t, int64(1), tl.ActiveCount())
+
+	assert.True(t, tl.Acquire())
+	assert.Equal(t, int64(2), tl.ActiveCount())
+
+	assert.True(t, tl.Acquire())
+	assert.Equal(t, int64(3), tl.ActiveCount())
+
+	// Fourth should fail
+	assert.False(t, tl.Acquire())
+	assert.Equal(t, int64(3), tl.ActiveCount())
+
+	// Release one
+	tl.Release()
+	assert.Equal(t, int64(2), tl.ActiveCount())
+
+	// Now should allow one more
+	assert.True(t, tl.Acquire())
+	assert.Equal(t, int64(3), tl.ActiveCount())
+
+	// Cleanup
+	tl.Release()
+	tl.Release()
+	tl.Release()
+	assert.Equal(t, int64(0), tl.ActiveCount())
+}
+
+func TestTunnelLimiter_ConcurrentAccess(t *testing.T) {
+	const limit = 10
+	const goroutines = 100
+
+	tl := NewTunnelLimiter(limit, nil)
+
+	var acquired int64
+	var wg sync.WaitGroup
+
+	// Try to acquire from many goroutines simultaneously
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if tl.Acquire() {
+				atomic.AddInt64(&acquired, 1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Should have acquired exactly 'limit' slots
+	assert.Equal(t, int64(limit), acquired)
+	assert.Equal(t, int64(limit), tl.ActiveCount())
+
+	// Release all
+	for i := 0; i < limit; i++ {
+		tl.Release()
+	}
+	assert.Equal(t, int64(0), tl.ActiveCount())
+}
+
+func TestTunnelLimiter_MaxTunnels(t *testing.T) {
+	tl := NewTunnelLimiter(42, nil)
+	assert.Equal(t, int64(42), tl.MaxTunnels())
+}


### PR DESCRIPTION
### Summary
This PR does the following:

1. Adds a CONNECT tunnel limiting mechanism to prevent smokescreen resource exhaustion.
2. The tunnel limiter increments the acquired slot on every dialContext call and releases the slot when the connection is closed. This tunnel slot release is invoked upon InstrumentedConn closure, which happens when the tunnel is closed.

NOTE: This allows as many CONNECT requests to call smokescreen, perform ACL checks etc, but only the tunnel limit number of connections can actually call `DialContext()` and establish tunnel. If we want to limit pre-Dial access also, we can configure the rate-limiter and concurrency-limiter for that purpose.

### Motivation
The `max_concurrent_requests` configuration in Smokescreen is ineffective for CONNECT tunnels. The rate limiter acquires a slot when ServeHTTP() starts and releases it via defer when the function returns. For CONNECT requests, goproxy hijacks the connection and ServeHTTP() returns immediately while the tunnel continues in background goroutines. This allows unlimited CONNECT tunnels regardless of the configured limit, enabling resource exhaustion (OOM crash in ~10 seconds with 64MB memory limit).

The current `max_concurrent_requests` is basically limiting the number of connections being served by smokescreen, but does not monitor if they still last. We need a dedicated tunnel limiter for that.

### Test plan

We create 20 non-CONNECT requests and then 20 CONNECT requests to a slow backend via smokescreen proxy. The first 20 requests get handled by the existing concurrency limiter in smokescreen. The tunnel limiting restricts the number of CONNECT requests.

**Before**

We see the number of connections exceeding the `max_concurrent_requests` limit and blocking smokescreen resources for 5 seconds.


https://github.com/user-attachments/assets/1c36a20c-0ee9-4e38-919c-b513d88d0d8a







**After**
We see the tunnel limit is applied and allows only 3 requests. 17 other CONNECT requests are rejected


https://github.com/user-attachments/assets/a48a5225-d34e-407d-b0ec-fde1cbfed1f7








