### PR TITLE
Fix connect timeout defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ smokescreen --max-concurrent-requests=100 --max-request-rate=50 --max-concurrent
 
 **Example (YAML):**
 ```yaml
+connect_timeout: 10s  # defaults to 10s; set to 0 to disable the timeout
 max_concurrent_requests: 100
 max_request_rate: 50
 max_request_burst: 150  # optional, defaults to 2x rate

--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -395,6 +395,7 @@ func NewConfig() *Config {
 		clientCasBySubjectKeyId: make(map[string]*x509.Certificate),
 		Log:                     log.New(),
 		Port:                    DefaultPort,
+		ConnectTimeout:          DefaultConnectTimeout,
 		ExitTimeout:             DefaultExitTimeout,
 		StatsSocketFileMode:     os.FileMode(DefaultStatsSocketFileMode),
 		ShuttingDown:            atomic.Value{},

--- a/pkg/smokescreen/config_loader.go
+++ b/pkg/smokescreen/config_loader.go
@@ -38,7 +38,7 @@ type yamlConfig struct {
 	AllowMissingRole     bool     `yaml:"allow_missing_role"`
 	Network              string   `yaml:"network"`
 
-	ConnectTimeout time.Duration  `yaml:"connect_timeout"`
+	ConnectTimeout *time.Duration `yaml:"connect_timeout"`
 	IdleTimeout    time.Duration  `yaml:"idle_timeout"`
 	ExitTimeout    *time.Duration `yaml:"exit_timeout"`
 
@@ -114,7 +114,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	c.IdleTimeout = yc.IdleTimeout
-	c.ConnectTimeout = yc.ConnectTimeout
+	if yc.ConnectTimeout != nil {
+		c.ConnectTimeout = *yc.ConnectTimeout
+	}
 	if yc.ExitTimeout != nil {
 		c.ExitTimeout = *yc.ExitTimeout
 	}


### PR DESCRIPTION
## Summary
Ensure we set the default timeout as expected.

Issue 1: The Config obj is initialized with timeout 0. This is a miss for users not loading a config file.
Issue 2: The config yaml loader expects a non-nil ConnectTimeout so if the yaml doesn't specify a value, the loader sets it to 0 and that overrides the Config object, making it unlimited.


## Validation
Wrote custom unit-test to validate this.