### PR TITLE
Return the error when a CRL file fails to parse

### DIFF
--- a/pkg/smokescreen/config.go
+++ b/pkg/smokescreen/config.go
@@ -484,7 +484,7 @@ func (config *Config) SetupCrls(crlFiles []string) error {
 
 		certList, err := x509.ParseCRL(crlBytes)
 		if err != nil {
-			log.Printf("Failed to parse CRL in '%s': %#v\n", crlFile, err)
+			return fmt.Errorf("failed to parse CRL in '%s': %w", crlFile, err)
 		}
 
 		// find the X509v3 Authority Key Identifier in the extensions (2.5.29.35)

--- a/pkg/smokescreen/crl_test.go
+++ b/pkg/smokescreen/crl_test.go
@@ -1,0 +1,34 @@
+//go:build !nounit
+// +build !nounit
+
+package smokescreen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A CRL file that does not parse should be reported as a configuration error,
+// not dereferenced.
+func TestSetupCrlsRejectsUnparseableFile(t *testing.T) {
+	crlFile := filepath.Join(t.TempDir(), "bad.crl")
+	require.NoError(t, os.WriteFile(crlFile, []byte("this is not a CRL"), 0600))
+
+	conf := NewConfig()
+	err := conf.SetupCrls([]string{crlFile})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), crlFile)
+}
+
+func TestSetupCrlsReportsAMissingFile(t *testing.T) {
+	conf := NewConfig()
+
+	err := conf.SetupCrls([]string{filepath.Join(t.TempDir(), "absent.crl")})
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Fixes #300.

`SetupCrls` logged a CRL parse failure and carried on, and the next statement ranges over `certList.TBSCertList.Extensions` with `certList` still nil. A malformed file passed to `--tls-crl-file` therefore takes the proxy down at boot rather than being rejected as bad configuration. The function already returns an error for an unreadable file, so this returns one for an unparseable file too, with the path and the underlying error wrapped in.

Two tests in a new `pkg/smokescreen/crl_test.go`: a file of non-CRL bytes has to come back as an error naming the file, and a path that does not exist still errors. On master the first one panics with `runtime error: invalid memory address or nil pointer dereference` inside `SetupCrls`.

`go vet` is clean and the unit tests in the package pass. I did not get a full `go test ./pkg/smokescreen/` to finish locally; the proxy tests in `smokescreen_test.go` sit waiting on connections in my sandbox, with or without this change.

One thing I deliberately left alone: `x509.ParseCRL` is deprecated in favour of `x509.ParseRevocationList`, and the surrounding code reads `TBSCertList` fields that the newer type exposes differently. That is a larger change than this bug needs.
