### PR TITLE
acl: pass ConnectReq through Decide via DecideArgs

### DIFF
--- a/pkg/smokescreen/acl/v1/acl.go
+++ b/pkg/smokescreen/acl/v1/acl.go
@@ -12,9 +12,12 @@ import (
 // DecideArgs holds the arguments for an ACL decision. Using a struct keeps the
 // Decider interface stable as new fields are added (e.g. Req for request-aware
 // authorization in custom Decider implementations). ACL.Decide does not
-// inspect Req; it is provided solely for use by custom implementations.
+// inspect Req or ConnectReq; they are provided solely for use by custom implementations.
 type DecideArgs struct {
-	Req              *http.Request
+	Req *http.Request
+	// ConnectReq is the edge CONNECT request from the client when Decide is
+	// evaluating a MITM inner HTTP request.
+	ConnectReq       *http.Request
 	Service          string
 	Host             string
 	ConnectProxyHost string

--- a/pkg/smokescreen/acl/v1/acl_test.go
+++ b/pkg/smokescreen/acl/v1/acl_test.go
@@ -523,6 +523,38 @@ func TestDecideReqIgnored(t *testing.T) {
 	a.Equal(dNil.Project, dWithReq.Project)
 }
 
+// TestDecideConnectReqIgnored verifies that ACL.Decide produces identical results
+// regardless of whether ConnectReq is set. ACL.Decide does not inspect ConnectReq;
+// it exists solely for use by custom Decider implementations (e.g. MITM inner requests).
+func TestDecideConnectReqIgnored(t *testing.T) {
+	a := assert.New(t)
+
+	testACL := &ACL{
+		Rules: map[string]Rule{
+			"svc": {
+				Policy:      Enforce,
+				DomainGlobs: []string{"allowed.com"},
+			},
+		},
+	}
+
+	dWithout, err := testACL.Decide(DecideArgs{Service: "svc", Host: "allowed.com"})
+	a.NoError(err)
+
+	connectReq, _ := http.NewRequest(http.MethodConnect, "https://allowed.com:443", nil)
+	connectReq.Header.Set("X-Custom-Header", "should-be-ignored")
+	dWith, err := testACL.Decide(DecideArgs{
+		Service:    "svc",
+		Host:       "allowed.com",
+		ConnectReq: connectReq,
+	})
+	a.NoError(err)
+
+	a.Equal(dWithout.Result, dWith.Result)
+	a.Equal(dWithout.Reason, dWith.Reason)
+	a.Equal(dWithout.Project, dWith.Project)
+}
+
 func TestDefaultRuleValidationWithDisableActions(t *testing.T) {
 	a := assert.New(t)
 	logger := logrus.New()

--- a/pkg/smokescreen/smokescreen.go
+++ b/pkg/smokescreen/smokescreen.go
@@ -93,6 +93,9 @@ type SmokescreenContext struct {
 	// This is an explicit flag that ensures role reuse only for CONNECT MITM requests
 	// and prevents attacks that try to reuse the role for traditional HTTP proxy requests.
 	isConnectMitm bool
+	// req is the edge CONNECT request from the client. Populated for MITM inner
+	// evaluations for custom EgressACL deciders
+	req *http.Request
 	// tunnelSlotAcquired indicates whether a tunnel limiter slot was acquired for this connection.
 	// If true, the slot must be released when the connection closes.
 	tunnelSlotAcquired bool
@@ -716,6 +719,7 @@ func newContext(cfg *Config, proxyType string, req *http.Request) *SmokescreenCo
 		ProxyType:     proxyType,
 		start:         start,
 		RequestedHost: req.Host,
+		req:    req,
 	}
 }
 
@@ -778,6 +782,7 @@ func BuildProxy(config *Config) *goproxy.ProxyHttpServer {
 			sctx = newContext(config, connectProxy, req)
 			sctx.Decision = &ACLDecision{Role: role}
 			sctx.isConnectMitm = true
+			sctx.req = existingSctx.req
 		} else {
 			// We are intentionally *not* setting pctx.HTTPErrorHandler because with traditional HTTP
 			// proxy requests we are able to specify the request during the call to OnResponse().
@@ -1386,8 +1391,14 @@ func checkACLsForRequest(config *Config, sctx *SmokescreenContext, req *http.Req
 		clientProvidedProxy = connectProxyUrl.Hostname()
 	}
 
+	var connectReq *http.Request
+	if sctx.isConnectMitm {
+		connectReq = sctx.req
+	}
+
 	ACLDecision, err := config.EgressACL.Decide(acl.DecideArgs{
 		Req:              req,
+		ConnectReq:       connectReq,
 		Service:          role,
 		Host:             destination.Host,
 		ConnectProxyHost: clientProvidedProxy,


### PR DESCRIPTION
## Summary

Add `ConnectReq *http.Request` to `DecideArgs` so custom `Decider` implementations can access the edge CONNECT request when smokescreen evaluates a MITM inner HTTP request.

```go
type DecideArgs struct {
    Req              *http.Request  // request under evaluation (MITM inner request)
    ConnectReq       *http.Request  // edge CONNECT that established the tunnel
    Service          string
    Host             string
    ConnectProxyHost string
}
```

For MITM flows, smokescreen now stores the edge CONNECT request on `SmokescreenContext` and passes it through `checkACLsForRequest` when `isConnectMitm` is set. Built-in `ACL.Decide` does not inspect `ConnectReq`; it is provided solely for custom implementations.

## Motivation

Smokescreen evaluates egress ACL twice for a tunneled HTTPS flow when MITM is enabled: once for `CONNECT`, and again for each decrypted application request forwarded to the remote domain.

`DecideArgs.Req` carries the request currently under evaluation. For MITM inner requests, that is not the same request as the edge `CONNECT`. Custom deciders may need context from either phase: headers, TLS state, or other request attributes available on one request but not the other.

`ConnectReq` exposes the original edge CONNECT alongside `Req`, keeping the `Decider` interface stable without adding another method. Downstream consumers can use whichever request has the context they need for their authorisation logic.

## Test plan

- `TestDecideConnectReqIgnored`: asserts `ACL.Decide` produces identical results regardless of whether `ConnectReq` is set (mirrors `TestDecideReqIgnored` from #286)
- CI passes