### PR TITLE
Skip CRL file when parsing fails to avoid nil dereference

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -482,6 +482,7 @@ func (config *Config) SetupCrls(crlFiles []string) error {
 		certList, err := x509.ParseCRL(crlBytes)
 		if err != nil {
 			log.Printf("Failed to parse CRL in '%s': %#v\n", crlFile, err)
+			continue
 		}
 
 		// find the X509v3 Authority Key Identifier in the extensions (2.5.29.35)


### PR DESCRIPTION
In SetupCrls, when x509.ParseCRL returns an error the error is logged but the loop continues. The very next statement accesses certList.TBSCertList.Extensions, which panics with a nil pointer dereference because certList is nil whenever ParseCRL returns an error.

The fix adds a continue so an unparseable CRL is logged and skipped, matching the pattern used elsewhere in the same loop for other recoverable per-file errors (missing Authority Key Identifier, signature mismatch, unknown issuer).

This affects any deployment that loads CRLs and ever points at a malformed or truncated CRL file. Today that crashes the process at config time instead of failing gracefully.