### PR TITLE
fix: deny ranges take precedence over allow ranges

### DIFF
--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -310,10 +310,10 @@ func classifyAddr(config *Config, addr *net.TCPAddr) ipType {
 		}
 	}
 
-	if addrIsInRuleRange(config.AllowRanges, addr) {
-		return ipAllowUserConfigured
-	} else if addrIsInRuleRange(config.DenyRanges, addr) {
+	if addrIsInRuleRange(config.DenyRanges, addr) {
 		return ipDenyUserConfigured
+	} else if addrIsInRuleRange(config.AllowRanges, addr) {
+		return ipAllowUserConfigured
 	} else if addrHasIPv6Embedding(addr) {
 		// Block IPv6 addresses that embed IPv4 addresses (NAT64, 6to4, Teredo, IPv4-mapped)
 		// These can bypass IPv4 safety checks and enable SSRF attacks

--- a/pkg/smokescreen/smokescreen_test.go
+++ b/pkg/smokescreen/smokescreen_test.go
@@ -255,6 +255,7 @@ func TestSelectTargetAddr(t *testing.T) {
 		temporarilyDeferredIPs []string
 		allowRanges            []string
 		denyRanges             []string
+		denyAddresses          []string
 		expectedIP             string
 		expectError            bool
 		errorContains          string
@@ -313,6 +314,23 @@ func TestSelectTargetAddr(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:          "Deny address takes precedence over allow range",
+			ips:           []string{"192.168.1.5", "192.168.1.6"},
+			port:          80,
+			allowRanges:   []string{"192.168.0.0/16"},
+			denyAddresses: []string{"192.168.1.5"},
+			expectedIP:    "192.168.1.6",
+			expectError:   false,
+		},
+		{
+			name:          "Deny address blocks all IPs even inside allow range",
+			ips:           []string{"192.168.1.5"},
+			port:          80,
+			allowRanges:   []string{"192.168.0.0/16"},
+			denyAddresses: []string{"192.168.1.5"},
+			expectError:   true,
+		},
+		{
 			name:                   "Deny range forces fallback to deferred IP",
 			ips:                    []string{"1.1.1.1", "8.8.8.8"},
 			port:                   80,
@@ -337,6 +355,11 @@ func TestSelectTargetAddr(t *testing.T) {
 
 			if len(tt.denyRanges) > 0 {
 				err := config.SetDenyRanges(tt.denyRanges)
+				require.NoError(t, err)
+			}
+
+			if len(tt.denyAddresses) > 0 {
+				err := config.SetDenyAddresses(tt.denyAddresses)
 				require.NoError(t, err)
 			}
 


### PR DESCRIPTION
classifyAddr evaluated AllowRanges before DenyRanges, so an address denied by --deny-address (appended to DenyRanges) was still allowed whenever it also matched an --allow-range. The order is swapped so a denied address is always rejected. Extended TestSelectTargetAddr with cases where an allow range overlaps a denied address.