### PR TITLE
fix(conntrack): correct 'occured' -> 'occurred' in InstrumentedConn.Idle docstring

### DIFF
--- a/pkg/smokescreen/conntrack/instrumented_conn.go
+++ b/pkg/smokescreen/conntrack/instrumented_conn.go
@@ -172,7 +172,7 @@ func (ic *InstrumentedConn) Write(b []byte) (int, error) {
 	return n, err
 }
 
-// Idle returns true when the connection's last activity occured before the
+// Idle returns true when the connection's last activity occurred before the
 // configured idle threshold.
 //
 // Idle should be called with the connection's lock held.


### PR DESCRIPTION
`pkg/smokescreen/conntrack/instrumented_conn.go:175` doc comment on `InstrumentedConn.Idle` reads:

```go
// Idle returns true when the connection's last activity occured before the
// configured idle threshold.
```

Fix the spelling to `occurred`. `go build ./...` and `go vet ./pkg/smokescreen/conntrack/` both clean against current `master`.