### PR TITLE
Add more error logs and update goproxy dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
         go-version: ['1.21', '1.22', '1.23']
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
     - name: Setup env
@@ -43,8 +43,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
       - name: Install goveralls 
         run: go install github.com/mattn/goveralls@latest
       - name: Close goveralls parallel build 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
-	github.com/stripe/goproxy v0.0.0-20251009123132-ee3e713dae03
+	github.com/stripe/goproxy v0.0.0-20260615103414-176e55e4af3b
 	golang.org/x/net v0.17.0
 	gopkg.in/urfave/cli.v1 v1.20.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/stripe/goproxy v0.0.0-20250909052350-d1a1594c59ae h1:SNPprcI2Snhux6ba
 github.com/stripe/goproxy v0.0.0-20250909052350-d1a1594c59ae/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/stripe/goproxy v0.0.0-20251009123132-ee3e713dae03 h1:Wrxanw4xr/0OErvwgq/5LGDHMzWFUkPx2gWwM/fChHM=
 github.com/stripe/goproxy v0.0.0-20251009123132-ee3e713dae03/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
+github.com/stripe/goproxy v0.0.0-20260615103414-176e55e4af3b h1:jX6LVUSAoMfMaGJ8LDfdQxIk1DI1FGSwDdgLNZrDSBY=
+github.com/stripe/goproxy v0.0.0-20260615103414-176e55e4af3b/go.mod h1:hF2CVgH4++5ijZiy9grGVP8Fsi4u+SMOtbnIKYbMUjY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -67,6 +67,7 @@ const (
 	LogMitmReqMethod         = "mitm_req_method"
 	LogMitmReqHeaders        = "mitm_req_headers"
 )
+
 type ipType int
 
 type ACLDecision struct {
@@ -623,7 +624,11 @@ func rejectResponse(pctx *goproxy.ProxyCtx, err error) *http.Response {
 		} else {
 			status = "Bad gateway"
 			code = http.StatusBadGateway
-			msg = "Failed to connect to remote host: " + e.Error()
+			errMsg := e.Error()
+			if errMsg == "<nil>" {
+				errMsg = fmt.Sprintf("<nil> (%T)", err)
+			}
+			msg = "Failed to connect to remote host: " + errMsg
 		}
 	} else if e, ok := err.(denyError); ok {
 		status = "Request rejected by proxy"
@@ -655,7 +660,7 @@ func rejectResponse(pctx *goproxy.ProxyCtx, err error) *http.Response {
 	resp.ProtoMajor = pctx.Req.ProtoMajor
 	resp.ProtoMinor = pctx.Req.ProtoMinor
 	resp.Header.Set(errorHeader, msg)
-	
+
 	// Add Retry-After header for tunnel limit errors
 	if _, ok := err.(tunnelLimitError); ok {
 		resp.Header.Set("Retry-After", "1")

--- a/vendor/github.com/stripe/goproxy/https.go
+++ b/vendor/github.com/stripe/goproxy/https.go
@@ -599,7 +599,11 @@ func (proxy *ProxyHttpServer) connectDialProxyWithContext(ctx *ProxyCtx, proxyHo
 		}
 	}
 
-	connectReq.Write(c)
+	if err := connectReq.Write(c); err != nil {
+		c.Close()
+		return nil, fmt.Errorf("connectDialProxyWithContext: write CONNECT request: %w", err)
+	}
+
 	// Read response.
 	// Okay to use and discard buffered reader here, because
 	// TLS server will not speak until spoken to.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/sirupsen/logrus/hooks/test
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
-# github.com/stripe/goproxy v0.0.0-20251009123132-ee3e713dae03
+# github.com/stripe/goproxy v0.0.0-20260615103414-176e55e4af3b
 ## explicit; go 1.13
 github.com/stripe/goproxy
 # golang.org/x/mod v0.8.0


### PR DESCRIPTION
There are cases where go prints the error as `<nil>` defined here: https://cs.opensource.google/go/go/+/refs/tags/go1.26.4:src/net/net.go;l=718-720 

We want to capture the Type error data as well in the error log.

Also updates the goproxy for PR https://github.com/stripe/goproxy/pull/34 

Also updates to use latest github actions as per https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/