### PR TITLE
feat: Config retains the egress ACL file path

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -81,6 +81,7 @@ type Config struct {
 	ExitTimeout                  time.Duration
 	MetricsClient                metrics.MetricsClientInterface
 	EgressACL                    acl.Decider
+	EgressACLFile                string
 	SupportProxyProtocol         bool
 	TlsConfig                    *tls.Config
 	CrlByAuthorityKeyId          map[string]*pkix.CertificateList
@@ -576,6 +577,7 @@ func (config *Config) SetupPrometheus(endpoint string, port string, listenAddr s
 func (config *Config) SetupEgressAcl(aclFile string) error {
 	if aclFile == "" {
 		config.EgressACL = nil
+		config.EgressACLFile = ""
 		return nil
 	}
 
@@ -587,6 +589,7 @@ func (config *Config) SetupEgressAcl(aclFile string) error {
 		return err
 	}
 	config.EgressACL = egressACL
+	config.EgressACLFile = aclFile
 
 	return nil
 }


### PR DESCRIPTION
Allows smokescreen lib clients to perform logic related to the file (hot-reload changes to rules, alert on modifications, etc.) without having to re-parse the file path from the command-line.