### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
         go-version: ['1.21', '1.22', '1.23']
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-go@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ matrix.go-version }}
     - name: Setup env
@@ -43,8 +43,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       - name: Install goveralls 
         run: go install github.com/mattn/goveralls@latest
       - name: Close goveralls parallel build 


### PR DESCRIPTION
Pins third-party GitHub Actions to immutable commit SHAs instead of mutable version tags. This helps prevent supply chain attacks by ensuring workflow dependencies cannot change without a reviewed update.